### PR TITLE
Translate function pointers and lambda

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -2668,15 +2668,10 @@ bool Converter::VisitCXXStdInitializerListExpr(
   return false;
 }
 
-std::string
-Converter::GetFunctionPointerDefaultAsString(clang::QualType qual_type) {
-  return "None";
-}
-
 std::string Converter::GetDefaultAsString(clang::QualType qual_type) {
   if (qual_type->isPointerType()) {
     if (qual_type->getPointeeType()->isFunctionType()) {
-      return GetFunctionPointerDefaultAsString(qual_type);
+      return "None";
     } else {
       computed_expr_type_ = ComputedExprType::FreshPointer;
       return keyword_default_;

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -225,24 +225,23 @@ bool Converter::VisitLValueReferenceType(clang::LValueReferenceType *type) {
   return Convert(pointee_type);
 }
 
-void Converter::ConvertFunctionPointerType(clang::PointerType *type) {
-  auto proto = type->getPointeeType()->getAs<clang::FunctionProtoType>();
-  assert(proto && "Type should be a function prototype");
-
-  StrCat("Option<", keyword_unsafe_, " fn(");
+std::string
+Converter::ConvertFunctionPointerType(const clang::FunctionProtoType *proto) {
+  std::string result = "fn(";
   for (auto p_ty : proto->param_types()) {
-    StrCat(std::format("{},", ToString(p_ty)));
+    result += ToString(p_ty) + ",";
   }
-  StrCat(")");
+  result += ")";
   if (!proto->getReturnType()->isVoidType()) {
-    StrCat(std::format("-> {}", ToString(proto->getReturnType())));
+    result += std::format(" -> {}", ToString(proto->getReturnType()));
   }
-  StrCat(">");
+  return result;
 }
 
 bool Converter::VisitPointerType(clang::PointerType *type) {
-  if (type->getPointeeType()->getAs<clang::FunctionProtoType>()) {
-    ConvertFunctionPointerType(type);
+  if (auto proto = type->getPointeeType()->getAs<clang::FunctionProtoType>()) {
+    StrCat(std::format("Option<{} {}>", keyword_unsafe_,
+                       ConvertFunctionPointerType(proto)));
     return false;
   }
 
@@ -1389,8 +1388,9 @@ void Converter::EmitFnPtrCall(clang::Expr *callee) {
   StrCat(").unwrap()");
 }
 
-void Converter::EmitFnAsValue(const clang::FunctionDecl *fn_decl) {
-  StrCat(std::format("Some({})", Mapper::GetFnRefName(fn_decl)));
+void Converter::ConvertFunctionToFunctionPointer(
+    const clang::FunctionDecl *fn_decl) {
+  StrCat(std::format("Some({})", GetNamedDeclAsString(fn_decl)));
 }
 
 void Converter::ConvertGenericCallExpr(clang::CallExpr *expr) {
@@ -2065,7 +2065,7 @@ bool Converter::VisitDeclRefExpr(clang::DeclRefExpr *expr) {
 
   if (auto *fn_decl = clang::dyn_cast<clang::FunctionDecl>(decl)) {
     if (isAddrOf()) {
-      EmitFnAsValue(fn_decl);
+      ConvertFunctionToFunctionPointer(fn_decl);
       return false;
     }
   }

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -1464,8 +1464,8 @@ void Converter::ConvertGenericCallExpr(clang::CallExpr *expr) {
   if (proto && !function) {
     EmitFnPtrCall(callee);
   } else {
-    PushExprKind push(*this, ExprKind::RValue);
-    Convert(StripFunctionPointerDecay(callee));
+    PushExprKind push(*this, ExprKind::Callee);
+    Convert(callee);
   }
   StrCat(token::kOpenParen);
   for (unsigned i = 0; i < num_named_params && i < num_args; ++i) {
@@ -1688,8 +1688,12 @@ bool Converter::VisitImplicitCastExpr(clang::ImplicitCastExpr *expr) {
   }
   case clang::CastKind::CK_FunctionToPointerDecay:
   case clang::CastKind::CK_BuiltinFnToFnPtr: {
-    PushExprKind push(*this, ExprKind::AddrOf);
-    Convert(sub_expr);
+    if (isCallee()) {
+      Convert(sub_expr);
+    } else {
+      PushExprKind push(*this, ExprKind::AddrOf);
+      Convert(sub_expr);
+    }
     break;
   }
   case clang::CastKind::CK_ConstructorConversion:
@@ -3256,7 +3260,12 @@ void Converter::PlaceholderCtx::dump() const {
 
 std::string Converter::ConvertPlaceholder(clang::Expr *expr, clang::Expr *arg,
                                           const PlaceholderCtx &ph_ctx) {
-  arg = StripFunctionPointerDecay(arg);
+  if (arg->getType()->isFunctionPointerType()) {
+    PushExprKind push(*this, ExprKind::Callee);
+    Buffer buf(*this);
+    Convert(arg);
+    return std::move(buf).str();
+  }
 
   if (ph_ctx.needs_materialization()) {
     auto materialized = ph_ctx.materialize_ctx->GetOrMaterialize(
@@ -3403,6 +3412,10 @@ bool Converter::isObject() const {
 
 bool Converter::isVoid() const {
   return curr_expr_kind_.empty() || curr_expr_kind_.back() == ExprKind::Void;
+}
+
+bool Converter::isCallee() const {
+  return !curr_expr_kind_.empty() && curr_expr_kind_.back() == ExprKind::Callee;
 }
 
 void Converter::SetFresh() {

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -130,17 +130,20 @@ bool Converter::VisitRecordType(clang::RecordType *type) {
   auto *decl = type->getDecl();
   if (auto lambda = clang::dyn_cast<clang::CXXRecordDecl>(decl)) {
     if (lambda->isLambda()) {
-      auto call_op = lambda->getLambdaCallOperator();
-      StrCat("Rc<dyn Fn(");
-      for (auto p : call_op->parameters()) {
-        StrCat(std::format("{},", ToStringBase(p->getType())));
+      if (in_function_formals_) {
+        auto call_op = lambda->getLambdaCallOperator();
+        StrCat("impl Fn(");
+        for (auto p : call_op->parameters()) {
+          StrCat(std::format("{},", ToStringBase(p->getType())));
+        }
+        StrCat(")");
+        if (!call_op->getReturnType()->isVoidType()) {
+          StrCat("->");
+          StrCat(ToStringBase(call_op->getReturnType()));
+        }
+      } else {
+        StrCat("_");
       }
-      StrCat(")");
-      if (!call_op->getReturnType()->isVoidType()) {
-        StrCat("->");
-        StrCat(ToStringBase(call_op->getReturnType()));
-      }
-      StrCat(">");
       return false;
     }
   }
@@ -226,7 +229,7 @@ void Converter::ConvertFunctionPointerType(clang::PointerType *type) {
   auto proto = type->getPointeeType()->getAs<clang::FunctionProtoType>();
   assert(proto && "Type should be a function prototype");
 
-  StrCat("Rc<dyn Fn(");
+  StrCat("Option<", keyword_unsafe_, " fn(");
   for (auto p_ty : proto->param_types()) {
     StrCat(std::format("{},", ToString(p_ty)));
   }
@@ -423,6 +426,9 @@ bool Converter::ConvertVarDeclSkipInit(clang::VarDecl *decl) {
 }
 
 bool Converter::ConvertLambdaVarDecl(clang::VarDecl *decl) {
+  if (decl->getType()->isFunctionPointerType()) {
+    return false;
+  }
   if (decl->hasInit()) {
     if (clang::isa<clang::LambdaExpr>(
             decl->getInit()->IgnoreUnlessSpelledInSource())) {
@@ -1377,6 +1383,16 @@ bool Converter::VisitCallExpr(clang::CallExpr *expr) {
   return false;
 }
 
+void Converter::EmitFnPtrCall(clang::Expr *callee) {
+  StrCat(token::kOpenParen);
+  Convert(callee);
+  StrCat(").unwrap()");
+}
+
+void Converter::EmitFnAsValue(const clang::FunctionDecl *fn_decl) {
+  StrCat(std::format("Some({})", Mapper::GetFnRefName(fn_decl)));
+}
+
 void Converter::ConvertGenericCallExpr(clang::CallExpr *expr) {
   clang::Expr *callee = expr->getCallee();
   auto convert_param_ty = [&](clang::QualType param_type, clang::Expr *expr) {
@@ -1399,7 +1415,8 @@ void Converter::ConvertGenericCallExpr(clang::CallExpr *expr) {
   StrCat(token::kOpenParen);
   StrCat(keyword_unsafe_);
   StrCat(token::kOpenCurlyBracket);
-  const auto *function = expr->getCalleeDecl()->getAsFunction();
+  const auto *function =
+      expr->getCalleeDecl() ? expr->getCalleeDecl()->getAsFunction() : nullptr;
   const clang::FunctionProtoType *proto = nullptr;
 
   if (!function) {
@@ -1447,7 +1464,12 @@ void Converter::ConvertGenericCallExpr(clang::CallExpr *expr) {
     }
   }
 
-  Convert(callee);
+  if (proto && !function) {
+    EmitFnPtrCall(callee);
+  } else {
+    PushExprKind push(*this, ExprKind::RValue);
+    Convert(StripFunctionPointerDecay(callee));
+  }
   StrCat(token::kOpenParen);
   for (unsigned i = 0; i < num_named_params && i < num_args; ++i) {
     auto *arg = expr->getArg(i + arg_begin);
@@ -1668,7 +1690,11 @@ bool Converter::VisitImplicitCastExpr(clang::ImplicitCastExpr *expr) {
     break;
   }
   case clang::CastKind::CK_FunctionToPointerDecay:
-  case clang::CastKind::CK_BuiltinFnToFnPtr:
+  case clang::CastKind::CK_BuiltinFnToFnPtr: {
+    PushExprKind push(*this, ExprKind::AddrOf);
+    Convert(sub_expr);
+    break;
+  }
   case clang::CastKind::CK_ConstructorConversion:
   case clang::CastKind::CK_DerivedToBase:
     Convert(sub_expr);
@@ -1692,7 +1718,11 @@ bool Converter::VisitImplicitCastExpr(clang::ImplicitCastExpr *expr) {
     ConvertEqualsNullPtr(sub_expr);
     break;
   case clang::CastKind::CK_NullToPointer:
-    StrCat(keyword_default_);
+    if (type->isFunctionPointerType()) {
+      StrCat("None");
+    } else {
+      StrCat(keyword_default_);
+    }
     computed_expr_type_ = ComputedExprType::FreshPointer;
     break;
   default:
@@ -1736,6 +1766,17 @@ bool Converter::VisitExplicitCastExpr(clang::ExplicitCastExpr *expr) {
   case clang::Stmt::CStyleCastExprClass:
     if (expr->getType() == sub_expr->getType()) {
       return Convert(sub_expr);
+    }
+    if (type->isFunctionPointerType() ||
+        sub_expr->getType()->isFunctionPointerType()) {
+      StrCat("std::mem::transmute::<");
+      Convert(sub_expr->getType());
+      StrCat(",");
+      Convert(type);
+      StrCat(">(");
+      Convert(sub_expr);
+      StrCat(")");
+      return false;
     }
     StrCat(token::kOpenParen);
     Convert(sub_expr);
@@ -1963,12 +2004,12 @@ bool Converter::VisitConditionalOperator(clang::ConditionalOperator *expr) {
   StrCat(keyword::kIf);
   Convert(expr->getCond());
   StrCat(token::kOpenCurlyBracket);
-  if (expr->isLValue() && !isRValue()) {
+  if (expr->isLValue() && !isRValue() && !expr->getType()->isFunctionType()) {
     StrCat(token::kRef, keyword_mut_);
   }
   Convert(expr->getTrueExpr());
   StrCat(token::kCloseCurlyBracket, keyword::kElse, token::kOpenCurlyBracket);
-  if (expr->isLValue() && !isRValue()) {
+  if (expr->isLValue() && !isRValue() && !expr->getType()->isFunctionType()) {
     StrCat(token::kRef, keyword_mut_);
   }
   Convert(expr->getFalseExpr());
@@ -2022,35 +2063,23 @@ bool Converter::VisitDeclRefExpr(clang::DeclRefExpr *expr) {
     return false;
   }
 
-  if (auto function = clang::dyn_cast<clang::FunctionDecl>(decl)) {
+  if (auto *fn_decl = clang::dyn_cast<clang::FunctionDecl>(decl)) {
     if (isAddrOf()) {
-      // Wrap unsafe function in safe closure because the Fn trait only accepts
-      // safe functions
-      std::string arguments;
-      for (unsigned i = 0; i < function->getNumParams(); ++i) {
-        arguments += (i ? ", a" : "a") + std::to_string(i);
-      }
-      StrCat("Rc::new", token::kOpenParen);
-      StrCat(std::format("|{}|", arguments));
-      StrCat(keyword_unsafe_, token::kOpenCurlyBracket);
-      StrCat(str);
-      StrCat(token::kOpenParen);
-      StrCat(arguments);
-      StrCat(token::kCloseParen);
-      StrCat(token::kCloseCurlyBracket);
-      StrCat(token::kCloseParen);
+      EmitFnAsValue(fn_decl);
       return false;
     }
   }
 
   if (auto var_decl = clang::dyn_cast<clang::VarDecl>(decl)) {
-    if (auto init = var_decl->getInit()) {
-      if (auto lambda = clang::dyn_cast<clang::LambdaExpr>(
-              init->IgnoreUnlessSpelledInSource())) {
-        StrCat(token::kOpenParen);
-        VisitLambdaExpr(lambda);
-        StrCat(token::kCloseParen);
-        return false;
+    if (!var_decl->getType()->isFunctionPointerType()) {
+      if (auto init = var_decl->getInit()) {
+        if (auto lambda = clang::dyn_cast<clang::LambdaExpr>(
+                init->IgnoreUnlessSpelledInSource())) {
+          StrCat(token::kOpenParen);
+          VisitLambdaExpr(lambda);
+          StrCat(token::kCloseParen);
+          return false;
+        }
       }
     }
   }
@@ -2509,6 +2538,9 @@ bool Converter::VisitCXXDefaultArgExpr(clang::CXXDefaultArgExpr *expr) {
 }
 
 bool Converter::VisitLambdaExpr(clang::LambdaExpr *expr) {
+  if (isAddrOf() && expr->capture_size() == 0) {
+    StrCat("Some");
+  }
   StrCat(token::kOpenParen);
   StrCat("|");
   for (auto p : expr->getLambdaClass()->getLambdaCallOperator()->parameters()) {
@@ -2638,15 +2670,7 @@ bool Converter::VisitCXXStdInitializerListExpr(
 
 std::string
 Converter::GetFunctionPointerDefaultAsString(clang::QualType qual_type) {
-  std::string ret;
-  auto proto = qual_type->getPointeeType()->getAs<clang::FunctionProtoType>();
-  assert(proto);
-  ret = "Rc::new(|";
-  for (unsigned i = 0; i < proto->getNumParams(); ++i) {
-    ret += "_,";
-  }
-  ret += R"(| { panic!("ub: uninit function pointer") }))";
-  return ret;
+  return "None";
 }
 
 std::string Converter::GetDefaultAsString(clang::QualType qual_type) {
@@ -2800,6 +2824,16 @@ void Converter::ConvertVarInit(clang::QualType qual_type, clang::Expr *expr) {
       StrCat(keyword_mut_);
     }
   }
+  if (qual_type->isFunctionPointerType()) {
+    if (auto *lambda = clang::dyn_cast<clang::LambdaExpr>(
+            expr->IgnoreUnlessSpelledInSource())) {
+      PushExprKind push(*this, ExprKind::AddrOf);
+      curr_init_type_.push(qual_type);
+      VisitLambdaExpr(lambda);
+      curr_init_type_.pop();
+      return;
+    }
+  }
   auto *ignore_casts = expr->IgnoreCasts();
   // FIXME: this looks very complicated
   if (auto *ctor = clang::dyn_cast<clang::CXXConstructExpr>(ignore_casts);
@@ -2845,7 +2879,8 @@ void Converter::ConvertUnsignedArithOperand(clang::Expr *expr,
 void Converter::ConvertEqualsNullPtr(clang::Expr *expr) {
   StrCat("(");
   Convert(expr);
-  if (IsUniquePtr(expr->getType())) {
+  if (IsUniquePtr(expr->getType()) ||
+      expr->getType()->isFunctionPointerType()) {
     StrCat(").is_none()");
   } else {
     StrCat(").is_null()");
@@ -3229,6 +3264,8 @@ void Converter::PlaceholderCtx::dump() const {
 
 std::string Converter::ConvertPlaceholder(clang::Expr *expr, clang::Expr *arg,
                                           const PlaceholderCtx &ph_ctx) {
+  arg = StripFunctionPointerDecay(arg);
+
   if (ph_ctx.needs_materialization()) {
     auto materialized = ph_ctx.materialize_ctx->GetOrMaterialize(
         static_cast<unsigned>(ph_ctx.materialize_idx),

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -131,16 +131,11 @@ bool Converter::VisitRecordType(clang::RecordType *type) {
   if (auto lambda = clang::dyn_cast<clang::CXXRecordDecl>(decl)) {
     if (lambda->isLambda()) {
       if (in_function_formals_) {
-        auto call_op = lambda->getLambdaCallOperator();
-        StrCat("impl Fn(");
-        for (auto p : call_op->parameters()) {
-          StrCat(std::format("{},", ToStringBase(p->getType())));
-        }
-        StrCat(")");
-        if (!call_op->getReturnType()->isVoidType()) {
-          StrCat("->");
-          StrCat(ToStringBase(call_op->getReturnType()));
-        }
+        StrCat(
+            ConvertFunctionPointerType(lambda->getLambdaCallOperator()
+                                           ->getType()
+                                           ->getAs<clang::FunctionProtoType>(),
+                                       FnProtoType::LambdaCallOperator));
       } else {
         StrCat("_");
       }
@@ -226,8 +221,10 @@ bool Converter::VisitLValueReferenceType(clang::LValueReferenceType *type) {
 }
 
 std::string
-Converter::ConvertFunctionPointerType(const clang::FunctionProtoType *proto) {
-  std::string result = "fn(";
+Converter::ConvertFunctionPointerType(const clang::FunctionProtoType *proto,
+                                      FnProtoType kind) {
+  std::string result =
+      (kind == FnProtoType::LambdaCallOperator ? "impl Fn(" : "fn(");
   for (auto p_ty : proto->param_types()) {
     result += ToString(p_ty) + ",";
   }

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -340,9 +340,6 @@ protected:
   virtual bool Convert(clang::Stmt *stmt);
   virtual bool Convert(clang::Expr *expr);
 
-  virtual std::string
-  GetFunctionPointerDefaultAsString(clang::QualType qual_type);
-
   virtual std::string GetDefaultAsString(clang::QualType qual_type);
 
   virtual std::string GetDefaultAsStringFallback(clang::QualType qual_type);

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -479,6 +479,7 @@ protected:
   static std::unordered_set<std::string> abstract_structs_;
 
   enum class ExprKind : uint8_t {
+    Callee,
     LValue,
     RValue,
     XValue,
@@ -489,6 +490,8 @@ protected:
 
   static const char *expr_kind_to_string(ExprKind kind) {
     switch (kind) {
+    case ExprKind::Callee:
+      return "Callee";
     case ExprKind::LValue:
       return "LValue";
     case ExprKind::RValue:
@@ -512,6 +515,7 @@ protected:
   bool isAddrOf() const;
   bool isObject() const;
   bool isVoid() const;
+  bool isCallee() const;
 
   void dump_expr_kinds();
 

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -61,8 +61,11 @@ public:
 
   virtual bool VisitPointerType(clang::PointerType *type);
 
+  enum class FnProtoType { LambdaCallOperator, FnPtr };
+
   virtual std::string
-  ConvertFunctionPointerType(const clang::FunctionProtoType *proto);
+  ConvertFunctionPointerType(const clang::FunctionProtoType *proto,
+                             FnProtoType kind = FnProtoType::FnPtr);
 
   virtual bool VisitDecayedType(clang::DecayedType *type);
 

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -61,7 +61,8 @@ public:
 
   virtual bool VisitPointerType(clang::PointerType *type);
 
-  void ConvertFunctionPointerType(clang::PointerType *type);
+  virtual std::string
+  ConvertFunctionPointerType(const clang::FunctionProtoType *proto);
 
   virtual bool VisitDecayedType(clang::DecayedType *type);
 
@@ -203,7 +204,8 @@ public:
 
   virtual void EmitFnPtrCall(clang::Expr *callee);
 
-  virtual void EmitFnAsValue(const clang::FunctionDecl *fn_decl);
+  virtual void
+  ConvertFunctionToFunctionPointer(const clang::FunctionDecl *fn_decl);
 
   virtual void ConvertPrintf(clang::CallExpr *expr);
 

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -201,6 +201,10 @@ public:
 
   void ConvertGenericCallExpr(clang::CallExpr *expr);
 
+  virtual void EmitFnPtrCall(clang::Expr *callee);
+
+  virtual void EmitFnAsValue(const clang::FunctionDecl *fn_decl);
+
   virtual void ConvertPrintf(clang::CallExpr *expr);
 
   void ConvertVAArgCall(clang::CallExpr *expr);
@@ -334,7 +338,8 @@ protected:
   virtual bool Convert(clang::Stmt *stmt);
   virtual bool Convert(clang::Expr *expr);
 
-  std::string GetFunctionPointerDefaultAsString(clang::QualType qual_type);
+  virtual std::string
+  GetFunctionPointerDefaultAsString(clang::QualType qual_type);
 
   virtual std::string GetDefaultAsString(clang::QualType qual_type);
 

--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -380,17 +380,6 @@ clang::QualType GetReturnTypeOfFunction(const clang::CallExpr *expr) {
   return {};
 }
 
-clang::Expr *StripFunctionPointerDecay(clang::Expr *expr) {
-  if (auto *ice = clang::dyn_cast<clang::ImplicitCastExpr>(expr)) {
-    auto ck = ice->getCastKind();
-    if (ck == clang::CK_FunctionToPointerDecay ||
-        ck == clang::CK_BuiltinFnToFnPtr) {
-      return ice->getSubExpr();
-    }
-  }
-  return expr;
-}
-
 std::string GetOverloadedOperator(const clang::FunctionDecl *decl) {
   switch (decl->getOverloadedOperator()) {
   case clang::OO_Less:

--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -362,22 +362,33 @@ const char *AccessSpecifierAsString(clang::AccessSpecifier spec) {
 }
 
 clang::QualType GetReturnTypeOfFunction(const clang::CallExpr *expr) {
-  auto decl = expr->getCalleeDecl();
-  if (decl->getAsFunction()) {
-    return decl->getAsFunction()->getReturnType().getCanonicalType();
+  if (auto *decl = expr->getCalleeDecl()) {
+    if (auto *fn = decl->getAsFunction()) {
+      return fn->getReturnType().getCanonicalType();
+    }
   }
 
-  auto callee_ty =
-      expr->getCallee()->getType().getDesugaredType(decl->getASTContext());
-  if (auto ptr_ty = callee_ty->getAs<clang::PointerType>()) {
-    return ptr_ty->getPointeeType()
-        ->getAs<clang::FunctionProtoType>()
-        ->getReturnType()
-        .getCanonicalType();
+  auto callee_ty = expr->getCallee()->getType();
+  if (auto *ptr_ty = callee_ty->getAs<clang::PointerType>()) {
+    if (auto *fn_ty =
+            ptr_ty->getPointeeType()->getAs<clang::FunctionProtoType>()) {
+      return fn_ty->getReturnType().getCanonicalType();
+    }
   }
 
   assert(0 && "Unhandled function prototype");
   return {};
+}
+
+clang::Expr *StripFunctionPointerDecay(clang::Expr *expr) {
+  if (auto *ice = clang::dyn_cast<clang::ImplicitCastExpr>(expr)) {
+    auto ck = ice->getCastKind();
+    if (ck == clang::CK_FunctionToPointerDecay ||
+        ck == clang::CK_BuiltinFnToFnPtr) {
+      return ice->getSubExpr();
+    }
+  }
+  return expr;
 }
 
 std::string GetOverloadedOperator(const clang::FunctionDecl *decl) {

--- a/cpp2rust/converter/converter_lib.h
+++ b/cpp2rust/converter/converter_lib.h
@@ -91,8 +91,6 @@ template <class T> llvm::SmallString<16> GetNumAsString(const T &num) {
 
 clang::QualType GetReturnTypeOfFunction(const clang::CallExpr *expr);
 
-clang::Expr *StripFunctionPointerDecay(clang::Expr *expr);
-
 std::string GetOverloadedOperator(const clang::FunctionDecl *decl);
 
 bool IsOverloadedComparisonOperator(const clang::CXXMethodDecl *decl);

--- a/cpp2rust/converter/converter_lib.h
+++ b/cpp2rust/converter/converter_lib.h
@@ -91,6 +91,8 @@ template <class T> llvm::SmallString<16> GetNumAsString(const T &num) {
 
 clang::QualType GetReturnTypeOfFunction(const clang::CallExpr *expr);
 
+clang::Expr *StripFunctionPointerDecay(clang::Expr *expr);
+
 std::string GetOverloadedOperator(const clang::FunctionDecl *decl);
 
 bool IsOverloadedComparisonOperator(const clang::CXXMethodDecl *decl);

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -165,10 +165,77 @@ bool ConverterRefCount::VisitLValueReferenceType(
   return false;
 }
 
+std::string ConverterRefCount::BuildFnAdapter(
+    const clang::FunctionDecl *src_fn,
+    const clang::FunctionProtoType *src_proto,
+    const clang::FunctionProtoType *target_proto) {
+
+  // UB: Incompatible arity
+  if (src_proto->getNumParams() != target_proto->getNumParams()) {
+    return "None";
+  }
+
+  PushConversionKind push(*this, ConversionKind::Unboxed);
+
+  // Build adapter signature: |a0: T0, a1: T1, ...| -> Tr
+  std::string closure = "(|";
+  for (unsigned i = 0; i < target_proto->getNumParams(); ++i) {
+    closure +=
+        std::format("a{}: {},", i, ToString(target_proto->getParamType(i)));
+  }
+  closure += "|";
+  if (!target_proto->getReturnType()->isVoidType()) {
+    closure += std::format(" -> {} ", ToString(target_proto->getReturnType()));
+  }
+  closure += "{ ";
+
+  // Build adapter body: src_fn(convert(a0), convert(a1), ...)
+  closure += Mapper::GetFnRefName(src_fn) + "(";
+  for (unsigned i = 0; i < src_proto->getNumParams(); ++i) {
+    auto src_pty = src_proto->getParamType(i);
+    auto tgt_pty = target_proto->getParamType(i);
+    if (ToString(src_pty) == ToString(tgt_pty)) {
+      closure += std::format("a{}", i);
+    } else if (src_pty->isPointerType() && tgt_pty->isPointerType()) {
+      if (tgt_pty->isVoidPointerType()) {
+        closure += std::format("a{}.cast::<{}>().unwrap()", i,
+                               GetPointeeRustType(src_pty));
+      } else if (src_pty->isVoidPointerType()) {
+        closure += std::format("a{}.to_any()", i);
+      } else if (tgt_pty->getPointeeType()->isCharType()) {
+        closure += std::format("a{}.reinterpret_cast::<{}>()", i,
+                               GetPointeeRustType(src_pty));
+      } else if (src_pty->getPointeeType()->isCharType()) {
+        closure += std::format("a{}.reinterpret_cast::<u8>()", i);
+      }
+    } else {
+      // UB: Incompatible types
+      return "None";
+    }
+    closure += ", ";
+  }
+  closure += ") })";
+
+  return std::format("Some({} as {})", closure, GetFnTypeString(target_proto));
+}
+
+std::string
+ConverterRefCount::GetFnTypeString(const clang::FunctionProtoType *proto) {
+  PushConversionKind push(*this, ConversionKind::Unboxed);
+  std::string result = "fn(";
+  for (auto p_ty : proto->param_types()) {
+    result += ToString(p_ty) + ",";
+  }
+  result += ")";
+  if (!proto->getReturnType()->isVoidType()) {
+    result += std::format(" -> {}", ToString(proto->getReturnType()));
+  }
+  return result;
+}
+
 bool ConverterRefCount::VisitPointerType(clang::PointerType *type) {
-  if (type->getPointeeType()->getAs<clang::FunctionProtoType>()) {
-    PushConversionKind push(*this, ConversionKind::Unboxed);
-    ConvertFunctionPointerType(type);
+  if (auto proto = type->getPointeeType()->getAs<clang::FunctionProtoType>()) {
+    StrCat(std::format("FnPtr<{}>", GetFnTypeString(proto)));
     return false;
   }
 
@@ -570,7 +637,7 @@ bool ConverterRefCount::VisitDeclRefExpr(clang::DeclRefExpr *expr) {
 
   if (clang::isa<clang::FunctionDecl>(decl)) {
     if (isAddrOf()) {
-      StrCat(std::format("Rc::new({})", str));
+      EmitFnAsValue(fn_decl);
     } else {
       StrCat(str);
     }
@@ -951,7 +1018,84 @@ bool ConverterRefCount::VisitImplicitCastExpr(clang::ImplicitCastExpr *expr) {
     }
   }
 
+  if (expr->getCastKind() == clang::CastKind::CK_NullToPointer &&
+      expr->getType()->isFunctionPointerType()) {
+    StrCat("FnPtr::null()");
+    computed_expr_type_ = ComputedExprType::FreshPointer;
+    return false;
+  }
+
   return Converter::VisitImplicitCastExpr(expr);
+}
+
+void ConverterRefCount::EmitFnPtrCall(clang::Expr *callee) {
+  StrCat("(*");
+  Convert(callee);
+  StrCat(")");
+}
+
+void ConverterRefCount::EmitFnAsValue(const clang::FunctionDecl *fn_decl) {
+  StrCat(std::format(
+      "fn_ptr!({}, {})", Mapper::GetFnRefName(fn_decl),
+      GetFnTypeString(fn_decl->getType()->getAs<clang::FunctionProtoType>())));
+}
+
+std::string ConverterRefCount::GetFunctionPointerDefaultAsString(
+    clang::QualType qual_type) {
+  return "FnPtr::null()";
+}
+
+void ConverterRefCount::ConvertEqualsNullPtr(clang::Expr *expr) {
+  StrCat("(");
+  Convert(expr);
+  StrCat(").is_null()");
+}
+
+bool ConverterRefCount::VisitFunctionPointerCast(
+    clang::ExplicitCastExpr *expr) {
+  if (expr->getType()->isFunctionPointerType() ||
+      expr->getSubExpr()->getType()->isFunctionPointerType()) {
+    if (expr->getSubExpr()->getType()->isFunctionPointerType() &&
+        expr->getType()->isFunctionPointerType()) {
+      auto target_proto =
+          expr->getType()->getPointeeType()->getAs<clang::FunctionProtoType>();
+      auto src_proto = expr->getSubExpr()
+                           ->getType()
+                           ->getPointeeType()
+                           ->getAs<clang::FunctionProtoType>();
+      auto fn_type = GetFnTypeString(target_proto);
+
+      std::string adapter = "None";
+      // Only accept direct references to the casted function. Otherwise the
+      // closure would be capturing and would not coerce into a fn pointer.
+      if (auto *decl_ref = clang::dyn_cast<clang::DeclRefExpr>(
+              expr->getSubExpr()->IgnoreImplicit())) {
+        if (auto *fn_decl =
+                clang::dyn_cast<clang::FunctionDecl>(decl_ref->getDecl())) {
+          adapter = BuildFnAdapter(fn_decl, src_proto, target_proto);
+        }
+      }
+
+      StrCat(std::format("{}.cast::<{}>({})", ToString(expr->getSubExpr()),
+                         fn_type, adapter));
+    } else if (expr->getSubExpr()->getType()->isFunctionPointerType() ||
+               expr->getType()->isVoidPointerType()) {
+      Convert(expr->getSubExpr());
+      StrCat(".to_any()");
+    } else if (expr->getSubExpr()->getType()->isVoidPointerType() ||
+               expr->getType()->isFunctionPointerType()) {
+      auto target_proto =
+          expr->getType()->getPointeeType()->getAs<clang::FunctionProtoType>();
+      auto fn_type = GetFnTypeString(target_proto);
+      StrCat(std::format("{}.cast_fn::<{}>().expect(\"ub:wrong fn type\")",
+                         ToString(expr->getSubExpr()), fn_type));
+    } else {
+      assert(0 && "Unhandled function pointer cast");
+    }
+    return false;
+  }
+
+  return true;
 }
 
 bool ConverterRefCount::VisitExplicitCastExpr(clang::ExplicitCastExpr *expr) {
@@ -968,7 +1112,9 @@ bool ConverterRefCount::VisitExplicitCastExpr(clang::ExplicitCastExpr *expr) {
     return false;
   case clang::Stmt::CStyleCastExprClass:
   case clang::Stmt::CXXStaticCastExprClass:
-    if (expr->getSubExpr()->getType()->isVoidPointerType()) {
+    if (!VisitFunctionPointerCast(expr)) {
+      return false;
+    } else if (expr->getSubExpr()->getType()->isVoidPointerType()) {
       Convert(expr->getSubExpr());
       PushConversionKind push(*this, ConversionKind::Unboxed);
       StrCat(std::format(".cast::<{}>().expect(\"ub:wrong type\")",
@@ -1477,9 +1623,13 @@ void ConverterRefCount::ConvertVarInit(clang::QualType qual_type,
     {
       Buffer buf(*this);
       PushConversionKind push(*this, ConversionKind::Unboxed);
-      StrCat("Rc::new(");
-      VisitLambdaExpr(lambda);
-      StrCat(")");
+      if (qual_type->isFunctionPointerType() && lambda->capture_size() == 0) {
+        StrCat("FnPtr::new((");
+        VisitLambdaExpr(lambda);
+        StrCat("), 0)");
+      } else {
+        VisitLambdaExpr(lambda);
+      }
       str = std::move(buf).str();
     }
     StrCat(BoxValue(std::move(str)));

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -1035,11 +1035,6 @@ void ConverterRefCount::ConvertFunctionToFunctionPointer(
                       fn_decl->getType()->getAs<clang::FunctionProtoType>())));
 }
 
-std::string ConverterRefCount::GetFunctionPointerDefaultAsString(
-    clang::QualType qual_type) {
-  return "FnPtr::null()";
-}
-
 void ConverterRefCount::ConvertEqualsNullPtr(clang::Expr *expr) {
   StrCat("(");
   Convert(expr);
@@ -1553,7 +1548,7 @@ std::string ConverterRefCount::GetDefaultAsString(clang::QualType qual_type) {
   if (qual_type->isPointerType()) {
     auto pointee_type = qual_type->getPointeeType();
     if (pointee_type->isFunctionType()) {
-      ret = GetFunctionPointerDefaultAsString(qual_type);
+      ret = "FnPtr::null()";
     } else {
       if (pointee_type->isVoidType()) {
         ret = "AnyPtr::default()";

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -190,7 +190,7 @@ std::string ConverterRefCount::BuildFnAdapter(
   closure += "{ ";
 
   // Build adapter body: src_fn(convert(a0), convert(a1), ...)
-  closure += Mapper::GetFnRefName(src_fn) + "(";
+  closure += GetNamedDeclAsString(src_fn) + "(";
   for (unsigned i = 0; i < src_proto->getNumParams(); ++i) {
     auto src_pty = src_proto->getParamType(i);
     auto tgt_pty = target_proto->getParamType(i);
@@ -199,12 +199,12 @@ std::string ConverterRefCount::BuildFnAdapter(
     } else if (src_pty->isPointerType() && tgt_pty->isPointerType()) {
       if (tgt_pty->isVoidPointerType()) {
         closure += std::format("a{}.cast::<{}>().unwrap()", i,
-                               GetPointeeRustType(src_pty));
+                               ToString(src_pty->getPointeeType()));
       } else if (src_pty->isVoidPointerType()) {
         closure += std::format("a{}.to_any()", i);
       } else if (tgt_pty->getPointeeType()->isCharType()) {
         closure += std::format("a{}.reinterpret_cast::<{}>()", i,
-                               GetPointeeRustType(src_pty));
+                               ToString(src_pty->getPointeeType()));
       } else if (src_pty->getPointeeType()->isCharType()) {
         closure += std::format("a{}.reinterpret_cast::<u8>()", i);
       }
@@ -216,26 +216,19 @@ std::string ConverterRefCount::BuildFnAdapter(
   }
   closure += ") })";
 
-  return std::format("Some({} as {})", closure, GetFnTypeString(target_proto));
+  return std::format("Some({} as {})", closure,
+                     ConvertFunctionPointerType(target_proto));
 }
 
-std::string
-ConverterRefCount::GetFnTypeString(const clang::FunctionProtoType *proto) {
+std::string ConverterRefCount::ConvertFunctionPointerType(
+    const clang::FunctionProtoType *proto) {
   PushConversionKind push(*this, ConversionKind::Unboxed);
-  std::string result = "fn(";
-  for (auto p_ty : proto->param_types()) {
-    result += ToString(p_ty) + ",";
-  }
-  result += ")";
-  if (!proto->getReturnType()->isVoidType()) {
-    result += std::format(" -> {}", ToString(proto->getReturnType()));
-  }
-  return result;
+  return Converter::ConvertFunctionPointerType(proto);
 }
 
 bool ConverterRefCount::VisitPointerType(clang::PointerType *type) {
   if (auto proto = type->getPointeeType()->getAs<clang::FunctionProtoType>()) {
-    StrCat(std::format("FnPtr<{}>", GetFnTypeString(proto)));
+    StrCat(std::format("FnPtr<{}>", ConvertFunctionPointerType(proto)));
     return false;
   }
 
@@ -635,9 +628,9 @@ bool ConverterRefCount::VisitDeclRefExpr(clang::DeclRefExpr *expr) {
   auto str = ConvertDeclRefExpr(expr);
   auto decl = expr->getDecl();
 
-  if (clang::isa<clang::FunctionDecl>(decl)) {
+  if (auto fn_decl = clang::dyn_cast<clang::FunctionDecl>(decl)) {
     if (isAddrOf()) {
-      EmitFnAsValue(fn_decl);
+      ConvertFunctionToFunctionPointer(fn_decl);
     } else {
       StrCat(str);
     }
@@ -1034,10 +1027,12 @@ void ConverterRefCount::EmitFnPtrCall(clang::Expr *callee) {
   StrCat(")");
 }
 
-void ConverterRefCount::EmitFnAsValue(const clang::FunctionDecl *fn_decl) {
-  StrCat(std::format(
-      "fn_ptr!({}, {})", Mapper::GetFnRefName(fn_decl),
-      GetFnTypeString(fn_decl->getType()->getAs<clang::FunctionProtoType>())));
+void ConverterRefCount::ConvertFunctionToFunctionPointer(
+    const clang::FunctionDecl *fn_decl) {
+  StrCat(
+      std::format("fn_ptr!({}, {})", GetNamedDeclAsString(fn_decl),
+                  ConvertFunctionPointerType(
+                      fn_decl->getType()->getAs<clang::FunctionProtoType>())));
 }
 
 std::string ConverterRefCount::GetFunctionPointerDefaultAsString(
@@ -1063,7 +1058,7 @@ bool ConverterRefCount::VisitFunctionPointerCast(
                            ->getType()
                            ->getPointeeType()
                            ->getAs<clang::FunctionProtoType>();
-      auto fn_type = GetFnTypeString(target_proto);
+      auto fn_type = ConvertFunctionPointerType(target_proto);
 
       std::string adapter = "None";
       // Only accept direct references to the casted function. Otherwise the
@@ -1086,7 +1081,7 @@ bool ConverterRefCount::VisitFunctionPointerCast(
                expr->getType()->isFunctionPointerType()) {
       auto target_proto =
           expr->getType()->getPointeeType()->getAs<clang::FunctionProtoType>();
-      auto fn_type = GetFnTypeString(target_proto);
+      auto fn_type = ConvertFunctionPointerType(target_proto);
       StrCat(std::format("{}.cast_fn::<{}>().expect(\"ub:wrong fn type\")",
                          ToString(expr->getSubExpr()), fn_type));
     } else {

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -221,9 +221,9 @@ std::string ConverterRefCount::BuildFnAdapter(
 }
 
 std::string ConverterRefCount::ConvertFunctionPointerType(
-    const clang::FunctionProtoType *proto) {
+    const clang::FunctionProtoType *proto, FnProtoType kind) {
   PushConversionKind push(*this, ConversionKind::Unboxed);
-  return Converter::ConvertFunctionPointerType(proto);
+  return Converter::ConvertFunctionPointerType(proto, kind);
 }
 
 bool ConverterRefCount::VisitPointerType(clang::PointerType *type) {

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -1029,10 +1029,10 @@ void ConverterRefCount::EmitFnPtrCall(clang::Expr *callee) {
 
 void ConverterRefCount::ConvertFunctionToFunctionPointer(
     const clang::FunctionDecl *fn_decl) {
-  StrCat(
-      std::format("fn_ptr!({}, {})", GetNamedDeclAsString(fn_decl),
-                  ConvertFunctionPointerType(
-                      fn_decl->getType()->getAs<clang::FunctionProtoType>())));
+  StrCat(std::format("FnPtr::<{}>::new({})",
+                     ConvertFunctionPointerType(
+                         fn_decl->getType()->getAs<clang::FunctionProtoType>()),
+                     GetNamedDeclAsString(fn_decl)));
 }
 
 void ConverterRefCount::ConvertEqualsNullPtr(clang::Expr *expr) {
@@ -1614,9 +1614,9 @@ void ConverterRefCount::ConvertVarInit(clang::QualType qual_type,
       Buffer buf(*this);
       PushConversionKind push(*this, ConversionKind::Unboxed);
       if (qual_type->isFunctionPointerType() && lambda->capture_size() == 0) {
-        StrCat("FnPtr::new((");
+        StrCat("FnPtr::new(");
         VisitLambdaExpr(lambda);
-        StrCat("), 0)");
+        StrCat(")");
       } else {
         VisitLambdaExpr(lambda);
       }

--- a/cpp2rust/converter/models/converter_refcount.h
+++ b/cpp2rust/converter/models/converter_refcount.h
@@ -22,6 +22,9 @@ public:
 
   bool VisitPointerType(clang::PointerType *type) override;
 
+  std::string
+  ConvertFunctionPointerType(const clang::FunctionProtoType *proto) override;
+
   bool VisitCXXRecordDecl(clang::CXXRecordDecl *decl) override;
 
   void ConvertOrdAndPartialOrdTraits(const clang::CXXRecordDecl *decl,
@@ -61,7 +64,8 @@ public:
 
   void EmitFnPtrCall(clang::Expr *callee) override;
 
-  void EmitFnAsValue(const clang::FunctionDecl *fn_decl) override;
+  void
+  ConvertFunctionToFunctionPointer(const clang::FunctionDecl *fn_decl) override;
 
   bool VisitCallExpr(clang::CallExpr *expr) override;
 
@@ -182,7 +186,6 @@ private:
   const char *GetPointerDerefSuffix(clang::QualType pointee_type);
   const char *GetPointerDerefPrefix(clang::QualType pointee_type) override;
 
-  std::string GetFnTypeString(const clang::FunctionProtoType *proto);
   std::string BuildFnAdapter(const clang::FunctionDecl *src_fn,
                              const clang::FunctionProtoType *src_proto,
                              const clang::FunctionProtoType *target_proto);

--- a/cpp2rust/converter/models/converter_refcount.h
+++ b/cpp2rust/converter/models/converter_refcount.h
@@ -59,11 +59,17 @@ public:
 
   void ConvertPrintf(clang::CallExpr *expr) override;
 
+  void EmitFnPtrCall(clang::Expr *callee) override;
+
+  void EmitFnAsValue(const clang::FunctionDecl *fn_decl) override;
+
   bool VisitCallExpr(clang::CallExpr *expr) override;
 
   bool VisitStringLiteral(clang::StringLiteral *expr) override;
 
   bool VisitImplicitCastExpr(clang::ImplicitCastExpr *expr) override;
+
+  bool VisitFunctionPointerCast(clang::ExplicitCastExpr *expr);
 
   bool VisitExplicitCastExpr(clang::ExplicitCastExpr *expr) override;
 
@@ -102,6 +108,11 @@ public:
   bool VisitCXXDefaultArgExpr(clang::CXXDefaultArgExpr *expr) override;
 
   std::string GetDefaultAsString(clang::QualType qual_type) override;
+
+  std::string
+  GetFunctionPointerDefaultAsString(clang::QualType qual_type) override;
+
+  void ConvertEqualsNullPtr(clang::Expr *expr) override;
 
   std::string GetDefaultAsStringFallback(clang::QualType qual_type) override;
 
@@ -170,6 +181,11 @@ private:
 
   const char *GetPointerDerefSuffix(clang::QualType pointee_type);
   const char *GetPointerDerefPrefix(clang::QualType pointee_type) override;
+
+  std::string GetFnTypeString(const clang::FunctionProtoType *proto);
+  std::string BuildFnAdapter(const clang::FunctionDecl *src_fn,
+                             const clang::FunctionProtoType *src_proto,
+                             const clang::FunctionProtoType *target_proto);
 
   void EmitSetOrAssign(clang::Expr *lhs, std::string_view rhs);
 

--- a/cpp2rust/converter/models/converter_refcount.h
+++ b/cpp2rust/converter/models/converter_refcount.h
@@ -113,9 +113,6 @@ public:
 
   std::string GetDefaultAsString(clang::QualType qual_type) override;
 
-  std::string
-  GetFunctionPointerDefaultAsString(clang::QualType qual_type) override;
-
   void ConvertEqualsNullPtr(clang::Expr *expr) override;
 
   std::string GetDefaultAsStringFallback(clang::QualType qual_type) override;

--- a/cpp2rust/converter/models/converter_refcount.h
+++ b/cpp2rust/converter/models/converter_refcount.h
@@ -23,7 +23,8 @@ public:
   bool VisitPointerType(clang::PointerType *type) override;
 
   std::string
-  ConvertFunctionPointerType(const clang::FunctionProtoType *proto) override;
+  ConvertFunctionPointerType(const clang::FunctionProtoType *proto,
+                             FnProtoType kind = FnProtoType::FnPtr) override;
 
   bool VisitCXXRecordDecl(clang::CXXRecordDecl *decl) override;
 

--- a/libcc2rs/src/fn_ptr.rs
+++ b/libcc2rs/src/fn_ptr.rs
@@ -31,15 +31,19 @@ macro_rules! impl_fn_addr {
 }
 impl_fn_addr!();
 
-#[derive(Clone)]
-pub(crate) struct FnState {
-    addr: usize,
-    original: Rc<dyn Any>,
-    current_cast: Option<Rc<dyn Any>>,
+trait ErasedFn: Any {
+    fn addr(&self) -> usize;
+}
+
+impl<T: FnAddr + Any> ErasedFn for T {
+    fn addr(&self) -> usize {
+        self.fn_addr()
+    }
 }
 
 pub struct FnPtr<T> {
-    state: Option<Rc<FnState>>,
+    original: Option<Rc<dyn ErasedFn>>,
+    current_cast: Option<Rc<dyn ErasedFn>>,
     // FnPtr does not use T, hence wrap in PhantomData
     _marker: PhantomData<T>,
 }
@@ -48,54 +52,48 @@ impl<T> FnPtr<T> {
     #[inline]
     pub fn null() -> Self {
         FnPtr {
-            state: None,
+            original: None,
+            current_cast: None,
             _marker: PhantomData,
         }
     }
 
     #[inline]
     pub fn is_null(&self) -> bool {
-        self.state.is_none()
+        self.original.is_none()
     }
 }
 
 impl<T: FnAddr + 'static> FnPtr<T> {
     pub fn new(f: T) -> Self {
-        let addr = f.fn_addr();
-        let rc: Rc<dyn Any> = Rc::new(f);
+        let rc: Rc<dyn ErasedFn> = Rc::new(f);
         FnPtr {
-            state: Some(Rc::new(FnState {
-                addr,
-                original: rc.clone(),
-                current_cast: Some(rc),
-            })),
+            original: Some(rc.clone()),
+            current_cast: Some(rc),
             _marker: PhantomData,
         }
     }
 }
 
 impl<T: 'static> FnPtr<T> {
-    pub fn cast<U: 'static>(&self, adapter: Option<U>) -> FnPtr<U> {
-        let state = self.state.as_ref().expect("ub: null fn pointer cast");
+    pub fn cast<U: FnAddr + 'static>(&self, adapter: Option<U>) -> FnPtr<U> {
+        let original = self.original.as_ref().expect("ub: null fn pointer cast");
 
-        let current_cast = if state
+        let current_cast = if self
             .current_cast
             .as_ref()
-            .is_some_and(|rc| (**rc).type_id() == TypeId::of::<U>())
+            .is_some_and(|rc| Any::type_id(&**rc) == TypeId::of::<U>())
         {
-            state.current_cast.clone()
-        } else if (*state.original).type_id() == TypeId::of::<U>() {
-            Some(state.original.clone())
+            self.current_cast.clone()
+        } else if Any::type_id(&**original) == TypeId::of::<U>() {
+            Some(original.clone())
         } else {
-            adapter.map(|a| Rc::new(a) as Rc<dyn Any>)
+            adapter.map(|a| Rc::new(a) as Rc<dyn ErasedFn>)
         };
 
         FnPtr {
-            state: Some(Rc::new(FnState {
-                addr: state.addr,
-                original: state.original.clone(),
-                current_cast,
-            })),
+            original: Some(original.clone()),
+            current_cast,
             _marker: PhantomData,
         }
     }
@@ -104,20 +102,24 @@ impl<T: 'static> FnPtr<T> {
 impl<T: 'static> Deref for FnPtr<T> {
     type Target = T;
     fn deref(&self) -> &T {
-        let state = self.state.as_ref().expect("ub: null fn pointer call");
-        match &state.current_cast {
-            Some(rc) => rc
-                .downcast_ref::<T>()
-                .expect("ub: fn pointer type mismatch"),
-            None => panic!("ub: calling through incompatible fn pointer type"),
+        if self.original.is_none() {
+            panic!("ub: null fn pointer call");
         }
+        let rc = self
+            .current_cast
+            .as_ref()
+            .expect("ub: calling through incompatible fn pointer type");
+        let any: &dyn Any = &**rc;
+        any.downcast_ref::<T>()
+            .expect("ub: fn pointer type mismatch")
     }
 }
 
 impl<T> Clone for FnPtr<T> {
     fn clone(&self) -> Self {
         FnPtr {
-            state: self.state.clone(),
+            original: self.original.clone(),
+            current_cast: self.current_cast.clone(),
             _marker: PhantomData,
         }
     }
@@ -131,9 +133,9 @@ impl<T> Default for FnPtr<T> {
 
 impl<T> PartialEq for FnPtr<T> {
     fn eq(&self, other: &Self) -> bool {
-        match (&self.state, &other.state) {
+        match (&self.original, &other.original) {
             (None, None) => true,
-            (Some(a), Some(b)) => a.addr == b.addr,
+            (Some(a), Some(b)) => a.addr() == b.addr(),
             _ => false,
         }
     }

--- a/libcc2rs/src/fn_ptr.rs
+++ b/libcc2rs/src/fn_ptr.rs
@@ -1,0 +1,172 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#[macro_export]
+macro_rules! fn_ptr {
+    ($f:expr, $ty:ty) => {
+        $crate::FnPtr::new($f as $ty, $f as *const () as usize)
+    };
+}
+
+use std::any::{Any, TypeId};
+use std::marker::PhantomData;
+use std::ops::Deref;
+use std::rc::Rc;
+
+use crate::rc::{AnyPtr, ErasedPtr};
+use crate::reinterpret::ByteRepr;
+
+#[derive(Clone)]
+pub(crate) struct FnState {
+    addr: usize,
+    cast_history: Vec<Option<Rc<dyn Any>>>,
+}
+
+pub struct FnPtr<T> {
+    state: Option<Rc<FnState>>,
+    // FnPtr does not use T, hence wrap in PhantomData
+    _marker: PhantomData<T>,
+}
+
+impl<T> FnPtr<T> {
+    #[inline]
+    pub fn null() -> Self {
+        FnPtr {
+            state: None,
+            _marker: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn is_null(&self) -> bool {
+        self.state.is_none()
+    }
+}
+
+impl<T: 'static> FnPtr<T> {
+    pub fn new(f: T, addr: usize) -> Self {
+        FnPtr {
+            state: Some(Rc::new(FnState {
+                addr,
+                cast_history: vec![Some(Rc::new(f))],
+            })),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn cast<U: 'static>(&self, adapter: Option<U>) -> FnPtr<U> {
+        let state = self.state.as_ref().expect("ub: null fn pointer cast");
+
+        for (i, entry) in state.cast_history.iter().enumerate() {
+            if let Some(ref rc) = entry {
+                if (*rc).as_ref().type_id() == TypeId::of::<U>() {
+                    return FnPtr {
+                        state: Some(Rc::new(FnState {
+                            addr: state.addr,
+                            cast_history: state.cast_history[..=i].to_vec(),
+                        })),
+                        _marker: PhantomData,
+                    };
+                }
+            }
+        }
+
+        let mut new_stack = state.cast_history.clone();
+        new_stack.push(adapter.map(|a| Rc::new(a) as Rc<dyn Any>));
+
+        FnPtr {
+            state: Some(Rc::new(FnState {
+                addr: state.addr,
+                cast_history: new_stack,
+            })),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T: 'static> Deref for FnPtr<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        let state = self.state.as_ref().expect("ub: null fn pointer call");
+        let entry = state
+            .cast_history
+            .last()
+            .expect("empty fn pointer cast_history");
+        match entry {
+            Some(rc) => rc
+                .downcast_ref::<T>()
+                .expect("ub: fn pointer type mismatch"),
+            None => panic!("ub: calling through incompatible fn pointer type"),
+        }
+    }
+}
+
+impl<T> Clone for FnPtr<T> {
+    fn clone(&self) -> Self {
+        FnPtr {
+            state: self.state.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> Default for FnPtr<T> {
+    fn default() -> Self {
+        Self::null()
+    }
+}
+
+impl<T> PartialEq for FnPtr<T> {
+    fn eq(&self, other: &Self) -> bool {
+        match (&self.state, &other.state) {
+            (None, None) => true,
+            (Some(a), Some(b)) => a.addr == b.addr,
+            _ => false,
+        }
+    }
+}
+
+impl<T> Eq for FnPtr<T> {}
+
+impl<T> std::fmt::Debug for FnPtr<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.state {
+            None => write!(f, "FnPtr(null)"),
+            Some(s) => write!(f, "FnPtr(0x{:x})", s.addr),
+        }
+    }
+}
+
+impl<T: 'static> ByteRepr for FnPtr<T> {}
+
+impl<T: 'static> ErasedPtr for FnPtr<T> {
+    fn pointee_type_id(&self) -> TypeId {
+        TypeId::of::<T>()
+    }
+    fn memcpy(&self, _src: &dyn ErasedPtr, _len: usize) {
+        panic!("memcpy not supported on fn pointer");
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn equals(&self, other: &dyn ErasedPtr) -> Option<bool> {
+        if self.pointee_type_id() != other.pointee_type_id() {
+            return None;
+        }
+        other.as_any().downcast_ref::<FnPtr<T>>().map(|o| self == o)
+    }
+}
+
+impl<T: 'static> FnPtr<T> {
+    pub fn to_any(&self) -> AnyPtr {
+        AnyPtr {
+            ptr: Rc::new(self.clone()),
+        }
+    }
+}
+
+impl AnyPtr {
+    pub fn cast_fn<T: 'static>(&self) -> Option<FnPtr<T>> {
+        self.ptr.as_any().downcast_ref::<FnPtr<T>>().cloned()
+    }
+}

--- a/libcc2rs/src/fn_ptr.rs
+++ b/libcc2rs/src/fn_ptr.rs
@@ -159,6 +159,9 @@ impl<T: 'static> ErasedPtr for FnPtr<T> {
         }
         other.as_any().downcast_ref::<FnPtr<T>>().map(|o| self == o)
     }
+    fn is_null(&self) -> bool {
+        FnPtr::is_null(self)
+    }
 }
 
 impl<T: 'static> FnPtr<T> {

--- a/libcc2rs/src/fn_ptr.rs
+++ b/libcc2rs/src/fn_ptr.rs
@@ -128,15 +128,6 @@ impl<T> PartialEq for FnPtr<T> {
 
 impl<T> Eq for FnPtr<T> {}
 
-impl<T> std::fmt::Debug for FnPtr<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.state {
-            None => write!(f, "FnPtr(null)"),
-            Some(s) => write!(f, "FnPtr(0x{:x})", s.addr),
-        }
-    }
-}
-
 impl<T: 'static> ByteRepr for FnPtr<T> {}
 
 impl<T: 'static> ErasedPtr for FnPtr<T> {

--- a/libcc2rs/src/fn_ptr.rs
+++ b/libcc2rs/src/fn_ptr.rs
@@ -1,13 +1,6 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-#[macro_export]
-macro_rules! fn_ptr {
-    ($f:expr, $ty:ty) => {
-        $crate::FnPtr::new($f as $ty, $f as *const () as usize)
-    };
-}
-
 use std::any::{Any, TypeId};
 use std::marker::PhantomData;
 use std::ops::Deref;
@@ -15,6 +8,28 @@ use std::rc::Rc;
 
 use crate::rc::{AnyPtr, ErasedPtr};
 use crate::reinterpret::ByteRepr;
+
+pub trait FnAddr {
+    fn fn_addr(&self) -> usize;
+}
+
+macro_rules! impl_fn_addr {
+    () => {
+        impl_fn_addr!(@gen A B C D E F G H I J);
+    };
+    (@gen $($a:ident)*) => {
+        impl<R $(, $a)*> FnAddr for fn($($a,)*) -> R {
+            #[inline]
+            fn fn_addr(&self) -> usize { *self as *const () as usize }
+        }
+        impl_fn_addr!(@peel $($a)*);
+    };
+    (@peel) => {};
+    (@peel $head:ident $($tail:ident)*) => {
+        impl_fn_addr!(@gen $($tail)*);
+    };
+}
+impl_fn_addr!();
 
 #[derive(Clone)]
 pub(crate) struct FnState {
@@ -43,17 +58,19 @@ impl<T> FnPtr<T> {
     }
 }
 
-impl<T: 'static> FnPtr<T> {
-    pub fn new(f: T, addr: usize) -> Self {
+impl<T: FnAddr + 'static> FnPtr<T> {
+    pub fn new(f: T) -> Self {
         FnPtr {
             state: Some(Rc::new(FnState {
-                addr,
+                addr: f.fn_addr(),
                 cast_history: vec![Some(Rc::new(f))],
             })),
             _marker: PhantomData,
         }
     }
+}
 
+impl<T: 'static> FnPtr<T> {
     pub fn cast<U: 'static>(&self, adapter: Option<U>) -> FnPtr<U> {
         let state = self.state.as_ref().expect("ub: null fn pointer cast");
 

--- a/libcc2rs/src/fn_ptr.rs
+++ b/libcc2rs/src/fn_ptr.rs
@@ -34,7 +34,8 @@ impl_fn_addr!();
 #[derive(Clone)]
 pub(crate) struct FnState {
     addr: usize,
-    cast_history: Vec<Option<Rc<dyn Any>>>,
+    original: Rc<dyn Any>,
+    current_cast: Option<Rc<dyn Any>>,
 }
 
 pub struct FnPtr<T> {
@@ -60,10 +61,13 @@ impl<T> FnPtr<T> {
 
 impl<T: FnAddr + 'static> FnPtr<T> {
     pub fn new(f: T) -> Self {
+        let addr = f.fn_addr();
+        let rc: Rc<dyn Any> = Rc::new(f);
         FnPtr {
             state: Some(Rc::new(FnState {
-                addr: f.fn_addr(),
-                cast_history: vec![Some(Rc::new(f))],
+                addr,
+                original: rc.clone(),
+                current_cast: Some(rc),
             })),
             _marker: PhantomData,
         }
@@ -74,27 +78,23 @@ impl<T: 'static> FnPtr<T> {
     pub fn cast<U: 'static>(&self, adapter: Option<U>) -> FnPtr<U> {
         let state = self.state.as_ref().expect("ub: null fn pointer cast");
 
-        for (i, entry) in state.cast_history.iter().enumerate() {
-            if let Some(ref rc) = entry {
-                if (*rc).as_ref().type_id() == TypeId::of::<U>() {
-                    return FnPtr {
-                        state: Some(Rc::new(FnState {
-                            addr: state.addr,
-                            cast_history: state.cast_history[..=i].to_vec(),
-                        })),
-                        _marker: PhantomData,
-                    };
-                }
-            }
-        }
-
-        let mut new_stack = state.cast_history.clone();
-        new_stack.push(adapter.map(|a| Rc::new(a) as Rc<dyn Any>));
+        let current_cast = if state
+            .current_cast
+            .as_ref()
+            .is_some_and(|rc| (**rc).type_id() == TypeId::of::<U>())
+        {
+            state.current_cast.clone()
+        } else if (*state.original).type_id() == TypeId::of::<U>() {
+            Some(state.original.clone())
+        } else {
+            adapter.map(|a| Rc::new(a) as Rc<dyn Any>)
+        };
 
         FnPtr {
             state: Some(Rc::new(FnState {
                 addr: state.addr,
-                cast_history: new_stack,
+                original: state.original.clone(),
+                current_cast,
             })),
             _marker: PhantomData,
         }
@@ -105,11 +105,7 @@ impl<T: 'static> Deref for FnPtr<T> {
     type Target = T;
     fn deref(&self) -> &T {
         let state = self.state.as_ref().expect("ub: null fn pointer call");
-        let entry = state
-            .cast_history
-            .last()
-            .expect("empty fn pointer cast_history");
-        match entry {
+        match &state.current_cast {
             Some(rc) => rc
                 .downcast_ref::<T>()
                 .expect("ub: fn pointer type mismatch"),

--- a/libcc2rs/src/lib.rs
+++ b/libcc2rs/src/lib.rs
@@ -7,6 +7,9 @@ pub use reinterpret::ByteRepr;
 mod rc;
 pub use rc::*;
 
+mod fn_ptr;
+pub use fn_ptr::FnPtr;
+
 mod inc;
 pub use inc::*;
 

--- a/libcc2rs/src/rc.rs
+++ b/libcc2rs/src/rc.rs
@@ -1004,7 +1004,7 @@ impl Ptr<u8> {
     }
 }
 
-trait ErasedPtr: std::any::Any {
+pub(crate) trait ErasedPtr: std::any::Any {
     fn pointee_type_id(&self) -> std::any::TypeId;
     fn memcpy(&self, src: &dyn ErasedPtr, len: usize);
     fn as_any(&self) -> &dyn std::any::Any;
@@ -1057,7 +1057,7 @@ where
 
 #[derive(Clone)]
 pub struct AnyPtr {
-    ptr: Rc<dyn ErasedPtr>,
+    pub(crate) ptr: Rc<dyn ErasedPtr>,
 }
 
 impl<T: ByteRepr + 'static> Ptr<T> {

--- a/tests/ub/out/refcount/dangling-prvalue-as-lvalue.rs
+++ b/tests/ub/out/refcount/dangling-prvalue-as-lvalue.rs
@@ -17,7 +17,7 @@ fn main_0() -> i32 {
     let v: Value<Vec<i32>> = Rc::new(RefCell::new(vec![1, 2]));
     let b: Ptr<i32> = ({
         let _a: Ptr<i32> = (v.as_pointer() as Ptr<i32>);
-        Rc::new(foo_0)(_a)
+        foo_0(_a)
     });
     (*v.borrow_mut()).clear();
     return (b.read());

--- a/tests/ub/out/refcount/ub1.rs
+++ b/tests/ub/out/refcount/ub1.rs
@@ -16,6 +16,6 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    let x: Ptr<i32> = ({ Rc::new(dangling_0)() });
+    let x: Ptr<i32> = ({ dangling_0() });
     return (x.read());
 }

--- a/tests/ub/out/unsafe/dangling-prvalue-as-lvalue.rs
+++ b/tests/ub/out/unsafe/dangling-prvalue-as-lvalue.rs
@@ -19,7 +19,7 @@ unsafe fn main_0() -> i32 {
     let mut v: Vec<i32> = vec![1, 2];
     let b: *const i32 = (unsafe {
         let _a: *const i32 = &(*v.as_mut_ptr()) as *const i32;
-        Rc::new(|a0| unsafe { foo_0(a0) })(_a)
+        foo_0(_a)
     });
     v.clear();
     return (*b);

--- a/tests/ub/out/unsafe/ub1.rs
+++ b/tests/ub/out/unsafe/ub1.rs
@@ -18,6 +18,6 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    let x: *mut i32 = (unsafe { Rc::new(|| unsafe { dangling_0() })() });
+    let x: *mut i32 = (unsafe { dangling_0() });
     return (*x);
 }

--- a/tests/unit/fn_ptr.cpp
+++ b/tests/unit/fn_ptr.cpp
@@ -1,0 +1,21 @@
+#include <assert.h>
+
+typedef int (*foo_t)(void *);
+
+int my_foo(void *p) { return *static_cast<int *>(p); }
+
+int foo(foo_t fn, int *pi) { return fn(pi); }
+
+int main() {
+  foo_t fn = nullptr;
+  assert(fn == nullptr);
+  assert(fn != my_foo);
+
+  fn = my_foo;
+  assert(fn != nullptr);
+  assert(fn == my_foo);
+
+  int a = 10;
+  assert(foo(fn, &a) == a);
+  return 0;
+}

--- a/tests/unit/fn_ptr.cpp
+++ b/tests/unit/fn_ptr.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
 #include <assert.h>
 
 typedef int (*foo_t)(void *);

--- a/tests/unit/fn_ptr_array.cpp
+++ b/tests/unit/fn_ptr_array.cpp
@@ -1,0 +1,21 @@
+#include <assert.h>
+
+typedef int (*op_t)(int, int);
+
+int add(int a, int b) { return a + b; }
+int sub(int a, int b) { return a - b; }
+int mul(int a, int b) { return a * b; }
+
+int main() {
+  op_t ops[3] = {add, sub, mul};
+
+  assert(ops[0](2, 3) == 5);
+  assert(ops[1](7, 4) == 3);
+  assert(ops[2](6, 5) == 30);
+
+  assert(ops[0] != nullptr);
+  assert(ops[0] == add);
+  assert(ops[0] != sub);
+
+  return 0;
+}

--- a/tests/unit/fn_ptr_array.cpp
+++ b/tests/unit/fn_ptr_array.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
 #include <assert.h>
 
 typedef int (*op_t)(int, int);

--- a/tests/unit/fn_ptr_as_condition.cpp
+++ b/tests/unit/fn_ptr_as_condition.cpp
@@ -1,0 +1,33 @@
+#include <assert.h>
+
+typedef void (*callback_t)(int *);
+
+void double_it(int *x) { *x *= 2; }
+
+void maybe_call(callback_t cb, int *x) {
+  if (cb) {
+    cb(x);
+  }
+}
+
+int main() {
+  int a = 5;
+  maybe_call(double_it, &a);
+  assert(a == 10);
+
+  int b = 5;
+  maybe_call(nullptr, &b);
+  assert(b == 5);
+
+  callback_t fn = nullptr;
+  if (!fn) {
+    fn = double_it;
+  }
+  int c = 3;
+  if (fn) {
+    fn(&c);
+  }
+  assert(c == 6);
+
+  return 0;
+}

--- a/tests/unit/fn_ptr_as_condition.cpp
+++ b/tests/unit/fn_ptr_as_condition.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
 #include <assert.h>
 
 typedef void (*callback_t)(int *);

--- a/tests/unit/fn_ptr_cast.cpp
+++ b/tests/unit/fn_ptr_cast.cpp
@@ -1,0 +1,56 @@
+#include <assert.h>
+
+typedef void (*generic_fn)(void);
+typedef int (*int_fn)(int);
+
+int double_it(int x) { return x * 2; }
+
+void test_roundtrip() {
+  int_fn fn = double_it;
+  assert(fn(5) == 10);
+
+  generic_fn gfn = (generic_fn)fn;
+  assert(gfn != nullptr);
+
+  int_fn fn2 = (int_fn)gfn;
+  assert(fn2(5) == 10);
+  assert(fn2 == fn);
+}
+
+void test_double_cast() {
+  int_fn fn = double_it;
+  int_fn fn2 = (int_fn)(generic_fn)fn;
+  assert(fn2(5) == 10);
+  assert(fn2 == fn);
+}
+
+struct Command {
+  void *data;
+};
+
+void test_void_ptr_to_fn() {
+  Command cmd;
+  cmd.data = (void *)double_it;
+
+  int_fn fn = (int_fn)cmd.data;
+  assert(fn(5) == 10);
+}
+
+typedef int (*generic_int_fn)(void *, int);
+
+int add_offset(int *base, int offset) { return *base + offset; }
+
+void test_call_through_cast() {
+  generic_int_fn gfn = (generic_int_fn)add_offset;
+  int val = 100;
+  int result = gfn(&val, 42);
+  assert(result == 142);
+}
+
+int main() {
+  test_roundtrip();
+  test_double_cast();
+  test_void_ptr_to_fn();
+  test_call_through_cast();
+  return 0;
+}

--- a/tests/unit/fn_ptr_cast.cpp
+++ b/tests/unit/fn_ptr_cast.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
 #include <assert.h>
 
 typedef void (*generic_fn)(void);

--- a/tests/unit/fn_ptr_conditional.cpp
+++ b/tests/unit/fn_ptr_conditional.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
 #include <assert.h>
 
 typedef int (*op_t)(int);

--- a/tests/unit/fn_ptr_conditional.cpp
+++ b/tests/unit/fn_ptr_conditional.cpp
@@ -1,0 +1,25 @@
+#include <assert.h>
+
+typedef int (*op_t)(int);
+
+int inc(int x) { return x + 1; }
+int dec(int x) { return x - 1; }
+int identity(int x) { return x; }
+
+op_t pick(int mode) { return mode > 0 ? inc : mode < 0 ? dec : identity; }
+
+int apply(op_t fn, int x) {
+  op_t actual = fn ? fn : identity;
+  return actual(x);
+}
+
+int main() {
+  assert(pick(1)(10) == 11);
+  assert(pick(-1)(10) == 9);
+  assert(pick(0)(10) == 10);
+
+  assert(apply(inc, 5) == 6);
+  assert(apply(nullptr, 5) == 5);
+
+  return 0;
+}

--- a/tests/unit/fn_ptr_default_arg.cpp
+++ b/tests/unit/fn_ptr_default_arg.cpp
@@ -1,0 +1,23 @@
+#include <assert.h>
+
+typedef int (*transform_t)(int);
+
+int identity(int x) { return x; }
+
+int apply(int x, transform_t fn = nullptr) {
+  if (fn) {
+    return fn(x);
+  }
+  return x;
+}
+
+int main() {
+  assert(apply(5) == 5);
+  assert(apply(5, nullptr) == 5);
+  assert(apply(5, identity) == 5);
+
+  transform_t negate = [](int x) { return -x; };
+  assert(apply(5, negate) == -5);
+
+  return 0;
+}

--- a/tests/unit/fn_ptr_default_arg.cpp
+++ b/tests/unit/fn_ptr_default_arg.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
 #include <assert.h>
 
 typedef int (*transform_t)(int);

--- a/tests/unit/fn_ptr_global.cpp
+++ b/tests/unit/fn_ptr_global.cpp
@@ -1,0 +1,36 @@
+#include <assert.h>
+
+typedef int (*op_t)(int);
+
+int double_it(int x) { return x * 2; }
+int triple_it(int x) { return x * 3; }
+
+static op_t g_op = nullptr;
+
+void set_op(op_t fn) { g_op = fn; }
+
+int call_op(int x) {
+  if (g_op) {
+    return g_op(x);
+  }
+  return x;
+}
+
+int main() {
+  assert(call_op(5) == 5);
+
+  set_op(double_it);
+  assert(g_op != nullptr);
+  assert(g_op == double_it);
+  assert(call_op(5) == 10);
+
+  set_op(triple_it);
+  assert(g_op == triple_it);
+  assert(call_op(5) == 15);
+
+  set_op(nullptr);
+  assert(g_op == nullptr);
+  assert(call_op(5) == 5);
+
+  return 0;
+}

--- a/tests/unit/fn_ptr_global.cpp
+++ b/tests/unit/fn_ptr_global.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
 #include <assert.h>
 
 typedef int (*op_t)(int);

--- a/tests/unit/fn_ptr_reassign.cpp
+++ b/tests/unit/fn_ptr_reassign.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
 #include <assert.h>
 
 typedef int (*op_t)(int, int);

--- a/tests/unit/fn_ptr_reassign.cpp
+++ b/tests/unit/fn_ptr_reassign.cpp
@@ -1,0 +1,27 @@
+#include <assert.h>
+
+typedef int (*op_t)(int, int);
+
+int add(int a, int b) { return a + b; }
+int sub(int a, int b) { return a - b; }
+int mul(int a, int b) { return a * b; }
+
+int main() {
+  op_t fn = add;
+  assert(fn(3, 4) == 7);
+
+  fn = sub;
+  assert(fn(10, 3) == 7);
+
+  fn = mul;
+  assert(fn(6, 7) == 42);
+
+  fn = nullptr;
+  assert(fn == nullptr);
+
+  fn = add;
+  assert(fn != nullptr);
+  assert(fn(1, 1) == 2);
+
+  return 0;
+}

--- a/tests/unit/fn_ptr_return.cpp
+++ b/tests/unit/fn_ptr_return.cpp
@@ -1,0 +1,27 @@
+#include <assert.h>
+
+typedef int (*op_t)(int);
+
+int inc(int x) { return x + 1; }
+int dec(int x) { return x - 1; }
+
+op_t pick(int choose_inc) {
+  if (choose_inc) {
+    return inc;
+  }
+  return dec;
+}
+
+int main() {
+  op_t f = pick(1);
+  assert(f != nullptr);
+  assert(f == inc);
+  assert(f(10) == 11);
+
+  op_t g = pick(0);
+  assert(g == dec);
+  assert(g(10) == 9);
+
+  assert(f != g);
+  return 0;
+}

--- a/tests/unit/fn_ptr_return.cpp
+++ b/tests/unit/fn_ptr_return.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
 #include <assert.h>
 
 typedef int (*op_t)(int);

--- a/tests/unit/fn_ptr_stable_sort.cpp
+++ b/tests/unit/fn_ptr_stable_sort.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
 #include <algorithm>
 #include <assert.h>
 #include <vector>

--- a/tests/unit/fn_ptr_stable_sort.cpp
+++ b/tests/unit/fn_ptr_stable_sort.cpp
@@ -1,0 +1,25 @@
+#include <algorithm>
+#include <assert.h>
+#include <vector>
+
+struct Item {
+  int key;
+  int value;
+};
+
+static bool Compare(const Item &a, const Item &b) { return a.key < b.key; }
+
+int main() {
+  std::vector<Item> v;
+  v.push_back({3, 30});
+  v.push_back({1, 10});
+  v.push_back({2, 20});
+
+  std::stable_sort(v.begin(), v.end(), Compare);
+
+  assert(v[0].key == 1);
+  assert(v[1].key == 2);
+  assert(v[2].key == 3);
+
+  return 0;
+}

--- a/tests/unit/fn_ptr_struct.cpp
+++ b/tests/unit/fn_ptr_struct.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
 #include <assert.h>
 
 typedef int (*handler_t)(int);

--- a/tests/unit/fn_ptr_struct.cpp
+++ b/tests/unit/fn_ptr_struct.cpp
@@ -1,0 +1,26 @@
+#include <assert.h>
+
+typedef int (*handler_t)(int);
+
+struct Handler {
+  int tag;
+  handler_t cb;
+};
+
+int double_it(int x) { return x * 2; }
+int negate(int x) { return -x; }
+
+int main() {
+  Handler h1 = {1, double_it};
+  Handler h2 = {2, negate};
+
+  assert(h1.cb != nullptr);
+  assert(h1.cb(5) == 10);
+  assert(h2.cb(7) == -7);
+
+  h1.cb = negate;
+  assert(h1.cb(3) == -3);
+  assert(h1.cb == h2.cb);
+
+  return 0;
+}

--- a/tests/unit/fn_ptr_void_return.cpp
+++ b/tests/unit/fn_ptr_void_return.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
 #include <assert.h>
 
 typedef void (*action_t)(int *);

--- a/tests/unit/fn_ptr_void_return.cpp
+++ b/tests/unit/fn_ptr_void_return.cpp
@@ -1,0 +1,25 @@
+#include <assert.h>
+
+typedef void (*action_t)(int *);
+
+void negate(int *x) { *x = -*x; }
+void zero_out(int *x) { *x = 0; }
+
+void run(action_t fn, int *x) { fn(x); }
+
+int main() {
+  int a = 42;
+  run(negate, &a);
+  assert(a == -42);
+
+  run(zero_out, &a);
+  assert(a == 0);
+
+  action_t fn = negate;
+  assert(fn != nullptr);
+  int b = 10;
+  fn(&b);
+  assert(b == -10);
+
+  return 0;
+}

--- a/tests/unit/fn_ptr_vtable.cpp
+++ b/tests/unit/fn_ptr_vtable.cpp
@@ -1,0 +1,41 @@
+#include <assert.h>
+
+typedef void *(*create_fn)(int);
+typedef int (*get_fn)(void *);
+typedef void (*destroy_fn)(void *);
+
+struct Vtable {
+  create_fn create;
+  get_fn get;
+  destroy_fn destroy;
+};
+
+static int storage;
+
+void *int_create(int val) {
+  storage = val;
+  return &storage;
+}
+
+int int_get(void *p) { return *(int *)p; }
+
+void int_destroy(void *p) { *(int *)p = 0; }
+
+int main() {
+  Vtable vt = {int_create, int_get, int_destroy};
+
+  assert(vt.create != nullptr);
+  assert(vt.get != nullptr);
+  assert(vt.destroy != nullptr);
+
+  void *obj = vt.create(42);
+  assert(vt.get(obj) == 42);
+
+  vt.destroy(obj);
+  assert(storage == 0);
+
+  vt.get = nullptr;
+  assert(vt.get == nullptr);
+
+  return 0;
+}

--- a/tests/unit/fn_ptr_vtable.cpp
+++ b/tests/unit/fn_ptr_vtable.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
 #include <assert.h>
 
 typedef void *(*create_fn)(int);

--- a/tests/unit/lambda_capture_pass.cpp
+++ b/tests/unit/lambda_capture_pass.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
 #include <assert.h>
 
 template <typename F> int apply(F fn, int x) { return fn(x); }

--- a/tests/unit/lambda_capture_pass.cpp
+++ b/tests/unit/lambda_capture_pass.cpp
@@ -1,0 +1,19 @@
+#include <assert.h>
+
+template <typename F> int apply(F fn, int x) { return fn(x); }
+
+int main() {
+  int base = 10;
+
+  auto add_base = [&base](int x) { return x + base; };
+  assert(apply(add_base, 5) == 15);
+
+  base = 100;
+  assert(apply(add_base, 5) == 105);
+
+  int factor = 3;
+  auto scale = [factor](int x) { return x * factor; };
+  assert(apply(scale, 4) == 12);
+
+  return 0;
+}

--- a/tests/unit/lambda_nested.cpp
+++ b/tests/unit/lambda_nested.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
 #include <assert.h>
 
 int main() {

--- a/tests/unit/lambda_nested.cpp
+++ b/tests/unit/lambda_nested.cpp
@@ -1,0 +1,17 @@
+#include <assert.h>
+
+int main() {
+  int x = 10;
+
+  auto outer = [&x](int y) {
+    auto inner = [&x, y](int z) { return x + y + z; };
+    return inner(1);
+  };
+
+  assert(outer(20) == 31);
+
+  x = 100;
+  assert(outer(20) == 121);
+
+  return 0;
+}

--- a/tests/unit/out/refcount/complex_function.rs
+++ b/tests/unit/out/refcount/complex_function.rs
@@ -133,11 +133,11 @@ fn main_0() -> i32 {
     let r1: Ptr<i32> = x1.as_pointer();
     let r2: Ptr<i32> = ({
         let _x: Ptr<i32> = x1.as_pointer();
-        Rc::new(bar_2)(_x)
+        bar_2(_x)
     });
     let r3: Ptr<i32> = ({
         let _x: Ptr<i32> = (r1).clone();
-        Rc::new(bar_2)(_x)
+        bar_2(_x)
     });
     let __rhs = (*x1.borrow());
     {
@@ -403,7 +403,7 @@ fn main_0() -> i32 {
             .deref())
             .v
             .as_pointer());
-            Rc::new(ptr_1)(_x)
+            ptr_1(_x)
         })
         .clone();
         let __tmp = __ptr.read() + 1;
@@ -436,7 +436,7 @@ fn main_0() -> i32 {
         .deref())
         .v
         .as_pointer());
-        Rc::new(ptr_1)(_x)
+        ptr_1(_x)
     });
     let ptr3: Value<Ptr<i32>> = Rc::new(RefCell::new(
         ({
@@ -450,7 +450,7 @@ fn main_0() -> i32 {
             .deref())
             .v
             .as_pointer());
-            Rc::new(ptr_1)(_x)
+            ptr_1(_x)
         }),
     ));
     let vptr: Value<i32> = Rc::new(RefCell::new(
@@ -481,7 +481,7 @@ fn main_0() -> i32 {
             .deref())
             .v
             .as_pointer();
-            Rc::new(bar_2)(_x)
+            bar_2(_x)
         }),
     ));
     ({
@@ -495,7 +495,7 @@ fn main_0() -> i32 {
         .deref())
         .v
         .as_pointer();
-        Rc::new(bar_2)(_x)
+        bar_2(_x)
     })
     .with_mut(|__v| __v.postfix_inc());
     return (((({

--- a/tests/unit/out/refcount/fn_ptr.rs
+++ b/tests/unit/out/refcount/fn_ptr.rs
@@ -27,13 +27,13 @@ fn main_0() -> i32 {
     assert!((*fn_.borrow()).is_null());
     assert!({
         let _lhs = (*fn_.borrow()).clone();
-        _lhs != fn_ptr!(my_foo_0, fn(AnyPtr) -> i32)
+        _lhs != FnPtr::<fn(AnyPtr) -> i32>::new(my_foo_0)
     });
-    (*fn_.borrow_mut()) = fn_ptr!(my_foo_0, fn(AnyPtr) -> i32);
+    (*fn_.borrow_mut()) = FnPtr::<fn(AnyPtr) -> i32>::new(my_foo_0);
     assert!(!((*fn_.borrow()).is_null()));
     assert!({
         let _lhs = (*fn_.borrow()).clone();
-        _lhs == fn_ptr!(my_foo_0, fn(AnyPtr) -> i32)
+        _lhs == FnPtr::<fn(AnyPtr) -> i32>::new(my_foo_0)
     });
     let a: Value<i32> = Rc::new(RefCell::new(10));
     assert!({

--- a/tests/unit/out/refcount/fn_ptr.rs
+++ b/tests/unit/out/refcount/fn_ptr.rs
@@ -1,0 +1,48 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn my_foo_0(p: AnyPtr) -> i32 {
+    let p: Value<AnyPtr> = Rc::new(RefCell::new(p));
+    return ((*p.borrow()).cast::<i32>().expect("ub:wrong type").read());
+}
+pub fn foo_1(fn_: FnPtr<fn(AnyPtr) -> i32>, pi: Ptr<i32>) -> i32 {
+    let fn_: Value<FnPtr<fn(AnyPtr) -> i32>> = Rc::new(RefCell::new(fn_));
+    let pi: Value<Ptr<i32>> = Rc::new(RefCell::new(pi));
+    return ({
+        let _arg0: AnyPtr = ((*pi.borrow()).clone() as Ptr<i32>).to_any();
+        (*(*fn_.borrow()))(_arg0)
+    });
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let fn_: Value<FnPtr<fn(AnyPtr) -> i32>> = Rc::new(RefCell::new(FnPtr::null()));
+    assert!((*fn_.borrow()).is_null());
+    assert!({
+        let _lhs = (*fn_.borrow()).clone();
+        _lhs != fn_ptr!(my_foo_0, fn(AnyPtr) -> i32)
+    });
+    (*fn_.borrow_mut()) = fn_ptr!(my_foo_0, fn(AnyPtr) -> i32);
+    assert!(!((*fn_.borrow()).is_null()));
+    assert!({
+        let _lhs = (*fn_.borrow()).clone();
+        _lhs == fn_ptr!(my_foo_0, fn(AnyPtr) -> i32)
+    });
+    let a: Value<i32> = Rc::new(RefCell::new(10));
+    assert!({
+        let _lhs = ({
+            let _fn: FnPtr<fn(AnyPtr) -> i32> = (*fn_.borrow()).clone();
+            let _pi: Ptr<i32> = (a.as_pointer());
+            foo_1(_fn, _pi)
+        });
+        _lhs == (*a.borrow())
+    });
+    return 0;
+}

--- a/tests/unit/out/refcount/fn_ptr_array.rs
+++ b/tests/unit/out/refcount/fn_ptr_array.rs
@@ -27,9 +27,9 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let ops: Value<Box<[FnPtr<fn(i32, i32) -> i32>]>> = Rc::new(RefCell::new(Box::new([
-        fn_ptr!(add_0, fn(i32, i32) -> i32),
-        fn_ptr!(sub_1, fn(i32, i32) -> i32),
-        fn_ptr!(mul_2, fn(i32, i32) -> i32),
+        FnPtr::<fn(i32, i32) -> i32>::new(add_0),
+        FnPtr::<fn(i32, i32) -> i32>::new(sub_1),
+        FnPtr::<fn(i32, i32) -> i32>::new(mul_2),
     ])));
     assert!(
         (({
@@ -53,7 +53,7 @@ fn main_0() -> i32 {
         }) == 30)
     );
     assert!(!(((*ops.borrow())[(0) as usize]).is_null()));
-    assert!(((*ops.borrow())[(0) as usize] == fn_ptr!(add_0, fn(i32, i32) -> i32)));
-    assert!(((*ops.borrow())[(0) as usize] != fn_ptr!(sub_1, fn(i32, i32) -> i32)));
+    assert!(((*ops.borrow())[(0) as usize] == FnPtr::<fn(i32, i32) -> i32>::new(add_0)));
+    assert!(((*ops.borrow())[(0) as usize] != FnPtr::<fn(i32, i32) -> i32>::new(sub_1)));
     return 0;
 }

--- a/tests/unit/out/refcount/fn_ptr_array.rs
+++ b/tests/unit/out/refcount/fn_ptr_array.rs
@@ -1,0 +1,59 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn add_0(a: i32, b: i32) -> i32 {
+    let a: Value<i32> = Rc::new(RefCell::new(a));
+    let b: Value<i32> = Rc::new(RefCell::new(b));
+    return ((*a.borrow()) + (*b.borrow()));
+}
+pub fn sub_1(a: i32, b: i32) -> i32 {
+    let a: Value<i32> = Rc::new(RefCell::new(a));
+    let b: Value<i32> = Rc::new(RefCell::new(b));
+    return ((*a.borrow()) - (*b.borrow()));
+}
+pub fn mul_2(a: i32, b: i32) -> i32 {
+    let a: Value<i32> = Rc::new(RefCell::new(a));
+    let b: Value<i32> = Rc::new(RefCell::new(b));
+    return ((*a.borrow()) * (*b.borrow()));
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let ops: Value<Box<[FnPtr<fn(i32, i32) -> i32>]>> = Rc::new(RefCell::new(Box::new([
+        fn_ptr!(add_0, fn(i32, i32) -> i32),
+        fn_ptr!(sub_1, fn(i32, i32) -> i32),
+        fn_ptr!(mul_2, fn(i32, i32) -> i32),
+    ])));
+    assert!(
+        (({
+            let _arg0: i32 = 2;
+            let _arg1: i32 = 3;
+            (*(*ops.borrow())[(0) as usize])(_arg0, _arg1)
+        }) == 5)
+    );
+    assert!(
+        (({
+            let _arg0: i32 = 7;
+            let _arg1: i32 = 4;
+            (*(*ops.borrow())[(1) as usize])(_arg0, _arg1)
+        }) == 3)
+    );
+    assert!(
+        (({
+            let _arg0: i32 = 6;
+            let _arg1: i32 = 5;
+            (*(*ops.borrow())[(2) as usize])(_arg0, _arg1)
+        }) == 30)
+    );
+    assert!(!(((*ops.borrow())[(0) as usize]).is_null()));
+    assert!(((*ops.borrow())[(0) as usize] == fn_ptr!(add_0, fn(i32, i32) -> i32)));
+    assert!(((*ops.borrow())[(0) as usize] != fn_ptr!(sub_1, fn(i32, i32) -> i32)));
+    return 0;
+}

--- a/tests/unit/out/refcount/fn_ptr_as_condition.rs
+++ b/tests/unit/out/refcount/fn_ptr_as_condition.rs
@@ -31,7 +31,7 @@ pub fn main() {
 fn main_0() -> i32 {
     let a: Value<i32> = Rc::new(RefCell::new(5));
     ({
-        let _cb: FnPtr<fn(Ptr<i32>)> = fn_ptr!(double_it_0, fn(Ptr::<i32>));
+        let _cb: FnPtr<fn(Ptr<i32>)> = FnPtr::<fn(Ptr<i32>)>::new(double_it_0);
         let _x: Ptr<i32> = (a.as_pointer());
         maybe_call_1(_cb, _x)
     });
@@ -45,7 +45,7 @@ fn main_0() -> i32 {
     assert!(((*b.borrow()) == 5));
     let fn_: Value<FnPtr<fn(Ptr<i32>)>> = Rc::new(RefCell::new(FnPtr::null()));
     if !!(*fn_.borrow()).is_null() {
-        (*fn_.borrow_mut()) = (fn_ptr!(double_it_0, fn(Ptr::<i32>))).clone();
+        (*fn_.borrow_mut()) = (FnPtr::<fn(Ptr<i32>)>::new(double_it_0)).clone();
     }
     let c: Value<i32> = Rc::new(RefCell::new(3));
     if !(*fn_.borrow()).is_null() {

--- a/tests/unit/out/refcount/fn_ptr_as_condition.rs
+++ b/tests/unit/out/refcount/fn_ptr_as_condition.rs
@@ -1,0 +1,59 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn double_it_0(x: Ptr<i32>) {
+    let x: Value<Ptr<i32>> = Rc::new(RefCell::new(x));
+    {
+        let __ptr = (*x.borrow()).clone();
+        let __tmp = __ptr.read() * 2;
+        __ptr.write(__tmp)
+    };
+}
+pub fn maybe_call_1(cb: FnPtr<fn(Ptr<i32>)>, x: Ptr<i32>) {
+    let cb: Value<FnPtr<fn(Ptr<i32>)>> = Rc::new(RefCell::new(cb));
+    let x: Value<Ptr<i32>> = Rc::new(RefCell::new(x));
+    if !(*cb.borrow()).is_null() {
+        ({
+            let _arg0: Ptr<i32> = (*x.borrow()).clone();
+            (*(*cb.borrow()))(_arg0)
+        });
+    }
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let a: Value<i32> = Rc::new(RefCell::new(5));
+    ({
+        let _cb: FnPtr<fn(Ptr<i32>)> = fn_ptr!(double_it_0, fn(Ptr::<i32>));
+        let _x: Ptr<i32> = (a.as_pointer());
+        maybe_call_1(_cb, _x)
+    });
+    assert!(((*a.borrow()) == 10));
+    let b: Value<i32> = Rc::new(RefCell::new(5));
+    ({
+        let _cb: FnPtr<fn(Ptr<i32>)> = FnPtr::null();
+        let _x: Ptr<i32> = (b.as_pointer());
+        maybe_call_1(_cb, _x)
+    });
+    assert!(((*b.borrow()) == 5));
+    let fn_: Value<FnPtr<fn(Ptr<i32>)>> = Rc::new(RefCell::new(FnPtr::null()));
+    if !!(*fn_.borrow()).is_null() {
+        (*fn_.borrow_mut()) = (fn_ptr!(double_it_0, fn(Ptr::<i32>))).clone();
+    }
+    let c: Value<i32> = Rc::new(RefCell::new(3));
+    if !(*fn_.borrow()).is_null() {
+        ({
+            let _arg0: Ptr<i32> = (c.as_pointer());
+            (*(*fn_.borrow()))(_arg0)
+        });
+    }
+    assert!(((*c.borrow()) == 6));
+    return 0;
+}

--- a/tests/unit/out/refcount/fn_ptr_cast.rs
+++ b/tests/unit/out/refcount/fn_ptr_cast.rs
@@ -1,0 +1,123 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn double_it_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    return ((*x.borrow()) * 2);
+}
+pub fn test_roundtrip_1() {
+    let fn_: Value<FnPtr<fn(i32) -> i32>> =
+        Rc::new(RefCell::new(fn_ptr!(double_it_0, fn(i32) -> i32)));
+    assert!(
+        (({
+            let _arg0: i32 = 5;
+            (*(*fn_.borrow()))(_arg0)
+        }) == 10)
+    );
+    let gfn: Value<FnPtr<fn()>> =
+        Rc::new(RefCell::new(((*fn_.borrow()).cast::<fn()>(None)).clone()));
+    assert!(!((*gfn.borrow()).is_null()));
+    let fn2: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(
+        ((*gfn.borrow()).cast::<fn(i32) -> i32>(None)).clone(),
+    ));
+    assert!(
+        (({
+            let _arg0: i32 = 5;
+            (*(*fn2.borrow()))(_arg0)
+        }) == 10)
+    );
+    assert!({
+        let _lhs = (*fn2.borrow()).clone();
+        _lhs == (*fn_.borrow()).clone()
+    });
+}
+pub fn test_double_cast_2() {
+    let fn_: Value<FnPtr<fn(i32) -> i32>> =
+        Rc::new(RefCell::new(fn_ptr!(double_it_0, fn(i32) -> i32)));
+    let fn2: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(
+        ((*fn_.borrow())
+            .cast::<fn()>(None)
+            .cast::<fn(i32) -> i32>(None))
+        .clone(),
+    ));
+    assert!(
+        (({
+            let _arg0: i32 = 5;
+            (*(*fn2.borrow()))(_arg0)
+        }) == 10)
+    );
+    assert!({
+        let _lhs = (*fn2.borrow()).clone();
+        _lhs == (*fn_.borrow()).clone()
+    });
+}
+#[derive(Default)]
+pub struct Command {
+    pub data: Value<AnyPtr>,
+}
+impl Clone for Command {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            data: Rc::new(RefCell::new((*self.data.borrow()).clone())),
+        };
+        this
+    }
+}
+impl ByteRepr for Command {}
+pub fn test_void_ptr_to_fn_3() {
+    let cmd: Value<Command> = Rc::new(RefCell::new(<Command>::default()));
+    (*(*cmd.borrow()).data.borrow_mut()) = fn_ptr!(double_it_0, fn(i32) -> i32).to_any();
+    let fn_: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(
+        ((*(*cmd.borrow()).data.borrow())
+            .cast_fn::<fn(i32) -> i32>()
+            .expect("ub:wrong fn type"))
+        .clone(),
+    ));
+    assert!(
+        (({
+            let _arg0: i32 = 5;
+            (*(*fn_.borrow()))(_arg0)
+        }) == 10)
+    );
+}
+pub fn add_offset_4(base: Ptr<i32>, offset: i32) -> i32 {
+    let base: Value<Ptr<i32>> = Rc::new(RefCell::new(base));
+    let offset: Value<i32> = Rc::new(RefCell::new(offset));
+    return {
+        let _lhs = ((*base.borrow()).read());
+        _lhs + (*offset.borrow())
+    };
+}
+pub fn test_call_through_cast_5() {
+    let gfn: Value<FnPtr<fn(AnyPtr, i32) -> i32>> = Rc::new(RefCell::new(
+        fn_ptr!(add_offset_4, fn(Ptr::<i32>, i32) -> i32).cast::<fn(AnyPtr, i32) -> i32>(Some(
+            (|a0: AnyPtr, a1: i32| -> i32 { add_offset_4(a0.cast::<i32>().unwrap(), a1) })
+                as fn(AnyPtr, i32) -> i32,
+        )),
+    ));
+    let val: Value<i32> = Rc::new(RefCell::new(100));
+    let result: Value<i32> = Rc::new(RefCell::new(
+        ({
+            let _arg0: AnyPtr = ((val.as_pointer()) as Ptr<i32>).to_any();
+            let _arg1: i32 = 42;
+            (*(*gfn.borrow()))(_arg0, _arg1)
+        }),
+    ));
+    assert!(((*result.borrow()) == 142));
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    ({ test_roundtrip_1() });
+    ({ test_double_cast_2() });
+    ({ test_void_ptr_to_fn_3() });
+    ({ test_call_through_cast_5() });
+    return 0;
+}

--- a/tests/unit/out/refcount/fn_ptr_cast.rs
+++ b/tests/unit/out/refcount/fn_ptr_cast.rs
@@ -13,7 +13,7 @@ pub fn double_it_0(x: i32) -> i32 {
 }
 pub fn test_roundtrip_1() {
     let fn_: Value<FnPtr<fn(i32) -> i32>> =
-        Rc::new(RefCell::new(fn_ptr!(double_it_0, fn(i32) -> i32)));
+        Rc::new(RefCell::new(FnPtr::<fn(i32) -> i32>::new(double_it_0)));
     assert!(
         (({
             let _arg0: i32 = 5;
@@ -39,7 +39,7 @@ pub fn test_roundtrip_1() {
 }
 pub fn test_double_cast_2() {
     let fn_: Value<FnPtr<fn(i32) -> i32>> =
-        Rc::new(RefCell::new(fn_ptr!(double_it_0, fn(i32) -> i32)));
+        Rc::new(RefCell::new(FnPtr::<fn(i32) -> i32>::new(double_it_0)));
     let fn2: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(
         ((*fn_.borrow())
             .cast::<fn()>(None)
@@ -72,7 +72,7 @@ impl Clone for Command {
 impl ByteRepr for Command {}
 pub fn test_void_ptr_to_fn_3() {
     let cmd: Value<Command> = Rc::new(RefCell::new(<Command>::default()));
-    (*(*cmd.borrow()).data.borrow_mut()) = fn_ptr!(double_it_0, fn(i32) -> i32).to_any();
+    (*(*cmd.borrow()).data.borrow_mut()) = FnPtr::<fn(i32) -> i32>::new(double_it_0).to_any();
     let fn_: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(
         ((*(*cmd.borrow()).data.borrow())
             .cast_fn::<fn(i32) -> i32>()
@@ -96,7 +96,7 @@ pub fn add_offset_4(base: Ptr<i32>, offset: i32) -> i32 {
 }
 pub fn test_call_through_cast_5() {
     let gfn: Value<FnPtr<fn(AnyPtr, i32) -> i32>> = Rc::new(RefCell::new(
-        fn_ptr!(add_offset_4, fn(Ptr::<i32>, i32) -> i32).cast::<fn(AnyPtr, i32) -> i32>(Some(
+        FnPtr::<fn(Ptr<i32>, i32) -> i32>::new(add_offset_4).cast::<fn(AnyPtr, i32) -> i32>(Some(
             (|a0: AnyPtr, a1: i32| -> i32 { add_offset_4(a0.cast::<i32>().unwrap(), a1) })
                 as fn(AnyPtr, i32) -> i32,
         )),

--- a/tests/unit/out/refcount/fn_ptr_conditional.rs
+++ b/tests/unit/out/refcount/fn_ptr_conditional.rs
@@ -22,12 +22,12 @@ pub fn identity_2(x: i32) -> i32 {
 pub fn pick_3(mode: i32) -> FnPtr<fn(i32) -> i32> {
     let mode: Value<i32> = Rc::new(RefCell::new(mode));
     return if ((*mode.borrow()) > 0) {
-        fn_ptr!(inc_0, fn(i32) -> i32)
+        FnPtr::<fn(i32) -> i32>::new(inc_0)
     } else {
         if ((*mode.borrow()) < 0) {
-            fn_ptr!(dec_1, fn(i32) -> i32)
+            FnPtr::<fn(i32) -> i32>::new(dec_1)
         } else {
-            fn_ptr!(identity_2, fn(i32) -> i32)
+            FnPtr::<fn(i32) -> i32>::new(identity_2)
         }
     };
 }
@@ -38,7 +38,7 @@ pub fn apply_4(fn_: FnPtr<fn(i32) -> i32>, x: i32) -> i32 {
         Rc::new(RefCell::new(if !(*fn_.borrow()).is_null() {
             (*fn_.borrow()).clone()
         } else {
-            fn_ptr!(identity_2, fn(i32) -> i32)
+            FnPtr::<fn(i32) -> i32>::new(identity_2)
         }));
     return ({
         let _arg0: i32 = (*x.borrow());
@@ -78,7 +78,7 @@ fn main_0() -> i32 {
     );
     assert!(
         (({
-            let _fn: FnPtr<fn(i32) -> i32> = fn_ptr!(inc_0, fn(i32) -> i32);
+            let _fn: FnPtr<fn(i32) -> i32> = FnPtr::<fn(i32) -> i32>::new(inc_0);
             let _x: i32 = 5;
             apply_4(_fn, _x)
         }) == 6)

--- a/tests/unit/out/refcount/fn_ptr_conditional.rs
+++ b/tests/unit/out/refcount/fn_ptr_conditional.rs
@@ -1,0 +1,94 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn inc_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    return ((*x.borrow()) + 1);
+}
+pub fn dec_1(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    return ((*x.borrow()) - 1);
+}
+pub fn identity_2(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    return (*x.borrow());
+}
+pub fn pick_3(mode: i32) -> FnPtr<fn(i32) -> i32> {
+    let mode: Value<i32> = Rc::new(RefCell::new(mode));
+    return if ((*mode.borrow()) > 0) {
+        fn_ptr!(inc_0, fn(i32) -> i32)
+    } else {
+        if ((*mode.borrow()) < 0) {
+            fn_ptr!(dec_1, fn(i32) -> i32)
+        } else {
+            fn_ptr!(identity_2, fn(i32) -> i32)
+        }
+    };
+}
+pub fn apply_4(fn_: FnPtr<fn(i32) -> i32>, x: i32) -> i32 {
+    let fn_: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(fn_));
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    let actual: Value<FnPtr<fn(i32) -> i32>> =
+        Rc::new(RefCell::new(if !(*fn_.borrow()).is_null() {
+            (*fn_.borrow()).clone()
+        } else {
+            fn_ptr!(identity_2, fn(i32) -> i32)
+        }));
+    return ({
+        let _arg0: i32 = (*x.borrow());
+        (*(*actual.borrow()))(_arg0)
+    });
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _arg0: i32 = 10;
+            (*({
+                let _mode: i32 = 1;
+                pick_3(_mode)
+            }))(_arg0)
+        }) == 11)
+    );
+    assert!(
+        (({
+            let _arg0: i32 = 10;
+            (*({
+                let _mode: i32 = -1_i32;
+                pick_3(_mode)
+            }))(_arg0)
+        }) == 9)
+    );
+    assert!(
+        (({
+            let _arg0: i32 = 10;
+            (*({
+                let _mode: i32 = 0;
+                pick_3(_mode)
+            }))(_arg0)
+        }) == 10)
+    );
+    assert!(
+        (({
+            let _fn: FnPtr<fn(i32) -> i32> = fn_ptr!(inc_0, fn(i32) -> i32);
+            let _x: i32 = 5;
+            apply_4(_fn, _x)
+        }) == 6)
+    );
+    assert!(
+        (({
+            let _fn: FnPtr<fn(i32) -> i32> = FnPtr::null();
+            let _x: i32 = 5;
+            apply_4(_fn, _x)
+        }) == 5)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/fn_ptr_default_arg.rs
+++ b/tests/unit/out/refcount/fn_ptr_default_arg.rs
@@ -1,0 +1,65 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn identity_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    return (*x.borrow());
+}
+pub fn apply_1(x: i32, fn_: Option<FnPtr<fn(i32) -> i32>>) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    let fn_: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(fn_.unwrap_or(FnPtr::null())));
+    if !(*fn_.borrow()).is_null() {
+        return ({
+            let _arg0: i32 = (*x.borrow());
+            (*(*fn_.borrow()))(_arg0)
+        });
+    }
+    return (*x.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = 5;
+            let _fn: FnPtr<fn(i32) -> i32> = Default::default();
+            apply_1(_x, Some(_fn))
+        }) == 5)
+    );
+    assert!(
+        (({
+            let _x: i32 = 5;
+            let _fn: FnPtr<fn(i32) -> i32> = FnPtr::null();
+            apply_1(_x, Some(_fn))
+        }) == 5)
+    );
+    assert!(
+        (({
+            let _x: i32 = 5;
+            let _fn: FnPtr<fn(i32) -> i32> = fn_ptr!(identity_0, fn(i32) -> i32);
+            apply_1(_x, Some(_fn))
+        }) == 5)
+    );
+    let negate: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::new(
+        (|x: i32| {
+            let x: Value<i32> = Rc::new(RefCell::new(x));
+            return -(*x.borrow());
+        }),
+        0,
+    )));
+    assert!(
+        (({
+            let _x: i32 = 5;
+            let _fn: FnPtr<fn(i32) -> i32> = (*negate.borrow()).clone();
+            apply_1(_x, Some(_fn))
+        }) == -5_i32)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/fn_ptr_default_arg.rs
+++ b/tests/unit/out/refcount/fn_ptr_default_arg.rs
@@ -43,7 +43,7 @@ fn main_0() -> i32 {
     assert!(
         (({
             let _x: i32 = 5;
-            let _fn: FnPtr<fn(i32) -> i32> = fn_ptr!(identity_0, fn(i32) -> i32);
+            let _fn: FnPtr<fn(i32) -> i32> = FnPtr::<fn(i32) -> i32>::new(identity_0);
             apply_1(_x, Some(_fn))
         }) == 5)
     );
@@ -52,7 +52,6 @@ fn main_0() -> i32 {
             let x: Value<i32> = Rc::new(RefCell::new(x));
             return -(*x.borrow());
         }),
-        0,
     )));
     assert!(
         (({

--- a/tests/unit/out/refcount/fn_ptr_global.rs
+++ b/tests/unit/out/refcount/fn_ptr_global.rs
@@ -1,0 +1,86 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn double_it_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    return ((*x.borrow()) * 2);
+}
+pub fn triple_it_1(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    return ((*x.borrow()) * 3);
+}
+thread_local!(
+    pub static g_op: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::null()));
+);
+pub fn set_op_2(fn_: FnPtr<fn(i32) -> i32>) {
+    let fn_: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(fn_));
+    (*g_op.with(Value::clone).borrow_mut()) = (*fn_.borrow()).clone();
+}
+pub fn call_op_3(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    if !(*g_op.with(Value::clone).borrow()).is_null() {
+        return ({
+            let _arg0: i32 = (*x.borrow());
+            (*(*g_op.with(Value::clone).borrow()))(_arg0)
+        });
+    }
+    return (*x.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = 5;
+            call_op_3(_x)
+        }) == 5)
+    );
+    ({
+        let _fn: FnPtr<fn(i32) -> i32> = fn_ptr!(double_it_0, fn(i32) -> i32);
+        set_op_2(_fn)
+    });
+    assert!(!((*g_op.with(Value::clone).borrow()).is_null()));
+    assert!({
+        let _lhs = (*g_op.with(Value::clone).borrow()).clone();
+        _lhs == fn_ptr!(double_it_0, fn(i32) -> i32)
+    });
+    assert!(
+        (({
+            let _x: i32 = 5;
+            call_op_3(_x)
+        }) == 10)
+    );
+    ({
+        let _fn: FnPtr<fn(i32) -> i32> = fn_ptr!(triple_it_1, fn(i32) -> i32);
+        set_op_2(_fn)
+    });
+    assert!({
+        let _lhs = (*g_op.with(Value::clone).borrow()).clone();
+        _lhs == fn_ptr!(triple_it_1, fn(i32) -> i32)
+    });
+    assert!(
+        (({
+            let _x: i32 = 5;
+            call_op_3(_x)
+        }) == 15)
+    );
+    ({
+        let _fn: FnPtr<fn(i32) -> i32> = FnPtr::null();
+        set_op_2(_fn)
+    });
+    assert!((*g_op.with(Value::clone).borrow()).is_null());
+    assert!(
+        (({
+            let _x: i32 = 5;
+            call_op_3(_x)
+        }) == 5)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/fn_ptr_global.rs
+++ b/tests/unit/out/refcount/fn_ptr_global.rs
@@ -43,13 +43,13 @@ fn main_0() -> i32 {
         }) == 5)
     );
     ({
-        let _fn: FnPtr<fn(i32) -> i32> = fn_ptr!(double_it_0, fn(i32) -> i32);
+        let _fn: FnPtr<fn(i32) -> i32> = FnPtr::<fn(i32) -> i32>::new(double_it_0);
         set_op_2(_fn)
     });
     assert!(!((*g_op.with(Value::clone).borrow()).is_null()));
     assert!({
         let _lhs = (*g_op.with(Value::clone).borrow()).clone();
-        _lhs == fn_ptr!(double_it_0, fn(i32) -> i32)
+        _lhs == FnPtr::<fn(i32) -> i32>::new(double_it_0)
     });
     assert!(
         (({
@@ -58,12 +58,12 @@ fn main_0() -> i32 {
         }) == 10)
     );
     ({
-        let _fn: FnPtr<fn(i32) -> i32> = fn_ptr!(triple_it_1, fn(i32) -> i32);
+        let _fn: FnPtr<fn(i32) -> i32> = FnPtr::<fn(i32) -> i32>::new(triple_it_1);
         set_op_2(_fn)
     });
     assert!({
         let _lhs = (*g_op.with(Value::clone).borrow()).clone();
-        _lhs == fn_ptr!(triple_it_1, fn(i32) -> i32)
+        _lhs == FnPtr::<fn(i32) -> i32>::new(triple_it_1)
     });
     assert!(
         (({

--- a/tests/unit/out/refcount/fn_ptr_reassign.rs
+++ b/tests/unit/out/refcount/fn_ptr_reassign.rs
@@ -27,7 +27,7 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let fn_: Value<FnPtr<fn(i32, i32) -> i32>> =
-        Rc::new(RefCell::new(fn_ptr!(add_0, fn(i32, i32) -> i32)));
+        Rc::new(RefCell::new(FnPtr::<fn(i32, i32) -> i32>::new(add_0)));
     assert!(
         (({
             let _arg0: i32 = 3;
@@ -35,7 +35,7 @@ fn main_0() -> i32 {
             (*(*fn_.borrow()))(_arg0, _arg1)
         }) == 7)
     );
-    (*fn_.borrow_mut()) = fn_ptr!(sub_1, fn(i32, i32) -> i32);
+    (*fn_.borrow_mut()) = FnPtr::<fn(i32, i32) -> i32>::new(sub_1);
     assert!(
         (({
             let _arg0: i32 = 10;
@@ -43,7 +43,7 @@ fn main_0() -> i32 {
             (*(*fn_.borrow()))(_arg0, _arg1)
         }) == 7)
     );
-    (*fn_.borrow_mut()) = fn_ptr!(mul_2, fn(i32, i32) -> i32);
+    (*fn_.borrow_mut()) = FnPtr::<fn(i32, i32) -> i32>::new(mul_2);
     assert!(
         (({
             let _arg0: i32 = 6;
@@ -53,7 +53,7 @@ fn main_0() -> i32 {
     );
     (*fn_.borrow_mut()) = FnPtr::null();
     assert!((*fn_.borrow()).is_null());
-    (*fn_.borrow_mut()) = fn_ptr!(add_0, fn(i32, i32) -> i32);
+    (*fn_.borrow_mut()) = FnPtr::<fn(i32, i32) -> i32>::new(add_0);
     assert!(!((*fn_.borrow()).is_null()));
     assert!(
         (({

--- a/tests/unit/out/refcount/fn_ptr_reassign.rs
+++ b/tests/unit/out/refcount/fn_ptr_reassign.rs
@@ -1,0 +1,66 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn add_0(a: i32, b: i32) -> i32 {
+    let a: Value<i32> = Rc::new(RefCell::new(a));
+    let b: Value<i32> = Rc::new(RefCell::new(b));
+    return ((*a.borrow()) + (*b.borrow()));
+}
+pub fn sub_1(a: i32, b: i32) -> i32 {
+    let a: Value<i32> = Rc::new(RefCell::new(a));
+    let b: Value<i32> = Rc::new(RefCell::new(b));
+    return ((*a.borrow()) - (*b.borrow()));
+}
+pub fn mul_2(a: i32, b: i32) -> i32 {
+    let a: Value<i32> = Rc::new(RefCell::new(a));
+    let b: Value<i32> = Rc::new(RefCell::new(b));
+    return ((*a.borrow()) * (*b.borrow()));
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let fn_: Value<FnPtr<fn(i32, i32) -> i32>> =
+        Rc::new(RefCell::new(fn_ptr!(add_0, fn(i32, i32) -> i32)));
+    assert!(
+        (({
+            let _arg0: i32 = 3;
+            let _arg1: i32 = 4;
+            (*(*fn_.borrow()))(_arg0, _arg1)
+        }) == 7)
+    );
+    (*fn_.borrow_mut()) = fn_ptr!(sub_1, fn(i32, i32) -> i32);
+    assert!(
+        (({
+            let _arg0: i32 = 10;
+            let _arg1: i32 = 3;
+            (*(*fn_.borrow()))(_arg0, _arg1)
+        }) == 7)
+    );
+    (*fn_.borrow_mut()) = fn_ptr!(mul_2, fn(i32, i32) -> i32);
+    assert!(
+        (({
+            let _arg0: i32 = 6;
+            let _arg1: i32 = 7;
+            (*(*fn_.borrow()))(_arg0, _arg1)
+        }) == 42)
+    );
+    (*fn_.borrow_mut()) = FnPtr::null();
+    assert!((*fn_.borrow()).is_null());
+    (*fn_.borrow_mut()) = fn_ptr!(add_0, fn(i32, i32) -> i32);
+    assert!(!((*fn_.borrow()).is_null()));
+    assert!(
+        (({
+            let _arg0: i32 = 1;
+            let _arg1: i32 = 1;
+            (*(*fn_.borrow()))(_arg0, _arg1)
+        }) == 2)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/fn_ptr_return.rs
+++ b/tests/unit/out/refcount/fn_ptr_return.rs
@@ -1,0 +1,67 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn inc_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    return ((*x.borrow()) + 1);
+}
+pub fn dec_1(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    return ((*x.borrow()) - 1);
+}
+pub fn pick_2(choose_inc: i32) -> FnPtr<fn(i32) -> i32> {
+    let choose_inc: Value<i32> = Rc::new(RefCell::new(choose_inc));
+    if ((*choose_inc.borrow()) != 0) {
+        return fn_ptr!(inc_0, fn(i32) -> i32);
+    }
+    return fn_ptr!(dec_1, fn(i32) -> i32);
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let f: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(
+        ({
+            let _choose_inc: i32 = 1;
+            pick_2(_choose_inc)
+        }),
+    ));
+    assert!(!((*f.borrow()).is_null()));
+    assert!({
+        let _lhs = (*f.borrow()).clone();
+        _lhs == fn_ptr!(inc_0, fn(i32) -> i32)
+    });
+    assert!(
+        (({
+            let _arg0: i32 = 10;
+            (*(*f.borrow()))(_arg0)
+        }) == 11)
+    );
+    let g: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(
+        ({
+            let _choose_inc: i32 = 0;
+            pick_2(_choose_inc)
+        }),
+    ));
+    assert!({
+        let _lhs = (*g.borrow()).clone();
+        _lhs == fn_ptr!(dec_1, fn(i32) -> i32)
+    });
+    assert!(
+        (({
+            let _arg0: i32 = 10;
+            (*(*g.borrow()))(_arg0)
+        }) == 9)
+    );
+    assert!({
+        let _lhs = (*f.borrow()).clone();
+        _lhs != (*g.borrow()).clone()
+    });
+    return 0;
+}

--- a/tests/unit/out/refcount/fn_ptr_return.rs
+++ b/tests/unit/out/refcount/fn_ptr_return.rs
@@ -18,9 +18,9 @@ pub fn dec_1(x: i32) -> i32 {
 pub fn pick_2(choose_inc: i32) -> FnPtr<fn(i32) -> i32> {
     let choose_inc: Value<i32> = Rc::new(RefCell::new(choose_inc));
     if ((*choose_inc.borrow()) != 0) {
-        return fn_ptr!(inc_0, fn(i32) -> i32);
+        return FnPtr::<fn(i32) -> i32>::new(inc_0);
     }
-    return fn_ptr!(dec_1, fn(i32) -> i32);
+    return FnPtr::<fn(i32) -> i32>::new(dec_1);
 }
 pub fn main() {
     std::process::exit(main_0());
@@ -35,7 +35,7 @@ fn main_0() -> i32 {
     assert!(!((*f.borrow()).is_null()));
     assert!({
         let _lhs = (*f.borrow()).clone();
-        _lhs == fn_ptr!(inc_0, fn(i32) -> i32)
+        _lhs == FnPtr::<fn(i32) -> i32>::new(inc_0)
     });
     assert!(
         (({
@@ -51,7 +51,7 @@ fn main_0() -> i32 {
     ));
     assert!({
         let _lhs = (*g.borrow()).clone();
-        _lhs == fn_ptr!(dec_1, fn(i32) -> i32)
+        _lhs == FnPtr::<fn(i32) -> i32>::new(dec_1)
     });
     assert!(
         (({

--- a/tests/unit/out/refcount/fn_ptr_stable_sort.rs
+++ b/tests/unit/out/refcount/fn_ptr_stable_sort.rs
@@ -1,0 +1,80 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+#[derive(Default)]
+pub struct Item {
+    pub key: Value<i32>,
+    pub value: Value<i32>,
+}
+impl Clone for Item {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            key: Rc::new(RefCell::new((*self.key.borrow()))),
+            value: Rc::new(RefCell::new((*self.value.borrow()))),
+        };
+        this
+    }
+}
+impl ByteRepr for Item {}
+pub fn Compare_0(a: Ptr<Item>, b: Ptr<Item>) -> bool {
+    return {
+        let _lhs = (*(*a.upgrade().deref()).key.borrow());
+        _lhs < (*(*b.upgrade().deref()).key.borrow())
+    };
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let v: Value<Vec<Item>> = Rc::new(RefCell::new(Vec::new()));
+    (*v.borrow_mut()).push(Item {
+        key: Rc::new(RefCell::new(3)),
+        value: Rc::new(RefCell::new(30)),
+    });
+    (*v.borrow_mut()).push(Item {
+        key: Rc::new(RefCell::new(1)),
+        value: Rc::new(RefCell::new(10)),
+    });
+    (*v.borrow_mut()).push(Item {
+        key: Rc::new(RefCell::new(2)),
+        value: Rc::new(RefCell::new(20)),
+    });
+    (v.as_pointer() as Ptr<Item>).sort_with_cmp(
+        (v.as_pointer() as Ptr<Item>).to_end().get_offset(),
+        Compare_0,
+    );
+    assert!(
+        ((*(*(v.as_pointer() as Ptr<Item>)
+            .offset(0_u64 as isize)
+            .upgrade()
+            .deref())
+        .key
+        .borrow())
+            == 1)
+    );
+    assert!(
+        ((*(*(v.as_pointer() as Ptr<Item>)
+            .offset(1_u64 as isize)
+            .upgrade()
+            .deref())
+        .key
+        .borrow())
+            == 2)
+    );
+    assert!(
+        ((*(*(v.as_pointer() as Ptr<Item>)
+            .offset(2_u64 as isize)
+            .upgrade()
+            .deref())
+        .key
+        .borrow())
+            == 3)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/fn_ptr_struct.rs
+++ b/tests/unit/out/refcount/fn_ptr_struct.rs
@@ -44,11 +44,11 @@ pub fn main() {
 fn main_0() -> i32 {
     let h1: Value<Handler> = Rc::new(RefCell::new(Handler {
         tag: Rc::new(RefCell::new(1)),
-        cb: Rc::new(RefCell::new(fn_ptr!(double_it_0, fn(i32) -> i32))),
+        cb: Rc::new(RefCell::new(FnPtr::<fn(i32) -> i32>::new(double_it_0))),
     }));
     let h2: Value<Handler> = Rc::new(RefCell::new(Handler {
         tag: Rc::new(RefCell::new(2)),
-        cb: Rc::new(RefCell::new(fn_ptr!(negate_1, fn(i32) -> i32))),
+        cb: Rc::new(RefCell::new(FnPtr::<fn(i32) -> i32>::new(negate_1))),
     }));
     assert!(!((*(*h1.borrow()).cb.borrow()).is_null()));
     assert!(
@@ -63,7 +63,7 @@ fn main_0() -> i32 {
             (*(*(*h2.borrow()).cb.borrow()))(_arg0)
         }) == -7_i32)
     );
-    (*(*h1.borrow()).cb.borrow_mut()) = fn_ptr!(negate_1, fn(i32) -> i32);
+    (*(*h1.borrow()).cb.borrow_mut()) = FnPtr::<fn(i32) -> i32>::new(negate_1);
     assert!(
         (({
             let _arg0: i32 = 3;

--- a/tests/unit/out/refcount/fn_ptr_struct.rs
+++ b/tests/unit/out/refcount/fn_ptr_struct.rs
@@ -1,0 +1,78 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+#[derive()]
+pub struct Handler {
+    pub tag: Value<i32>,
+    pub cb: Value<FnPtr<fn(i32) -> i32>>,
+}
+impl Clone for Handler {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            tag: Rc::new(RefCell::new((*self.tag.borrow()))),
+            cb: Rc::new(RefCell::new((*self.cb.borrow()).clone())),
+        };
+        this
+    }
+}
+impl Default for Handler {
+    fn default() -> Self {
+        Handler {
+            tag: <Value<i32>>::default(),
+            cb: Rc::new(RefCell::new(FnPtr::null())),
+        }
+    }
+}
+impl ByteRepr for Handler {}
+pub fn double_it_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    return ((*x.borrow()) * 2);
+}
+pub fn negate_1(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    return -(*x.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let h1: Value<Handler> = Rc::new(RefCell::new(Handler {
+        tag: Rc::new(RefCell::new(1)),
+        cb: Rc::new(RefCell::new(fn_ptr!(double_it_0, fn(i32) -> i32))),
+    }));
+    let h2: Value<Handler> = Rc::new(RefCell::new(Handler {
+        tag: Rc::new(RefCell::new(2)),
+        cb: Rc::new(RefCell::new(fn_ptr!(negate_1, fn(i32) -> i32))),
+    }));
+    assert!(!((*(*h1.borrow()).cb.borrow()).is_null()));
+    assert!(
+        (({
+            let _arg0: i32 = 5;
+            (*(*(*h1.borrow()).cb.borrow()))(_arg0)
+        }) == 10)
+    );
+    assert!(
+        (({
+            let _arg0: i32 = 7;
+            (*(*(*h2.borrow()).cb.borrow()))(_arg0)
+        }) == -7_i32)
+    );
+    (*(*h1.borrow()).cb.borrow_mut()) = fn_ptr!(negate_1, fn(i32) -> i32);
+    assert!(
+        (({
+            let _arg0: i32 = 3;
+            (*(*(*h1.borrow()).cb.borrow()))(_arg0)
+        }) == -3_i32)
+    );
+    assert!({
+        let _lhs = (*(*h1.borrow()).cb.borrow()).clone();
+        _lhs == (*(*h2.borrow()).cb.borrow()).clone()
+    });
+    return 0;
+}

--- a/tests/unit/out/refcount/fn_ptr_void_return.rs
+++ b/tests/unit/out/refcount/fn_ptr_void_return.rs
@@ -1,0 +1,53 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn negate_0(x: Ptr<i32>) {
+    let x: Value<Ptr<i32>> = Rc::new(RefCell::new(x));
+    let __rhs = -((*x.borrow()).read());
+    (*x.borrow()).write(__rhs);
+}
+pub fn zero_out_1(x: Ptr<i32>) {
+    let x: Value<Ptr<i32>> = Rc::new(RefCell::new(x));
+    (*x.borrow()).write(0);
+}
+pub fn run_2(fn_: FnPtr<fn(Ptr<i32>)>, x: Ptr<i32>) {
+    let fn_: Value<FnPtr<fn(Ptr<i32>)>> = Rc::new(RefCell::new(fn_));
+    let x: Value<Ptr<i32>> = Rc::new(RefCell::new(x));
+    ({
+        let _arg0: Ptr<i32> = (*x.borrow()).clone();
+        (*(*fn_.borrow()))(_arg0)
+    });
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let a: Value<i32> = Rc::new(RefCell::new(42));
+    ({
+        let _fn: FnPtr<fn(Ptr<i32>)> = fn_ptr!(negate_0, fn(Ptr::<i32>));
+        let _x: Ptr<i32> = (a.as_pointer());
+        run_2(_fn, _x)
+    });
+    assert!(((*a.borrow()) == -42_i32));
+    ({
+        let _fn: FnPtr<fn(Ptr<i32>)> = fn_ptr!(zero_out_1, fn(Ptr::<i32>));
+        let _x: Ptr<i32> = (a.as_pointer());
+        run_2(_fn, _x)
+    });
+    assert!(((*a.borrow()) == 0));
+    let fn_: Value<FnPtr<fn(Ptr<i32>)>> = Rc::new(RefCell::new(fn_ptr!(negate_0, fn(Ptr::<i32>))));
+    assert!(!((*fn_.borrow()).is_null()));
+    let b: Value<i32> = Rc::new(RefCell::new(10));
+    ({
+        let _arg0: Ptr<i32> = (b.as_pointer());
+        (*(*fn_.borrow()))(_arg0)
+    });
+    assert!(((*b.borrow()) == -10_i32));
+    return 0;
+}

--- a/tests/unit/out/refcount/fn_ptr_void_return.rs
+++ b/tests/unit/out/refcount/fn_ptr_void_return.rs
@@ -30,18 +30,19 @@ pub fn main() {
 fn main_0() -> i32 {
     let a: Value<i32> = Rc::new(RefCell::new(42));
     ({
-        let _fn: FnPtr<fn(Ptr<i32>)> = fn_ptr!(negate_0, fn(Ptr::<i32>));
+        let _fn: FnPtr<fn(Ptr<i32>)> = FnPtr::<fn(Ptr<i32>)>::new(negate_0);
         let _x: Ptr<i32> = (a.as_pointer());
         run_2(_fn, _x)
     });
     assert!(((*a.borrow()) == -42_i32));
     ({
-        let _fn: FnPtr<fn(Ptr<i32>)> = fn_ptr!(zero_out_1, fn(Ptr::<i32>));
+        let _fn: FnPtr<fn(Ptr<i32>)> = FnPtr::<fn(Ptr<i32>)>::new(zero_out_1);
         let _x: Ptr<i32> = (a.as_pointer());
         run_2(_fn, _x)
     });
     assert!(((*a.borrow()) == 0));
-    let fn_: Value<FnPtr<fn(Ptr<i32>)>> = Rc::new(RefCell::new(fn_ptr!(negate_0, fn(Ptr::<i32>))));
+    let fn_: Value<FnPtr<fn(Ptr<i32>)>> =
+        Rc::new(RefCell::new(FnPtr::<fn(Ptr<i32>)>::new(negate_0)));
     assert!(!((*fn_.borrow()).is_null()));
     let b: Value<i32> = Rc::new(RefCell::new(10));
     ({

--- a/tests/unit/out/refcount/fn_ptr_vtable.rs
+++ b/tests/unit/out/refcount/fn_ptr_vtable.rs
@@ -1,0 +1,86 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+#[derive()]
+pub struct Vtable {
+    pub create: Value<FnPtr<fn(i32) -> AnyPtr>>,
+    pub get: Value<FnPtr<fn(AnyPtr) -> i32>>,
+    pub destroy: Value<FnPtr<fn(AnyPtr)>>,
+}
+impl Clone for Vtable {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            create: Rc::new(RefCell::new((*self.create.borrow()).clone())),
+            get: Rc::new(RefCell::new((*self.get.borrow()).clone())),
+            destroy: Rc::new(RefCell::new((*self.destroy.borrow()).clone())),
+        };
+        this
+    }
+}
+impl Default for Vtable {
+    fn default() -> Self {
+        Vtable {
+            create: Rc::new(RefCell::new(FnPtr::null())),
+            get: Rc::new(RefCell::new(FnPtr::null())),
+            destroy: Rc::new(RefCell::new(FnPtr::null())),
+        }
+    }
+}
+impl ByteRepr for Vtable {}
+thread_local!(
+    pub static storage: Value<i32> = <Value<i32>>::default();
+);
+pub fn int_create_0(val: i32) -> AnyPtr {
+    let val: Value<i32> = Rc::new(RefCell::new(val));
+    (*storage.with(Value::clone).borrow_mut()) = (*val.borrow());
+    return ((storage.with(Value::clone).as_pointer()) as Ptr<i32>).to_any();
+}
+pub fn int_get_1(p: AnyPtr) -> i32 {
+    let p: Value<AnyPtr> = Rc::new(RefCell::new(p));
+    return ((*p.borrow()).cast::<i32>().expect("ub:wrong type").read());
+}
+pub fn int_destroy_2(p: AnyPtr) {
+    let p: Value<AnyPtr> = Rc::new(RefCell::new(p));
+    (*p.borrow()).cast::<i32>().expect("ub:wrong type").write(0);
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let vt: Value<Vtable> = Rc::new(RefCell::new(Vtable {
+        create: Rc::new(RefCell::new(
+            (fn_ptr!(int_create_0, fn(i32) -> AnyPtr)).clone(),
+        )),
+        get: Rc::new(RefCell::new(fn_ptr!(int_get_1, fn(AnyPtr) -> i32))),
+        destroy: Rc::new(RefCell::new(fn_ptr!(int_destroy_2, fn(AnyPtr)))),
+    }));
+    assert!(!((*(*vt.borrow()).create.borrow()).is_null()));
+    assert!(!((*(*vt.borrow()).get.borrow()).is_null()));
+    assert!(!((*(*vt.borrow()).destroy.borrow()).is_null()));
+    let obj: Value<AnyPtr> = Rc::new(RefCell::new(
+        ({
+            let _arg0: i32 = 42;
+            (*(*(*vt.borrow()).create.borrow()))(_arg0)
+        }),
+    ));
+    assert!(
+        (({
+            let _arg0: AnyPtr = (*obj.borrow()).clone();
+            (*(*(*vt.borrow()).get.borrow()))(_arg0)
+        }) == 42)
+    );
+    ({
+        let _arg0: AnyPtr = (*obj.borrow()).clone();
+        (*(*(*vt.borrow()).destroy.borrow()))(_arg0)
+    });
+    assert!(((*storage.with(Value::clone).borrow()) == 0));
+    (*(*vt.borrow()).get.borrow_mut()) = FnPtr::null();
+    assert!((*(*vt.borrow()).get.borrow()).is_null());
+    return 0;
+}

--- a/tests/unit/out/refcount/fn_ptr_vtable.rs
+++ b/tests/unit/out/refcount/fn_ptr_vtable.rs
@@ -55,10 +55,10 @@ pub fn main() {
 fn main_0() -> i32 {
     let vt: Value<Vtable> = Rc::new(RefCell::new(Vtable {
         create: Rc::new(RefCell::new(
-            (fn_ptr!(int_create_0, fn(i32) -> AnyPtr)).clone(),
+            (FnPtr::<fn(i32) -> AnyPtr>::new(int_create_0)).clone(),
         )),
-        get: Rc::new(RefCell::new(fn_ptr!(int_get_1, fn(AnyPtr) -> i32))),
-        destroy: Rc::new(RefCell::new(fn_ptr!(int_destroy_2, fn(AnyPtr)))),
+        get: Rc::new(RefCell::new(FnPtr::<fn(AnyPtr) -> i32>::new(int_get_1))),
+        destroy: Rc::new(RefCell::new(FnPtr::<fn(AnyPtr)>::new(int_destroy_2))),
     }));
     assert!(!((*(*vt.borrow()).create.borrow()).is_null()));
     assert!(!((*(*vt.borrow()).get.borrow()).is_null()));

--- a/tests/unit/out/refcount/lambda_capture_pass.rs
+++ b/tests/unit/out/refcount/lambda_capture_pass.rs
@@ -12,7 +12,7 @@ pub fn apply_0(fn_: impl Fn(i32) -> i32, x: i32) -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(x));
     return ({
         let _x: i32 = (*x.borrow());
-        (*fn_.borrow())(_x)
+        (*fn_.borrow_mut())(_x)
     })
     .clone();
 }
@@ -21,7 +21,7 @@ pub fn apply_1(fn_: impl Fn(i32) -> i32, x: i32) -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(x));
     return ({
         let _x: i32 = (*x.borrow());
-        (*fn_.borrow())(_x)
+        (*fn_.borrow_mut())(_x)
     })
     .clone();
 }

--- a/tests/unit/out/refcount/lambda_capture_pass.rs
+++ b/tests/unit/out/refcount/lambda_capture_pass.rs
@@ -1,0 +1,69 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn apply_0(fn_: impl Fn(i32) -> i32, x: i32) -> i32 {
+    let fn_: Value<_> = Rc::new(RefCell::new(fn_));
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    return ({
+        let _x: i32 = (*x.borrow());
+        (*fn_.borrow())(_x)
+    })
+    .clone();
+}
+pub fn apply_1(fn_: impl Fn(i32) -> i32, x: i32) -> i32 {
+    let fn_: Value<_> = Rc::new(RefCell::new(fn_));
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    return ({
+        let _x: i32 = (*x.borrow());
+        (*fn_.borrow())(_x)
+    })
+    .clone();
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let base: Value<i32> = Rc::new(RefCell::new(10));
+    let add_base: Value<_> = Rc::new(RefCell::new(
+        (|x: i32| {
+            let x: Value<i32> = Rc::new(RefCell::new(x));
+            return ((*x.borrow()) + (*base.borrow()));
+        }),
+    ));
+    assert!(
+        (({
+            let _fn: _ = (*add_base.borrow()).clone();
+            let _x: i32 = 5;
+            apply_0(_fn, _x)
+        }) == 15)
+    );
+    (*base.borrow_mut()) = 100;
+    assert!(
+        (({
+            let _fn: _ = (*add_base.borrow()).clone();
+            let _x: i32 = 5;
+            apply_0(_fn, _x)
+        }) == 105)
+    );
+    let factor: Value<i32> = Rc::new(RefCell::new(3));
+    let scale: Value<_> = Rc::new(RefCell::new(
+        (|x: i32| {
+            let x: Value<i32> = Rc::new(RefCell::new(x));
+            return ((*x.borrow()) * (*factor.borrow()));
+        }),
+    ));
+    assert!(
+        (({
+            let _fn: _ = (*scale.borrow()).clone();
+            let _x: i32 = 4;
+            apply_1(_fn, _x)
+        }) == 12)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/lambda_nested.rs
+++ b/tests/unit/out/refcount/lambda_nested.rs
@@ -1,0 +1,45 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(10));
+    let outer: Value<_> = Rc::new(RefCell::new(
+        (|y: i32| {
+            let y: Value<i32> = Rc::new(RefCell::new(y));
+            let inner: Value<_> = Rc::new(RefCell::new(
+                (|z: i32| {
+                    let z: Value<i32> = Rc::new(RefCell::new(z));
+                    return (((*x.borrow()) + (*y.borrow())) + (*z.borrow()));
+                }),
+            ));
+            return ({
+                let _z: i32 = 1;
+                (*inner.borrow())(_z)
+            })
+            .clone();
+        }),
+    ));
+    assert!(
+        (({
+            let _y: i32 = 20;
+            (*outer.borrow())(_y)
+        }) == 31)
+    );
+    (*x.borrow_mut()) = 100;
+    assert!(
+        (({
+            let _y: i32 = 20;
+            (*outer.borrow())(_y)
+        }) == 121)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/lambda_nested.rs
+++ b/tests/unit/out/refcount/lambda_nested.rs
@@ -23,7 +23,7 @@ fn main_0() -> i32 {
             ));
             return ({
                 let _z: i32 = 1;
-                (*inner.borrow())(_z)
+                (*inner.borrow_mut())(_z)
             })
             .clone();
         }),
@@ -31,14 +31,14 @@ fn main_0() -> i32 {
     assert!(
         (({
             let _y: i32 = 20;
-            (*outer.borrow())(_y)
+            (*outer.borrow_mut())(_y)
         }) == 31)
     );
     (*x.borrow_mut()) = 100;
     assert!(
         (({
             let _y: i32 = 20;
-            (*outer.borrow())(_y)
+            (*outer.borrow_mut())(_y)
         }) == 121)
     );
     return 0;

--- a/tests/unit/out/refcount/no_direct_callee.rs
+++ b/tests/unit/out/refcount/no_direct_callee.rs
@@ -10,9 +10,9 @@ use std::rc::{Rc, Weak};
 pub fn test1_0() -> bool {
     return false;
 }
-pub fn test_1(fn_: Rc<dyn Fn() -> bool>) -> i32 {
-    let fn_: Value<Rc<dyn Fn() -> bool>> = Rc::new(RefCell::new(fn_));
-    if !({ (*fn_.borrow())() }) {
+pub fn test_1(fn_: FnPtr<fn() -> bool>) -> i32 {
+    let fn_: Value<FnPtr<fn() -> bool>> = Rc::new(RefCell::new(fn_));
+    if !({ (*(*fn_.borrow()))() }) {
         return 1;
     }
     return 0;
@@ -22,7 +22,7 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     return ({
-        let _fn: Rc<dyn Fn() -> bool> = Rc::new(test1_0);
+        let _fn: FnPtr<fn() -> bool> = fn_ptr!(test1_0, fn() -> bool);
         test_1(_fn)
     });
 }

--- a/tests/unit/out/refcount/no_direct_callee.rs
+++ b/tests/unit/out/refcount/no_direct_callee.rs
@@ -22,7 +22,7 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     return ({
-        let _fn: FnPtr<fn() -> bool> = fn_ptr!(test1_0, fn() -> bool);
+        let _fn: FnPtr<fn() -> bool> = FnPtr::<fn() -> bool>::new(test1_0);
         test_1(_fn)
     });
 }

--- a/tests/unit/out/refcount/printfs.rs
+++ b/tests/unit/out/refcount/printfs.rs
@@ -44,7 +44,7 @@ fn main_0() -> i32 {
                     .to_c_string_iterator()
                     .chain(std::iter::once(0))
                     .collect::<Vec<u8>>();
-                Rc::new(fn_0)(_v)
+                fn_0(_v)
             })
         ))
         .as_pointer() as Ptr<u8>)
@@ -53,7 +53,7 @@ fn main_0() -> i32 {
         "{}",
         (({
             let _v: Ptr<Vec<u8>> = s.as_pointer();
-            Rc::new(fn2_1)(_v)
+            fn2_1(_v)
         })
         .to_strong()
         .as_pointer() as Ptr<u8>)

--- a/tests/unit/out/refcount/prvalue-as-lvalue.rs
+++ b/tests/unit/out/refcount/prvalue-as-lvalue.rs
@@ -18,7 +18,7 @@ fn main_0() -> i32 {
     let pa: Value<Ptr<i32>> = Rc::new(RefCell::new((a.as_pointer())));
     let b: Ptr<i32> = ({
         let _a: Ptr<i32> = (*pa.borrow()).clone();
-        Rc::new(foo_0)(_a)
+        foo_0(_a)
     });
     return (b.read());
 }

--- a/tests/unit/out/refcount/ref_calls.rs
+++ b/tests/unit/out/refcount/ref_calls.rs
@@ -27,7 +27,7 @@ fn main_0() -> i32 {
     ));
     let z: Ptr<i32> = ({
         let _x: Ptr<i32> = x.as_pointer();
-        Rc::new(foo_1)(_x)
+        foo_1(_x)
     });
     return {
         let _lhs = {

--- a/tests/unit/out/unsafe/complex_function.rs
+++ b/tests/unit/out/unsafe/complex_function.rs
@@ -90,11 +90,11 @@ unsafe fn main_0() -> i32 {
     let r1: *mut i32 = &mut x1 as *mut i32;
     let r2: *mut i32 = (unsafe {
         let _x: *mut i32 = &mut x1 as *mut i32;
-        Rc::new(|a0| unsafe { bar_2(a0) })(_x)
+        bar_2(_x)
     });
     let r3: *mut i32 = (unsafe {
         let _x: *mut i32 = r1;
-        Rc::new(|a0| unsafe { bar_2(a0) })(_x)
+        bar_2(_x)
     });
     (*r2) += x1;
     (*r3) += (*r1);
@@ -230,12 +230,12 @@ unsafe fn main_0() -> i32 {
     let mut pref: *mut i32 = (unsafe {
         let _x: *mut i32 =
             &mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v as *mut i32;
-        Rc::new(|a0| unsafe { bar_2(a0) })(_x)
+        bar_2(_x)
     });
     (*(unsafe {
         let _x: *mut i32 =
             &mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v as *mut i32;
-        Rc::new(|a0| unsafe { bar_2(a0) })(_x)
+        bar_2(_x)
     }))
     .postfix_inc();
     return (((*(unsafe {

--- a/tests/unit/out/unsafe/fn_ptr.rs
+++ b/tests/unit/out/unsafe/fn_ptr.rs
@@ -1,0 +1,43 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn my_foo_0(mut p: *mut ::libc::c_void) -> i32 {
+    return (*(p as *mut i32));
+}
+pub unsafe fn foo_1(
+    mut fn_: Option<unsafe fn(*mut ::libc::c_void) -> i32>,
+    mut pi: *mut i32,
+) -> i32 {
+    return (unsafe {
+        let _arg0: *mut ::libc::c_void = (pi as *mut i32 as *mut ::libc::c_void);
+        (fn_).unwrap()(_arg0)
+    });
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut fn_: Option<unsafe fn(*mut ::libc::c_void) -> i32> = None;
+    assert!((fn_).is_none());
+    assert!(((fn_) != (Some(my_foo_0))));
+    fn_ = Some(my_foo_0);
+    assert!(!((fn_).is_none()));
+    assert!(((fn_) == (Some(my_foo_0))));
+    let mut a: i32 = 10;
+    assert!(
+        ((unsafe {
+            let _fn: Option<unsafe fn(*mut ::libc::c_void) -> i32> = fn_;
+            let _pi: *mut i32 = (&mut a as *mut i32);
+            foo_1(_fn, _pi)
+        }) == (a))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/fn_ptr_array.rs
+++ b/tests/unit/out/unsafe/fn_ptr_array.rs
@@ -1,0 +1,51 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn add_0(mut a: i32, mut b: i32) -> i32 {
+    return ((a) + (b));
+}
+pub unsafe fn sub_1(mut a: i32, mut b: i32) -> i32 {
+    return ((a) - (b));
+}
+pub unsafe fn mul_2(mut a: i32, mut b: i32) -> i32 {
+    return ((a) * (b));
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut ops: [Option<unsafe fn(i32, i32) -> i32>; 3] = [Some(add_0), Some(sub_1), Some(mul_2)];
+    assert!(
+        ((unsafe {
+            let _arg0: i32 = 2;
+            let _arg1: i32 = 3;
+            (ops[(0) as usize]).unwrap()(_arg0, _arg1)
+        }) == (5))
+    );
+    assert!(
+        ((unsafe {
+            let _arg0: i32 = 7;
+            let _arg1: i32 = 4;
+            (ops[(1) as usize]).unwrap()(_arg0, _arg1)
+        }) == (3))
+    );
+    assert!(
+        ((unsafe {
+            let _arg0: i32 = 6;
+            let _arg1: i32 = 5;
+            (ops[(2) as usize]).unwrap()(_arg0, _arg1)
+        }) == (30))
+    );
+    assert!(!((ops[(0) as usize]).is_none()));
+    assert!(((ops[(0) as usize]) == (Some(add_0))));
+    assert!(((ops[(0) as usize]) != (Some(sub_1))));
+    return 0;
+}

--- a/tests/unit/out/unsafe/fn_ptr_as_condition.rs
+++ b/tests/unit/out/unsafe/fn_ptr_as_condition.rs
@@ -1,0 +1,54 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn double_it_0(mut x: *mut i32) {
+    (*x) *= 2;
+}
+pub unsafe fn maybe_call_1(mut cb: Option<unsafe fn(*mut i32)>, mut x: *mut i32) {
+    if !(cb).is_none() {
+        (unsafe {
+            let _arg0: *mut i32 = x;
+            (cb).unwrap()(_arg0)
+        });
+    }
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut a: i32 = 5;
+    (unsafe {
+        let _cb: Option<unsafe fn(*mut i32)> = Some(double_it_0);
+        let _x: *mut i32 = (&mut a as *mut i32);
+        maybe_call_1(_cb, _x)
+    });
+    assert!(((a) == (10)));
+    let mut b: i32 = 5;
+    (unsafe {
+        let _cb: Option<unsafe fn(*mut i32)> = None;
+        let _x: *mut i32 = (&mut b as *mut i32);
+        maybe_call_1(_cb, _x)
+    });
+    assert!(((b) == (5)));
+    let mut fn_: Option<unsafe fn(*mut i32)> = None;
+    if !!(fn_).is_none() {
+        fn_ = Some(double_it_0);
+    }
+    let mut c: i32 = 3;
+    if !(fn_).is_none() {
+        (unsafe {
+            let _arg0: *mut i32 = (&mut c as *mut i32);
+            (fn_).unwrap()(_arg0)
+        });
+    }
+    assert!(((c) == (6)));
+    return 0;
+}

--- a/tests/unit/out/unsafe/fn_ptr_cast.rs
+++ b/tests/unit/out/unsafe/fn_ptr_cast.rs
@@ -1,0 +1,94 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn double_it_0(mut x: i32) -> i32 {
+    return ((x) * (2));
+}
+pub unsafe fn test_roundtrip_1() {
+    let mut fn_: Option<unsafe fn(i32) -> i32> = Some(double_it_0);
+    assert!(
+        ((unsafe {
+            let _arg0: i32 = 5;
+            (fn_).unwrap()(_arg0)
+        }) == (10))
+    );
+    let mut gfn: Option<unsafe fn()> =
+        std::mem::transmute::<Option<unsafe fn(i32) -> i32>, Option<unsafe fn()>>(fn_);
+    assert!(!((gfn).is_none()));
+    let mut fn2: Option<unsafe fn(i32) -> i32> =
+        std::mem::transmute::<Option<unsafe fn()>, Option<unsafe fn(i32) -> i32>>(gfn);
+    assert!(
+        ((unsafe {
+            let _arg0: i32 = 5;
+            (fn2).unwrap()(_arg0)
+        }) == (10))
+    );
+    assert!(((fn2) == (fn_)));
+}
+pub unsafe fn test_double_cast_2() {
+    let mut fn_: Option<unsafe fn(i32) -> i32> = Some(double_it_0);
+    let mut fn2: Option<unsafe fn(i32) -> i32> =
+        std::mem::transmute::<Option<unsafe fn()>, Option<unsafe fn(i32) -> i32>>(
+            std::mem::transmute::<Option<unsafe fn(i32) -> i32>, Option<unsafe fn()>>(fn_),
+        );
+    assert!(
+        ((unsafe {
+            let _arg0: i32 = 5;
+            (fn2).unwrap()(_arg0)
+        }) == (10))
+    );
+    assert!(((fn2) == (fn_)));
+}
+#[derive(Copy, Clone, Default)]
+pub struct Command {
+    pub data: *mut ::libc::c_void,
+}
+pub unsafe fn test_void_ptr_to_fn_3() {
+    let mut cmd: Command = <Command>::default();
+    cmd.data = std::mem::transmute::<Option<unsafe fn(i32) -> i32>, *mut ::libc::c_void>(Some(
+        double_it_0,
+    ));
+    let mut fn_: Option<unsafe fn(i32) -> i32> =
+        std::mem::transmute::<*mut ::libc::c_void, Option<unsafe fn(i32) -> i32>>(cmd.data);
+    assert!(
+        ((unsafe {
+            let _arg0: i32 = 5;
+            (fn_).unwrap()(_arg0)
+        }) == (10))
+    );
+}
+pub unsafe fn add_offset_4(mut base: *mut i32, mut offset: i32) -> i32 {
+    return ((*base) + (offset));
+}
+pub unsafe fn test_call_through_cast_5() {
+    let mut gfn: Option<unsafe fn(*mut ::libc::c_void, i32) -> i32> = std::mem::transmute::<
+        Option<unsafe fn(*mut i32, i32) -> i32>,
+        Option<unsafe fn(*mut ::libc::c_void, i32) -> i32>,
+    >(Some(add_offset_4));
+    let mut val: i32 = 100;
+    let mut result: i32 = (unsafe {
+        let _arg0: *mut ::libc::c_void =
+            ((&mut val as *mut i32) as *mut i32 as *mut ::libc::c_void);
+        let _arg1: i32 = 42;
+        (gfn).unwrap()(_arg0, _arg1)
+    });
+    assert!(((result) == (142)));
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    (unsafe { test_roundtrip_1() });
+    (unsafe { test_double_cast_2() });
+    (unsafe { test_void_ptr_to_fn_3() });
+    (unsafe { test_call_through_cast_5() });
+    return 0;
+}

--- a/tests/unit/out/unsafe/fn_ptr_conditional.rs
+++ b/tests/unit/out/unsafe/fn_ptr_conditional.rs
@@ -1,0 +1,92 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn inc_0(mut x: i32) -> i32 {
+    return ((x) + (1));
+}
+pub unsafe fn dec_1(mut x: i32) -> i32 {
+    return ((x) - (1));
+}
+pub unsafe fn identity_2(mut x: i32) -> i32 {
+    return x;
+}
+pub unsafe fn pick_3(mut mode: i32) -> Option<unsafe fn(i32) -> i32> {
+    return if ((mode) > (0)) {
+        Some(inc_0)
+    } else {
+        if ((mode) < (0)) {
+            Some(dec_1)
+        } else {
+            Some(identity_2)
+        }
+    };
+}
+pub unsafe fn apply_4(mut fn_: Option<unsafe fn(i32) -> i32>, mut x: i32) -> i32 {
+    let mut actual: Option<unsafe fn(i32) -> i32> = if !(fn_).is_none() {
+        fn_
+    } else {
+        Some(identity_2)
+    };
+    return (unsafe {
+        let _arg0: i32 = x;
+        (actual).unwrap()(_arg0)
+    });
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _arg0: i32 = 10;
+            (unsafe {
+                let _mode: i32 = 1;
+                pick_3(_mode)
+            })
+            .unwrap()(_arg0)
+        }) == (11))
+    );
+    assert!(
+        ((unsafe {
+            let _arg0: i32 = 10;
+            (unsafe {
+                let _mode: i32 = -1_i32;
+                pick_3(_mode)
+            })
+            .unwrap()(_arg0)
+        }) == (9))
+    );
+    assert!(
+        ((unsafe {
+            let _arg0: i32 = 10;
+            (unsafe {
+                let _mode: i32 = 0;
+                pick_3(_mode)
+            })
+            .unwrap()(_arg0)
+        }) == (10))
+    );
+    assert!(
+        ((unsafe {
+            let _fn: Option<unsafe fn(i32) -> i32> = Some(inc_0);
+            let _x: i32 = 5;
+            apply_4(_fn, _x)
+        }) == (6))
+    );
+    assert!(
+        ((unsafe {
+            let _fn: Option<unsafe fn(i32) -> i32> = None;
+            let _x: i32 = 5;
+            apply_4(_fn, _x)
+        }) == (5))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/fn_ptr_default_arg.rs
+++ b/tests/unit/out/unsafe/fn_ptr_default_arg.rs
@@ -1,0 +1,61 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn identity_0(mut x: i32) -> i32 {
+    return x;
+}
+pub unsafe fn apply_1(mut x: i32, mut fn_: Option<Option<unsafe fn(i32) -> i32>>) -> i32 {
+    let mut fn_: Option<unsafe fn(i32) -> i32> = fn_.unwrap_or(None);
+    if !(fn_).is_none() {
+        return (unsafe {
+            let _arg0: i32 = x;
+            (fn_).unwrap()(_arg0)
+        });
+    }
+    return x;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = 5;
+            let _fn: Option<unsafe fn(i32) -> i32> = Default::default();
+            apply_1(_x, Some(_fn))
+        }) == (5))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 5;
+            let _fn: Option<unsafe fn(i32) -> i32> = None;
+            apply_1(_x, Some(_fn))
+        }) == (5))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 5;
+            let _fn: Option<unsafe fn(i32) -> i32> = Some(identity_0);
+            apply_1(_x, Some(_fn))
+        }) == (5))
+    );
+    let mut negate: Option<unsafe fn(i32) -> i32> = Some(|x: i32| {
+        return -x;
+    });
+    assert!(
+        ((unsafe {
+            let _x: i32 = 5;
+            let _fn: Option<unsafe fn(i32) -> i32> = negate;
+            apply_1(_x, Some(_fn))
+        }) == (-5_i32))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/fn_ptr_global.rs
+++ b/tests/unit/out/unsafe/fn_ptr_global.rs
@@ -1,0 +1,76 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn double_it_0(mut x: i32) -> i32 {
+    return ((x) * (2));
+}
+pub unsafe fn triple_it_1(mut x: i32) -> i32 {
+    return ((x) * (3));
+}
+pub static mut g_op: Option<unsafe fn(i32) -> i32> = None;
+pub unsafe fn set_op_2(mut fn_: Option<unsafe fn(i32) -> i32>) {
+    g_op = fn_;
+}
+pub unsafe fn call_op_3(mut x: i32) -> i32 {
+    if !(g_op).is_none() {
+        return (unsafe {
+            let _arg0: i32 = x;
+            (g_op).unwrap()(_arg0)
+        });
+    }
+    return x;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = 5;
+            call_op_3(_x)
+        }) == (5))
+    );
+    (unsafe {
+        let _fn: Option<unsafe fn(i32) -> i32> = Some(double_it_0);
+        set_op_2(_fn)
+    });
+    assert!(!((g_op).is_none()));
+    assert!(((g_op) == (Some(double_it_0))));
+    assert!(
+        ((unsafe {
+            let _x: i32 = 5;
+            call_op_3(_x)
+        }) == (10))
+    );
+    (unsafe {
+        let _fn: Option<unsafe fn(i32) -> i32> = Some(triple_it_1);
+        set_op_2(_fn)
+    });
+    assert!(((g_op) == (Some(triple_it_1))));
+    assert!(
+        ((unsafe {
+            let _x: i32 = 5;
+            call_op_3(_x)
+        }) == (15))
+    );
+    (unsafe {
+        let _fn: Option<unsafe fn(i32) -> i32> = None;
+        set_op_2(_fn)
+    });
+    assert!((g_op).is_none());
+    assert!(
+        ((unsafe {
+            let _x: i32 = 5;
+            call_op_3(_x)
+        }) == (5))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/fn_ptr_reassign.rs
+++ b/tests/unit/out/unsafe/fn_ptr_reassign.rs
@@ -1,0 +1,61 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn add_0(mut a: i32, mut b: i32) -> i32 {
+    return ((a) + (b));
+}
+pub unsafe fn sub_1(mut a: i32, mut b: i32) -> i32 {
+    return ((a) - (b));
+}
+pub unsafe fn mul_2(mut a: i32, mut b: i32) -> i32 {
+    return ((a) * (b));
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut fn_: Option<unsafe fn(i32, i32) -> i32> = Some(add_0);
+    assert!(
+        ((unsafe {
+            let _arg0: i32 = 3;
+            let _arg1: i32 = 4;
+            (fn_).unwrap()(_arg0, _arg1)
+        }) == (7))
+    );
+    fn_ = Some(sub_1);
+    assert!(
+        ((unsafe {
+            let _arg0: i32 = 10;
+            let _arg1: i32 = 3;
+            (fn_).unwrap()(_arg0, _arg1)
+        }) == (7))
+    );
+    fn_ = Some(mul_2);
+    assert!(
+        ((unsafe {
+            let _arg0: i32 = 6;
+            let _arg1: i32 = 7;
+            (fn_).unwrap()(_arg0, _arg1)
+        }) == (42))
+    );
+    fn_ = None;
+    assert!((fn_).is_none());
+    fn_ = Some(add_0);
+    assert!(!((fn_).is_none()));
+    assert!(
+        ((unsafe {
+            let _arg0: i32 = 1;
+            let _arg1: i32 = 1;
+            (fn_).unwrap()(_arg0, _arg1)
+        }) == (2))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/fn_ptr_return.rs
+++ b/tests/unit/out/unsafe/fn_ptr_return.rs
@@ -1,0 +1,53 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn inc_0(mut x: i32) -> i32 {
+    return ((x) + (1));
+}
+pub unsafe fn dec_1(mut x: i32) -> i32 {
+    return ((x) - (1));
+}
+pub unsafe fn pick_2(mut choose_inc: i32) -> Option<unsafe fn(i32) -> i32> {
+    if (choose_inc != 0) {
+        return Some(inc_0);
+    }
+    return Some(dec_1);
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut f: Option<unsafe fn(i32) -> i32> = (unsafe {
+        let _choose_inc: i32 = 1;
+        pick_2(_choose_inc)
+    });
+    assert!(!((f).is_none()));
+    assert!(((f) == (Some(inc_0))));
+    assert!(
+        ((unsafe {
+            let _arg0: i32 = 10;
+            (f).unwrap()(_arg0)
+        }) == (11))
+    );
+    let mut g: Option<unsafe fn(i32) -> i32> = (unsafe {
+        let _choose_inc: i32 = 0;
+        pick_2(_choose_inc)
+    });
+    assert!(((g) == (Some(dec_1))));
+    assert!(
+        ((unsafe {
+            let _arg0: i32 = 10;
+            (g).unwrap()(_arg0)
+        }) == (9))
+    );
+    assert!(((f) != (g)));
+    return 0;
+}

--- a/tests/unit/out/unsafe/fn_ptr_stable_sort.rs
+++ b/tests/unit/out/unsafe/fn_ptr_stable_sort.rs
@@ -1,0 +1,44 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+#[derive(Copy, Clone, Default)]
+pub struct Item {
+    pub key: i32,
+    pub value: i32,
+}
+pub unsafe fn Compare_0(a: *const Item, b: *const Item) -> bool {
+    return (((*a).key) < ((*b).key));
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut v: Vec<Item> = Vec::new();
+    v.push(Item { key: 3, value: 30 });
+    v.push(Item { key: 1, value: 10 });
+    v.push(Item { key: 2, value: 20 });
+    {
+        let len = v.as_mut_ptr().add(v.len()).offset_from(v.as_mut_ptr()) as usize;
+        ::std::slice::from_raw_parts_mut(v.as_mut_ptr(), len).sort_by(|x, y| {
+            if (Compare_0)(x, y) {
+                std::cmp::Ordering::Less
+            } else if (Compare_0)(y, x) {
+                std::cmp::Ordering::Greater
+            } else {
+                std::cmp::Ordering::Equal
+            }
+        })
+    };
+    assert!(((v[(0_u64) as usize].key) == (1)));
+    assert!(((v[(1_u64) as usize].key) == (2)));
+    assert!(((v[(2_u64) as usize].key) == (3)));
+    return 0;
+}

--- a/tests/unit/out/unsafe/fn_ptr_struct.rs
+++ b/tests/unit/out/unsafe/fn_ptr_struct.rs
@@ -1,0 +1,65 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+#[derive(Clone)]
+pub struct Handler {
+    pub tag: i32,
+    pub cb: Option<unsafe fn(i32) -> i32>,
+}
+impl Default for Handler {
+    fn default() -> Self {
+        Handler {
+            tag: 0_i32,
+            cb: None,
+        }
+    }
+}
+pub unsafe fn double_it_0(mut x: i32) -> i32 {
+    return ((x) * (2));
+}
+pub unsafe fn negate_1(mut x: i32) -> i32 {
+    return -x;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut h1: Handler = Handler {
+        tag: 1,
+        cb: Some(double_it_0),
+    };
+    let mut h2: Handler = Handler {
+        tag: 2,
+        cb: Some(negate_1),
+    };
+    assert!(!((h1.cb).is_none()));
+    assert!(
+        ((unsafe {
+            let _arg0: i32 = 5;
+            (h1.cb).unwrap()(_arg0)
+        }) == (10))
+    );
+    assert!(
+        ((unsafe {
+            let _arg0: i32 = 7;
+            (h2.cb).unwrap()(_arg0)
+        }) == (-7_i32))
+    );
+    (h1.cb) = Some(negate_1);
+    assert!(
+        ((unsafe {
+            let _arg0: i32 = 3;
+            (h1.cb).unwrap()(_arg0)
+        }) == (-3_i32))
+    );
+    assert!(((h1.cb) == (h2.cb)));
+    return 0;
+}

--- a/tests/unit/out/unsafe/fn_ptr_void_return.rs
+++ b/tests/unit/out/unsafe/fn_ptr_void_return.rs
@@ -1,0 +1,50 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn negate_0(mut x: *mut i32) {
+    (*x) = -(*x);
+}
+pub unsafe fn zero_out_1(mut x: *mut i32) {
+    (*x) = 0;
+}
+pub unsafe fn run_2(mut fn_: Option<unsafe fn(*mut i32)>, mut x: *mut i32) {
+    (unsafe {
+        let _arg0: *mut i32 = x;
+        (fn_).unwrap()(_arg0)
+    });
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut a: i32 = 42;
+    (unsafe {
+        let _fn: Option<unsafe fn(*mut i32)> = Some(negate_0);
+        let _x: *mut i32 = (&mut a as *mut i32);
+        run_2(_fn, _x)
+    });
+    assert!(((a) == (-42_i32)));
+    (unsafe {
+        let _fn: Option<unsafe fn(*mut i32)> = Some(zero_out_1);
+        let _x: *mut i32 = (&mut a as *mut i32);
+        run_2(_fn, _x)
+    });
+    assert!(((a) == (0)));
+    let mut fn_: Option<unsafe fn(*mut i32)> = Some(negate_0);
+    assert!(!((fn_).is_none()));
+    let mut b: i32 = 10;
+    (unsafe {
+        let _arg0: *mut i32 = (&mut b as *mut i32);
+        (fn_).unwrap()(_arg0)
+    });
+    assert!(((b) == (-10_i32)));
+    return 0;
+}

--- a/tests/unit/out/unsafe/fn_ptr_vtable.rs
+++ b/tests/unit/out/unsafe/fn_ptr_vtable.rs
@@ -1,0 +1,68 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+#[derive(Clone)]
+pub struct Vtable {
+    pub create: Option<unsafe fn(i32) -> *mut ::libc::c_void>,
+    pub get: Option<unsafe fn(*mut ::libc::c_void) -> i32>,
+    pub destroy: Option<unsafe fn(*mut ::libc::c_void)>,
+}
+impl Default for Vtable {
+    fn default() -> Self {
+        Vtable {
+            create: None,
+            get: None,
+            destroy: None,
+        }
+    }
+}
+pub static mut storage: i32 = 0_i32;
+pub unsafe fn int_create_0(mut val: i32) -> *mut ::libc::c_void {
+    storage = val;
+    return ((&mut storage as *mut i32) as *mut i32 as *mut ::libc::c_void);
+}
+pub unsafe fn int_get_1(mut p: *mut ::libc::c_void) -> i32 {
+    return (*(p as *mut i32));
+}
+pub unsafe fn int_destroy_2(mut p: *mut ::libc::c_void) {
+    (*(p as *mut i32)) = 0;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut vt: Vtable = Vtable {
+        create: Some(int_create_0),
+        get: Some(int_get_1),
+        destroy: Some(int_destroy_2),
+    };
+    assert!(!((vt.create).is_none()));
+    assert!(!((vt.get).is_none()));
+    assert!(!((vt.destroy).is_none()));
+    let mut obj: *mut ::libc::c_void = (unsafe {
+        let _arg0: i32 = 42;
+        (vt.create).unwrap()(_arg0)
+    });
+    assert!(
+        ((unsafe {
+            let _arg0: *mut ::libc::c_void = obj;
+            (vt.get).unwrap()(_arg0)
+        }) == (42))
+    );
+    (unsafe {
+        let _arg0: *mut ::libc::c_void = obj;
+        (vt.destroy).unwrap()(_arg0)
+    });
+    assert!(((storage) == (0)));
+    (vt.get) = None;
+    assert!((vt.get).is_none());
+    return 0;
+}

--- a/tests/unit/out/unsafe/lambda_capture_pass.rs
+++ b/tests/unit/out/unsafe/lambda_capture_pass.rs
@@ -1,0 +1,62 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn apply_0(mut fn_: impl Fn(i32) -> i32, mut x: i32) -> i32 {
+    return (unsafe {
+        let _x: i32 = x;
+        fn_(_x)
+    });
+}
+pub unsafe fn apply_1(mut fn_: impl Fn(i32) -> i32, mut x: i32) -> i32 {
+    return (unsafe {
+        let _x: i32 = x;
+        fn_(_x)
+    });
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut base: i32 = 10;
+    assert!(
+        ((unsafe {
+            let _fn: _ = (|x: i32| {
+                return ((x) + (base));
+            })
+            .clone();
+            let _x: i32 = 5;
+            apply_0(_fn, _x)
+        }) == (15))
+    );
+    base = 100;
+    assert!(
+        ((unsafe {
+            let _fn: _ = (|x: i32| {
+                return ((x) + (base));
+            })
+            .clone();
+            let _x: i32 = 5;
+            apply_0(_fn, _x)
+        }) == (105))
+    );
+    let mut factor: i32 = 3;
+    assert!(
+        ((unsafe {
+            let _fn: _ = (|x: i32| {
+                return ((x) * (factor));
+            })
+            .clone();
+            let _x: i32 = 4;
+            apply_1(_fn, _x)
+        }) == (12))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/lambda_nested.rs
+++ b/tests/unit/out/unsafe/lambda_nested.rs
@@ -1,0 +1,45 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::Seek;
+use std::io::{Read, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut x: i32 = 10;
+    assert!(
+        ((unsafe {
+            let _y: i32 = 20;
+            (|y: i32| {
+                return (unsafe {
+                    let _z: i32 = 1;
+                    (|z: i32| {
+                        return (((x) + (y)) + (z));
+                    })(_z)
+                });
+            })(_y)
+        }) == (31))
+    );
+    x = 100;
+    assert!(
+        ((unsafe {
+            let _y: i32 = 20;
+            (|y: i32| {
+                return (unsafe {
+                    let _z: i32 = 1;
+                    (|z: i32| {
+                        return (((x) + (y)) + (z));
+                    })(_z)
+                });
+            })(_y)
+        }) == (121))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/no_direct_callee.rs
+++ b/tests/unit/out/unsafe/no_direct_callee.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 pub unsafe fn test1_0() -> bool {
     return false;
 }
-pub unsafe fn test_1(mut fn_: Option<fn() -> bool>) -> i32 {
+pub unsafe fn test_1(mut fn_: Option<unsafe fn() -> bool>) -> i32 {
     if !(unsafe { (fn_).unwrap()() }) {
         return 1;
     }
@@ -23,7 +23,7 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     return (unsafe {
-        let _fn: Option<fn() -> bool> = Some(test1_0);
+        let _fn: Option<unsafe fn() -> bool> = Some(test1_0);
         test_1(_fn)
     });
 }

--- a/tests/unit/out/unsafe/no_direct_callee.rs
+++ b/tests/unit/out/unsafe/no_direct_callee.rs
@@ -10,8 +10,8 @@ use std::rc::Rc;
 pub unsafe fn test1_0() -> bool {
     return false;
 }
-pub unsafe fn test_1(mut fn_: Rc<dyn Fn() -> bool>) -> i32 {
-    if !(unsafe { fn_() }) {
+pub unsafe fn test_1(mut fn_: Option<fn() -> bool>) -> i32 {
+    if !(unsafe { (fn_).unwrap()() }) {
         return 1;
     }
     return 0;
@@ -23,7 +23,7 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     return (unsafe {
-        let _fn: Rc<dyn Fn() -> bool> = Rc::new(|| unsafe { test1_0() });
+        let _fn: Option<fn() -> bool> = Some(test1_0);
         test_1(_fn)
     });
 }

--- a/tests/unit/out/unsafe/prvalue-as-lvalue.rs
+++ b/tests/unit/out/unsafe/prvalue-as-lvalue.rs
@@ -20,7 +20,7 @@ unsafe fn main_0() -> i32 {
     let mut pa: *mut i32 = (&mut a as *mut i32);
     let b: *const i32 = (unsafe {
         let _a: *const i32 = &(*pa) as *const i32;
-        Rc::new(|a0| unsafe { foo_0(a0) })(_a)
+        foo_0(_a)
     });
     return (*b);
 }

--- a/tests/unit/out/unsafe/ref_calls.rs
+++ b/tests/unit/out/unsafe/ref_calls.rs
@@ -26,7 +26,7 @@ unsafe fn main_0() -> i32 {
     }));
     let z: *mut i32 = (unsafe {
         let _x: *mut i32 = &mut x as *mut i32;
-        Rc::new(|a0| unsafe { foo_1(a0) })(_x)
+        foo_1(_x)
     });
     return ((((*(unsafe {
         let _x: *mut i32 = &mut x as *mut i32;


### PR DESCRIPTION
Sub-part of #3, only covers: translate function pointers and non-capturing lambdas as Option<fn> in unsafe and FnPtr in refcount

* deleted the `fn_ptr!` macro, address is computed inside `FnPtr::new` using the `FnAddr` trait
* replaced `cast_history` with the original function pointer + current cast
* in unsafe function pointers + casts are translated using: `Option<fn>` + `std::mem::transmute`
* in refcount function pointers + casts are translated using: `FnPtr<fn>` + `FnPtr<fn>::cast`