### PR TITLE
Fix detection of va_list type

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -63,15 +63,15 @@ bool Converter::VisitRecoveryExpr(clang::RecoveryExpr *expr) {
 }
 
 bool Converter::Convert(clang::QualType qual_type) {
-  if (Mapper::Contains(qual_type) &&
-      Mapper::Map(qual_type) != ignore_rule_type_) {
-    StrCat(Mapper::Map(qual_type));
-    return false;
-  }
-
   // Catch va_list before desugaring
   if (IsVaListType(qual_type)) {
     StrCat("VaList");
+    return false;
+  }
+
+  if (Mapper::Contains(qual_type) &&
+      Mapper::Map(qual_type) != ignore_rule_type_) {
+    StrCat(Mapper::Map(qual_type));
     return false;
   }
 

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -69,6 +69,12 @@ bool Converter::Convert(clang::QualType qual_type) {
     return false;
   }
 
+  // Catch va_list before desugaring
+  if (IsVaListType(qual_type)) {
+    StrCat("VaList");
+    return false;
+  }
+
   qual_type = qual_type.getUnqualifiedType().getDesugaredType(ctx_);
   return TraverseType(qual_type);
 }
@@ -243,7 +249,7 @@ bool Converter::VisitPointerType(clang::PointerType *type) {
     return false;
   }
 
-  if (IsVaListType(ctx_, clang::QualType(type, 0))) {
+  if (IsVaListType(clang::QualType(type, 0))) {
     StrCat("VaList");
     return false;
   }
@@ -371,7 +377,7 @@ bool Converter::ConvertVarDeclSkipInit(clang::VarDecl *decl) {
   auto qual_type = decl->getType();
   auto name = GetNamedDeclAsString(decl);
 
-  if (IsVaListType(ctx_, qual_type) && decl->isLocalVarDecl()) {
+  if (IsVaListType(qual_type) && decl->isLocalVarDecl()) {
     ConvertVaListVarDecl(decl);
     return true;
   }
@@ -1641,7 +1647,7 @@ bool Converter::VisitImplicitCastExpr(clang::ImplicitCastExpr *expr) {
       return Convert(sub_expr);
     }
     // __va_list_tag [1] decays to __va_list_tag *. Just pass through by value
-    if (IsVaListType(ctx_, sub_expr->getType())) {
+    if (IsVaListType(sub_expr->getType())) {
       Convert(sub_expr);
       break;
     }
@@ -2650,6 +2656,11 @@ Converter::GetFunctionPointerDefaultAsString(clang::QualType qual_type) {
 }
 
 std::string Converter::GetDefaultAsString(clang::QualType qual_type) {
+  if (IsVaListType(qual_type)) {
+    computed_expr_type_ = ComputedExprType::FreshValue;
+    return "VaList::default()";
+  }
+
   if (qual_type->isPointerType()) {
     if (qual_type->getPointeeType()->isFunctionType()) {
       return GetFunctionPointerDefaultAsString(qual_type);

--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -600,24 +600,24 @@ bool IsRedundantCopyInConversion(clang::ASTContext &ctx,
   return parent && parent->getConstructor()->isConvertingConstructor(false);
 }
 
-// va_list is implemented as __va_list_tag[1] and decays to __va_list_tag *.
-// That's because va_list must have pointer semantics, but still be passed as
-// value by user code.
-bool IsVaListType(clang::ASTContext &ctx, clang::QualType type) {
-  auto canonical = type.getCanonicalType();
-  auto va_list = ctx.getBuiltinVaListType().getCanonicalType();
-
-  // Direct match: va_list itself
-  if (canonical == va_list) {
-    return true;
+bool IsVaListType(clang::QualType type) {
+  for (auto t = type; !t.isNull();) {
+    if (auto *adjusted = t->getAs<clang::AdjustedType>()) {
+      // Possibly decayed va_list
+      t = adjusted->getOriginalType();
+      continue;
+    } else if (auto *typedef_type = t->getAs<clang::TypedefType>()) {
+      // Typedef'ed va_list
+      if (auto decl = typedef_type->getDecl()) {
+        if (decl->getName().contains("va_list")) {
+          return true;
+        }
+        t = decl->getUnderlyingType();
+        continue;
+      }
+    }
+    break;
   }
-
-  // Decayed match: __va_list_tag[1] decays to __va_list_tag *
-  if (auto *arr = clang::dyn_cast<clang::ConstantArrayType>(va_list)) {
-    return canonical ==
-           ctx.getPointerType(arr->getElementType()).getCanonicalType();
-  }
-
   return false;
 }
 

--- a/cpp2rust/converter/converter_lib.h
+++ b/cpp2rust/converter/converter_lib.h
@@ -142,7 +142,7 @@ std::string GetClassName(clang::QualType type);
 bool IsRedundantCopyInConversion(clang::ASTContext &ctx,
                                  const clang::CXXConstructExpr *expr);
 
-bool IsVaListType(clang::ASTContext &ctx, clang::QualType type);
+bool IsVaListType(clang::QualType type);
 
 bool IsBuiltinVaStart(const clang::CallExpr *expr);
 

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -133,6 +133,12 @@ std::string ConverterRefCount::BoxValue(std::string &&str) const {
 }
 
 bool ConverterRefCount::Convert(clang::QualType qual_type) {
+  // Detect va_list before desugaring strips the typedef.
+  if (IsVaListType(qual_type)) {
+    StrCat(BoxType("VaList"));
+    return false;
+  }
+
   if (!Mapper::Contains(qual_type))
     qual_type = qual_type.getUnqualifiedType().getDesugaredType(ctx_);
 
@@ -172,7 +178,7 @@ bool ConverterRefCount::VisitPointerType(clang::PointerType *type) {
     return false;
   }
 
-  if (IsVaListType(ctx_, clang::QualType(type, 0))) {
+  if (IsVaListType(clang::QualType(type, 0))) {
     StrCat("VaList");
     return false;
   }
@@ -933,7 +939,7 @@ bool ConverterRefCount::VisitImplicitCastExpr(clang::ImplicitCastExpr *expr) {
   }
 
   if (expr->getCastKind() == clang::CastKind::CK_ArrayToPointerDecay) {
-    if (IsVaListType(ctx_, sub_expr->getType())) {
+    if (IsVaListType(sub_expr->getType())) {
       Convert(sub_expr);
       return false;
     }
@@ -1408,6 +1414,10 @@ bool ConverterRefCount::VisitCXXDefaultArgExpr(clang::CXXDefaultArgExpr *expr) {
 }
 
 std::string ConverterRefCount::GetDefaultAsString(clang::QualType qual_type) {
+  if (IsVaListType(qual_type)) {
+    return BoxValue("VaList::default()");
+  }
+
   std::string ret;
   if (qual_type->isPointerType()) {
     auto pointee_type = qual_type->getPointeeType();

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -133,7 +133,7 @@ std::string ConverterRefCount::BoxValue(std::string &&str) const {
 }
 
 bool ConverterRefCount::Convert(clang::QualType qual_type) {
-  // Detect va_list before desugaring strips the typedef.
+  // Catch va_list before desugaring
   if (IsVaListType(qual_type)) {
     StrCat(BoxType("VaList"));
     return false;

--- a/tests/unit/out/refcount/va_arg_chain.rs
+++ b/tests/unit/out/refcount/va_arg_chain.rs
@@ -28,7 +28,7 @@ pub fn middle_layer_1(n: i32, ap: VaList) -> i32 {
 }
 pub fn top_level_2(n: i32, args: &[VaArg]) -> i32 {
     let n: Value<i32> = Rc::new(RefCell::new(n));
-    let ap: Value<VaList> = <Value<VaList>>::default();
+    let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
     (*ap.borrow_mut()) = VaList::new(args);
     let result: Value<i32> = Rc::new(RefCell::new(
         ({

--- a/tests/unit/out/refcount/va_arg_concat.rs
+++ b/tests/unit/out/refcount/va_arg_concat.rs
@@ -9,7 +9,7 @@ use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 pub fn sum_ints_0(first: i32, args: &[VaArg]) -> i32 {
     let first: Value<i32> = Rc::new(RefCell::new(first));
-    let ap: Value<VaList> = <Value<VaList>>::default();
+    let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
     let total: Value<i32> = Rc::new(RefCell::new((*first.borrow())));
     (*ap.borrow_mut()) = VaList::new(args);
     let val: Value<i32> = <Value<i32>>::default();

--- a/tests/unit/out/refcount/va_arg_conditional.rs
+++ b/tests/unit/out/refcount/va_arg_conditional.rs
@@ -11,7 +11,7 @@ pub fn conditional_log_0(verbose: i32, fmt: Ptr<u8>, args: &[VaArg]) -> i32 {
     let verbose: Value<i32> = Rc::new(RefCell::new(verbose));
     let fmt: Value<Ptr<u8>> = Rc::new(RefCell::new(fmt));
     if ((*verbose.borrow()) != 0) {
-        let ap: Value<VaList> = <Value<VaList>>::default();
+        let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
         (*ap.borrow_mut()) = VaList::new(args);
         let result: Value<i32> = Rc::new(RefCell::new(((*ap.borrow_mut()).arg::<i32>()).clone()));
         return (*result.borrow());

--- a/tests/unit/out/refcount/va_arg_copy.rs
+++ b/tests/unit/out/refcount/va_arg_copy.rs
@@ -9,8 +9,8 @@ use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 pub fn sum_with_copy_0(count: i32, args: &[VaArg]) -> i32 {
     let count: Value<i32> = Rc::new(RefCell::new(count));
-    let ap: Value<VaList> = <Value<VaList>>::default();
-    let aq: Value<VaList> = <Value<VaList>>::default();
+    let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
+    let aq: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
     (*ap.borrow_mut()) = VaList::new(args);
     (*aq.borrow_mut()) = (*ap.borrow_mut()).clone();
     let sum1: Value<i32> = Rc::new(RefCell::new(0));

--- a/tests/unit/out/refcount/va_arg_forward.rs
+++ b/tests/unit/out/refcount/va_arg_forward.rs
@@ -20,7 +20,7 @@ pub fn inner_0(count: i32, ap: VaList) -> i32 {
 }
 pub fn outer_1(count: i32, args: &[VaArg]) -> i32 {
     let count: Value<i32> = Rc::new(RefCell::new(count));
-    let ap: Value<VaList> = <Value<VaList>>::default();
+    let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
     (*ap.borrow_mut()) = VaList::new(args);
     let result: Value<i32> = Rc::new(RefCell::new(
         ({

--- a/tests/unit/out/refcount/va_arg_mixed_int_ptr.rs
+++ b/tests/unit/out/refcount/va_arg_mixed_int_ptr.rs
@@ -9,7 +9,7 @@ use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 pub fn mixed_args_0(count: i32, args: &[VaArg]) -> i32 {
     let count: Value<i32> = Rc::new(RefCell::new(count));
-    let ap: Value<VaList> = <Value<VaList>>::default();
+    let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
     (*ap.borrow_mut()) = VaList::new(args);
     let total: Value<i32> = Rc::new(RefCell::new(0));
     let i: Value<i32> = Rc::new(RefCell::new(0));

--- a/tests/unit/out/refcount/va_arg_mixed_types.rs
+++ b/tests/unit/out/refcount/va_arg_mixed_types.rs
@@ -9,7 +9,7 @@ use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 pub fn sum_mixed_0(count: i32, args: &[VaArg]) -> i32 {
     let count: Value<i32> = Rc::new(RefCell::new(count));
-    let ap: Value<VaList> = <Value<VaList>>::default();
+    let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
     (*ap.borrow_mut()) = VaList::new(args);
     let total: Value<i32> = Rc::new(RefCell::new(0));
     let i: Value<i32> = Rc::new(RefCell::new(0));

--- a/tests/unit/out/refcount/va_arg_printf.rs
+++ b/tests/unit/out/refcount/va_arg_printf.rs
@@ -17,7 +17,7 @@ pub fn logf_impl_0(fmt: Ptr<u8>, ap: VaList) -> i32 {
 }
 pub fn logf_1(fmt: Ptr<u8>, args: &[VaArg]) -> i32 {
     let fmt: Value<Ptr<u8>> = Rc::new(RefCell::new(fmt));
-    let ap: Value<VaList> = <Value<VaList>>::default();
+    let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
     (*ap.borrow_mut()) = VaList::new(args);
     let result: Value<i32> = Rc::new(RefCell::new(
         ({

--- a/tests/unit/out/refcount/va_arg_promotion.rs
+++ b/tests/unit/out/refcount/va_arg_promotion.rs
@@ -9,7 +9,7 @@ use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 pub fn test_promotions_0(count: i32, args: &[VaArg]) -> i32 {
     let count: Value<i32> = Rc::new(RefCell::new(count));
-    let ap: Value<VaList> = <Value<VaList>>::default();
+    let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
     (*ap.borrow_mut()) = VaList::new(args);
     let a: Value<i32> = Rc::new(RefCell::new(((*ap.borrow_mut()).arg::<i32>()).clone()));
     let b: Value<i32> = Rc::new(RefCell::new(((*ap.borrow_mut()).arg::<i32>()).clone()));

--- a/tests/unit/out/refcount/va_arg_snprintf.rs
+++ b/tests/unit/out/refcount/va_arg_snprintf.rs
@@ -11,7 +11,7 @@ pub fn extract_first_0(buf: Ptr<u8>, size: i32, fmt: Ptr<u8>, args: &[VaArg]) ->
     let buf: Value<Ptr<u8>> = Rc::new(RefCell::new(buf));
     let size: Value<i32> = Rc::new(RefCell::new(size));
     let fmt: Value<Ptr<u8>> = Rc::new(RefCell::new(fmt));
-    let ap: Value<VaList> = <Value<VaList>>::default();
+    let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
     (*ap.borrow_mut()) = VaList::new(args);
     let n: Value<i32> = Rc::new(RefCell::new(((*ap.borrow_mut()).arg::<i32>()).clone()));
     let __rhs = ((*n.borrow()) as u8);

--- a/tests/unit/out/refcount/va_arg_struct_ctx.rs
+++ b/tests/unit/out/refcount/va_arg_struct_ctx.rs
@@ -26,7 +26,7 @@ pub fn set_error_0(ctx: Ptr<context>, fmt: Ptr<u8>, args: &[VaArg]) {
     let ctx: Value<Ptr<context>> = Rc::new(RefCell::new(ctx));
     let fmt: Value<Ptr<u8>> = Rc::new(RefCell::new(fmt));
     if ((*(*(*ctx.borrow()).upgrade().deref()).verbose.borrow()) != 0) {
-        let ap: Value<VaList> = Rc::new(RefCell::new(<VaList>::default()));
+        let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
         (*ap.borrow_mut()) = VaList::new(args);
         (*(*(*ctx.borrow()).upgrade().deref()).last_error.borrow_mut()) =
             ((*ap.borrow_mut()).arg::<i32>()).clone();

--- a/tests/unit/out/refcount/va_arg_two_passes.rs
+++ b/tests/unit/out/refcount/va_arg_two_passes.rs
@@ -9,7 +9,7 @@ use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 pub fn sum_then_product_0(first: i32, args: &[VaArg]) -> i32 {
     let first: Value<i32> = Rc::new(RefCell::new(first));
-    let ap: Value<VaList> = <Value<VaList>>::default();
+    let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
     let sum: Value<i32> = Rc::new(RefCell::new((*first.borrow())));
     let product: Value<i32> = Rc::new(RefCell::new((*first.borrow())));
     (*ap.borrow_mut()) = VaList::new(args);

--- a/tests/unit/out/unsafe/va_arg_chain.rs
+++ b/tests/unit/out/unsafe/va_arg_chain.rs
@@ -23,7 +23,7 @@ pub unsafe fn middle_layer_1(mut n: i32, mut ap: VaList) -> i32 {
     });
 }
 pub unsafe fn top_level_2(mut n: i32, args: &[VaArg]) -> i32 {
-    let mut ap: VaList = <VaList>::default();
+    let mut ap: VaList = VaList::default();
     ap = VaList::new(args);
     let mut result: i32 = (unsafe {
         let _n: i32 = n;

--- a/tests/unit/out/unsafe/va_arg_concat.rs
+++ b/tests/unit/out/unsafe/va_arg_concat.rs
@@ -8,7 +8,7 @@ use std::io::{Read, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn sum_ints_0(mut first: i32, args: &[VaArg]) -> i32 {
-    let mut ap: VaList = <VaList>::default();
+    let mut ap: VaList = VaList::default();
     let mut total: i32 = first;
     ap = VaList::new(args);
     let mut val: i32 = 0_i32;

--- a/tests/unit/out/unsafe/va_arg_conditional.rs
+++ b/tests/unit/out/unsafe/va_arg_conditional.rs
@@ -9,7 +9,7 @@ use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn conditional_log_0(mut verbose: i32, mut fmt: *const u8, args: &[VaArg]) -> i32 {
     if (verbose != 0) {
-        let mut ap: VaList = <VaList>::default();
+        let mut ap: VaList = VaList::default();
         ap = VaList::new(args);
         let mut result: i32 = ap.arg::<i32>();
         return result;

--- a/tests/unit/out/unsafe/va_arg_copy.rs
+++ b/tests/unit/out/unsafe/va_arg_copy.rs
@@ -8,8 +8,8 @@ use std::io::{Read, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn sum_with_copy_0(mut count: i32, args: &[VaArg]) -> i32 {
-    let mut ap: VaList = <VaList>::default();
-    let mut aq: VaList = <VaList>::default();
+    let mut ap: VaList = VaList::default();
+    let mut aq: VaList = VaList::default();
     ap = VaList::new(args);
     aq = ap.clone();
     let mut sum1: i32 = 0;

--- a/tests/unit/out/unsafe/va_arg_forward.rs
+++ b/tests/unit/out/unsafe/va_arg_forward.rs
@@ -17,7 +17,7 @@ pub unsafe fn inner_0(mut count: i32, mut ap: VaList) -> i32 {
     return total;
 }
 pub unsafe fn outer_1(mut count: i32, args: &[VaArg]) -> i32 {
-    let mut ap: VaList = <VaList>::default();
+    let mut ap: VaList = VaList::default();
     ap = VaList::new(args);
     let mut result: i32 = (unsafe {
         let _count: i32 = count;

--- a/tests/unit/out/unsafe/va_arg_mixed_int_ptr.rs
+++ b/tests/unit/out/unsafe/va_arg_mixed_int_ptr.rs
@@ -8,7 +8,7 @@ use std::io::{Read, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn mixed_args_0(mut count: i32, args: &[VaArg]) -> i32 {
-    let mut ap: VaList = <VaList>::default();
+    let mut ap: VaList = VaList::default();
     ap = VaList::new(args);
     let mut total: i32 = 0;
     let mut i: i32 = 0;

--- a/tests/unit/out/unsafe/va_arg_mixed_types.rs
+++ b/tests/unit/out/unsafe/va_arg_mixed_types.rs
@@ -8,7 +8,7 @@ use std::io::{Read, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn sum_mixed_0(mut count: i32, args: &[VaArg]) -> i32 {
-    let mut ap: VaList = <VaList>::default();
+    let mut ap: VaList = VaList::default();
     ap = VaList::new(args);
     let mut total: i32 = 0;
     let mut i: i32 = 0;

--- a/tests/unit/out/unsafe/va_arg_printf.rs
+++ b/tests/unit/out/unsafe/va_arg_printf.rs
@@ -11,7 +11,7 @@ pub unsafe fn logf_impl_0(mut fmt: *const u8, mut ap: VaList) -> i32 {
     return ((ap.arg::<i32>()) + (ap.arg::<i32>()));
 }
 pub unsafe fn logf_1(mut fmt: *const u8, args: &[VaArg]) -> i32 {
-    let mut ap: VaList = <VaList>::default();
+    let mut ap: VaList = VaList::default();
     ap = VaList::new(args);
     let mut result: i32 = (unsafe {
         let _fmt: *const u8 = fmt;

--- a/tests/unit/out/unsafe/va_arg_promotion.rs
+++ b/tests/unit/out/unsafe/va_arg_promotion.rs
@@ -8,7 +8,7 @@ use std::io::{Read, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn test_promotions_0(mut count: i32, args: &[VaArg]) -> i32 {
-    let mut ap: VaList = <VaList>::default();
+    let mut ap: VaList = VaList::default();
     ap = VaList::new(args);
     let mut a: i32 = ap.arg::<i32>();
     let mut b: i32 = ap.arg::<i32>();

--- a/tests/unit/out/unsafe/va_arg_snprintf.rs
+++ b/tests/unit/out/unsafe/va_arg_snprintf.rs
@@ -13,7 +13,7 @@ pub unsafe fn extract_first_0(
     mut fmt: *const u8,
     args: &[VaArg],
 ) -> i32 {
-    let mut ap: VaList = <VaList>::default();
+    let mut ap: VaList = VaList::default();
     ap = VaList::new(args);
     let mut n: i32 = ap.arg::<i32>();
     (*buf.offset((0) as isize)) = (n as u8);

--- a/tests/unit/out/unsafe/va_arg_struct_ctx.rs
+++ b/tests/unit/out/unsafe/va_arg_struct_ctx.rs
@@ -14,7 +14,7 @@ pub struct context {
 }
 pub unsafe fn set_error_0(mut ctx: *mut context, mut fmt: *const u8, args: &[VaArg]) {
     if ((*ctx).verbose != 0) {
-        let mut ap: VaList = <VaList>::default();
+        let mut ap: VaList = VaList::default();
         ap = VaList::new(args);
         (*ctx).last_error = (ap.arg::<i32>()).clone();
     }

--- a/tests/unit/out/unsafe/va_arg_two_passes.rs
+++ b/tests/unit/out/unsafe/va_arg_two_passes.rs
@@ -8,7 +8,7 @@ use std::io::{Read, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn sum_then_product_0(mut first: i32, args: &[VaArg]) -> i32 {
-    let mut ap: VaList = <VaList>::default();
+    let mut ap: VaList = VaList::default();
     let mut sum: i32 = first;
     let mut product: i32 = first;
     ap = VaList::new(args);


### PR DESCRIPTION
On macOS `va_list` is typedef'ed to `char*`, on Linux is typedefed to `__va_list_tag[1]`. Traverse the TypedefType/AdjustedType in order to check if a type is va_list instead of checking against the Linux specific `__va_list_tag`.