### PR TITLE
Add switch tests

### DIFF
--- a/tests/lit/lit/formats/Cpp2RustTest.py
+++ b/tests/lit/lit/formats/Cpp2RustTest.py
@@ -96,10 +96,6 @@ class Cpp2RustTest(TestFormat):
       shutil.rmtree(tmp_dir, True)
       return code, str
 
-    expected_file = self.getExpectedFile(filepath, model, fname)
-    if not os.path.exists(expected_file) and not replace_expected:
-      return fail('no expected file')
-
     cmd = ['./cpp2rust/cpp2rust', '-file', cc_input, '-model', model,
            '-o', rs_file]
 
@@ -118,6 +114,10 @@ class Cpp2RustTest(TestFormat):
       if should_not_translate:
         return lit.Test.PASS, ''
       return fail('cpp2rust failed\n' + err)
+
+    expected_file = self.getExpectedFile(filepath, model, fname)
+    if not os.path.exists(expected_file) and not replace_expected:
+      return fail('no expected file')
 
     if replace_expected:
       self.updateExpected(generated, expected_file)

--- a/tests/lit/lit/formats/Cpp2RustTest.py
+++ b/tests/lit/lit/formats/Cpp2RustTest.py
@@ -26,6 +26,7 @@ class Cpp2RustTest(TestFormat):
     self.regex_xfail = re.compile(r"//\s*XFAIL:\s*(.*)")
     self.regex_panic = re.compile(r"//\s*panic\s*(?::\s*(.*))?$", re.MULTILINE)
     self.regex_nocompile = re.compile(r"//\s*no-compile\s*(?::\s*(.*))?$", re.MULTILINE)
+    self.regex_translation_fail = re.compile(r"//\s*translation-fail\s*(?::\s*(.*))?$", re.MULTILINE)
     self.regex_nondet_result = re.compile(r"//\s*nondet-result\s*(?::\s*(.*))?$", re.MULTILINE)
     self.rust_version = read_rust_version()
     os.environ['RUSTFLAGS'] = '-Awarnings -A dangerous-implicit-autorefs'
@@ -83,6 +84,7 @@ class Cpp2RustTest(TestFormat):
 
     should_panic = matches_model(self.regex_panic.search(text), model)
     should_not_compile = matches_model(self.regex_nocompile.search(text), model)
+    should_not_translate = matches_model(self.regex_translation_fail.search(text), model)
     is_nondet_result = matches_model(self.regex_nondet_result.search(text), model)
 
     tmp_dir = "tmp/" + fname + "-" + model + "_" + format(random.getrandbits(64), "x")
@@ -113,6 +115,8 @@ class Cpp2RustTest(TestFormat):
       generated = f.read()
 
     if returncode != 0:
+      if should_not_translate:
+        return lit.Test.PASS, ''
       return fail('cpp2rust failed\n' + err)
 
     if replace_expected:

--- a/tests/lit/lit/formats/Cpp2RustTest.py
+++ b/tests/lit/lit/formats/Cpp2RustTest.py
@@ -112,7 +112,7 @@ class Cpp2RustTest(TestFormat):
 
     if returncode != 0:
       if should_not_translate:
-        return lit.Test.PASS, ''
+        return lit.Test.XFAIL, ''
       return fail('cpp2rust failed\n' + err)
 
     expected_file = self.getExpectedFile(filepath, model, fname)

--- a/tests/unit/out/refcount/switch_basic.rs
+++ b/tests/unit/out/refcount/switch_basic.rs
@@ -1,0 +1,58 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn basic_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    let r: Value<i32> = Rc::new(RefCell::new(0));
+    'switch: {
+        let __match_cond = (*x.borrow());
+        match __match_cond {
+            v if v == 0 => {
+                (*r.borrow_mut()) = 10;
+                break 'switch;
+            }
+            v if v == 1 => {
+                (*r.borrow_mut()) = 20;
+                break 'switch;
+            }
+            v if v == 2 => {
+                (*r.borrow_mut()) = 30;
+                break 'switch;
+            }
+            _ => {
+                (*r.borrow_mut()) = 40;
+                break 'switch;
+            }
+        }
+    };
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = 0;
+            basic_0(_x)
+        }) == 10)
+    );
+    assert!(
+        (({
+            let _x: i32 = 2;
+            basic_0(_x)
+        }) == 30)
+    );
+    assert!(
+        (({
+            let _x: i32 = 99;
+            basic_0(_x)
+        }) == 40)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_borrow_in_condition_and_in_body.rs
+++ b/tests/unit/out/refcount/switch_borrow_in_condition_and_in_body.rs
@@ -1,0 +1,39 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn borrow_in_condition_and_in_body_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    'switch: {
+        let __match_cond = (*x.borrow());
+        match __match_cond {
+            v if v == 0 => {}
+            _ => {
+                return ((*x.borrow()) + 1);
+            }
+        }
+    };
+    panic!("ub: non-void function does not return a value")
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = 0;
+            borrow_in_condition_and_in_body_0(_x)
+        }) == 1)
+    );
+    assert!(
+        (({
+            let _x: i32 = 1;
+            borrow_in_condition_and_in_body_0(_x)
+        }) == 2)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_char.rs
+++ b/tests/unit/out/refcount/switch_char.rs
@@ -1,0 +1,75 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn switch_char_0(c: u8) -> i32 {
+    let c: Value<u8> = Rc::new(RefCell::new(c));
+    'switch: {
+        let __match_cond = ((*c.borrow()) as i32);
+        match __match_cond {
+            v if v == (('a' as u8) as i32) => {
+                return 1;
+            }
+            v if v == (('b' as u8) as i32) => {
+                return 2;
+            }
+            v if v == (('\n' as u8) as i32) => {
+                return 3;
+            }
+            v if v == (('\0' as u8) as i32) => {
+                return 4;
+            }
+            _ => {
+                return 0;
+            }
+        }
+    };
+    panic!("ub: non-void function does not return a value")
+}
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+enum Color {
+    #[default]
+    kRed = 0,
+    kGreen = 1,
+    kBlue = 2,
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _c: u8 = ('a' as u8);
+            switch_char_0(_c)
+        }) == 1)
+    );
+    assert!(
+        (({
+            let _c: u8 = ('b' as u8);
+            switch_char_0(_c)
+        }) == 2)
+    );
+    assert!(
+        (({
+            let _c: u8 = ('\n' as u8);
+            switch_char_0(_c)
+        }) == 3)
+    );
+    assert!(
+        (({
+            let _c: u8 = ('\0' as u8);
+            switch_char_0(_c)
+        }) == 4)
+    );
+    assert!(
+        (({
+            let _c: u8 = ('z' as u8);
+            switch_char_0(_c)
+        }) == 0)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_complex_cond.rs
+++ b/tests/unit/out/refcount/switch_complex_cond.rs
@@ -1,0 +1,68 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn switch_complex_cond_0(p: Ptr<i32>, bias: i32) -> i32 {
+    let p: Value<Ptr<i32>> = Rc::new(RefCell::new(p));
+    let bias: Value<i32> = Rc::new(RefCell::new(bias));
+    'switch: {
+        let __match_cond = {
+            let _lhs = ((*p.borrow()).read());
+            _lhs + (*bias.borrow())
+        };
+        match __match_cond {
+            v if v == 0 => {
+                return 1;
+            }
+            v if v == 5 => {
+                return 2;
+            }
+            v if v == 10 => {
+                return 3;
+            }
+            _ => {
+                return 0;
+            }
+        }
+    };
+    panic!("ub: non-void function does not return a value")
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let p_val: Value<i32> = Rc::new(RefCell::new(5));
+    assert!(
+        (({
+            let _p: Ptr<i32> = (p_val.as_pointer());
+            let _bias: i32 = 0;
+            switch_complex_cond_0(_p, _bias)
+        }) == 2)
+    );
+    assert!(
+        (({
+            let _p: Ptr<i32> = (p_val.as_pointer());
+            let _bias: i32 = 5;
+            switch_complex_cond_0(_p, _bias)
+        }) == 3)
+    );
+    assert!(
+        (({
+            let _p: Ptr<i32> = (p_val.as_pointer());
+            let _bias: i32 = -5_i32;
+            switch_complex_cond_0(_p, _bias)
+        }) == 1)
+    );
+    assert!(
+        (({
+            let _p: Ptr<i32> = (p_val.as_pointer());
+            let _bias: i32 = 99;
+            switch_complex_cond_0(_p, _bias)
+        }) == 0)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_compound_case_body.rs
+++ b/tests/unit/out/refcount/switch_compound_case_body.rs
@@ -1,0 +1,57 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn compound_case_body_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    let r: Value<i32> = Rc::new(RefCell::new(0));
+    'switch: {
+        let __match_cond = (*x.borrow());
+        match __match_cond {
+            v if v == 1 => {
+                let y: Value<i32> = Rc::new(RefCell::new(10));
+                let z: Value<i32> = Rc::new(RefCell::new(20));
+                (*r.borrow_mut()) = ((*y.borrow()) + (*z.borrow()));
+                break 'switch;
+            }
+            v if v == 2 => {
+                let y: Value<i32> = Rc::new(RefCell::new(100));
+                (*r.borrow_mut()) = ((*y.borrow()) - 1);
+                break 'switch;
+            }
+            _ => {
+                (*r.borrow_mut()) = -1_i32;
+                break 'switch;
+            }
+        }
+    };
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = 1;
+            compound_case_body_0(_x)
+        }) == 30)
+    );
+    assert!(
+        (({
+            let _x: i32 = 2;
+            compound_case_body_0(_x)
+        }) == 99)
+    );
+    assert!(
+        (({
+            let _x: i32 = 9;
+            compound_case_body_0(_x)
+        }) == -1_i32)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_continue_inside_switch.rs
+++ b/tests/unit/out/refcount/switch_continue_inside_switch.rs
@@ -1,0 +1,43 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn continue_inside_switch_0(n: i32) -> i32 {
+    let n: Value<i32> = Rc::new(RefCell::new(n));
+    let r: Value<i32> = Rc::new(RefCell::new(0));
+    let i: Value<i32> = Rc::new(RefCell::new(0));
+    'loop_: while ((*i.borrow()) < (*n.borrow())) {
+        'switch: {
+            let __match_cond = (*i.borrow());
+            match __match_cond {
+                v if v == 0 || v == 2 || v == 4 => {
+                    (*i.borrow_mut()).prefix_inc();
+                    continue 'loop_;
+                }
+                _ => {
+                    (*r.borrow_mut()) += (*i.borrow());
+                    break 'switch;
+                }
+            }
+        };
+        (*r.borrow_mut()) += 1000;
+        (*i.borrow_mut()).prefix_inc();
+    }
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _n: i32 = 6;
+            continue_inside_switch_0(_n)
+        }) == ((((1 + 3) + 5) as i32) + (3 * 1000)))
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_default_first.rs
+++ b/tests/unit/out/refcount/switch_default_first.rs
@@ -1,0 +1,48 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn default_first_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    let r: Value<i32> = Rc::new(RefCell::new(0));
+    'switch: {
+        let __match_cond = (*x.borrow());
+        match __match_cond {
+            _ => {
+                (*r.borrow_mut()) = 7;
+                break 'switch;
+            }
+            v if v == 1 => {
+                (*r.borrow_mut()) = 1;
+                break 'switch;
+            }
+            v if v == 2 => {
+                (*r.borrow_mut()) = 2;
+                break 'switch;
+            }
+        }
+    };
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = 1;
+            default_first_0(_x)
+        }) == 1)
+    );
+    assert!(
+        (({
+            let _x: i32 = 99;
+            default_first_0(_x)
+        }) == 7)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_default_middle.rs
+++ b/tests/unit/out/refcount/switch_default_middle.rs
@@ -1,0 +1,54 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn default_middle_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    let r: Value<i32> = Rc::new(RefCell::new(0));
+    'switch: {
+        let __match_cond = (*x.borrow());
+        match __match_cond {
+            v if v == 1 => {
+                (*r.borrow_mut()) = 1;
+                break 'switch;
+            }
+            _ => {
+                (*r.borrow_mut()) = 99;
+                break 'switch;
+            }
+            v if v == 2 => {
+                (*r.borrow_mut()) = 2;
+                break 'switch;
+            }
+        }
+    };
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = 1;
+            default_middle_0(_x)
+        }) == 1)
+    );
+    assert!(
+        (({
+            let _x: i32 = 2;
+            default_middle_0(_x)
+        }) == 2)
+    );
+    assert!(
+        (({
+            let _x: i32 = 99;
+            default_middle_0(_x)
+        }) == 99)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_empty_case_with_break.rs
+++ b/tests/unit/out/refcount/switch_empty_case_with_break.rs
@@ -1,0 +1,53 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn empty_case_with_break_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    let r: Value<i32> = Rc::new(RefCell::new(5));
+    'switch: {
+        let __match_cond = (*x.borrow());
+        match __match_cond {
+            v if v == 1 => {
+                break 'switch;
+            }
+            v if v == 2 => {
+                (*r.borrow_mut()) = 2;
+                break 'switch;
+            }
+            _ => {
+                (*r.borrow_mut()) = 9;
+                break 'switch;
+            }
+        }
+    };
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = 1;
+            empty_case_with_break_0(_x)
+        }) == 5)
+    );
+    assert!(
+        (({
+            let _x: i32 = 2;
+            empty_case_with_break_0(_x)
+        }) == 2)
+    );
+    assert!(
+        (({
+            let _x: i32 = 9;
+            empty_case_with_break_0(_x)
+        }) == 9)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_empty_switch.rs
+++ b/tests/unit/out/refcount/switch_empty_switch.rs
@@ -1,0 +1,30 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn empty_switch_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    'switch: {
+        let __match_cond = (*x.borrow());
+        match __match_cond {
+            _ => {}
+        }
+    };
+    return (*x.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = 5;
+            empty_switch_0(_x)
+        }) == 5)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_enum.rs
+++ b/tests/unit/out/refcount/switch_enum.rs
@@ -1,0 +1,58 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+enum Color {
+    #[default]
+    kRed = 0,
+    kGreen = 1,
+    kBlue = 2,
+}
+pub fn switch_enum_0(c: Color) -> i32 {
+    let c: Value<Color> = Rc::new(RefCell::new(c));
+    'switch: {
+        let __match_cond = ((*c.borrow()) as i32);
+        match __match_cond {
+            v if v == (Color::kRed as i32) => {
+                return 10;
+            }
+            v if v == (Color::kGreen as i32) => {
+                return 20;
+            }
+            v if v == (Color::kBlue as i32) => {
+                return 30;
+            }
+            _ => {}
+        }
+    };
+    return -1_i32;
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _c: Color = Color::kRed;
+            switch_enum_0(_c)
+        }) == 10)
+    );
+    assert!(
+        (({
+            let _c: Color = Color::kGreen;
+            switch_enum_0(_c)
+        }) == 20)
+    );
+    assert!(
+        (({
+            let _c: Color = Color::kBlue;
+            switch_enum_0(_c)
+        }) == 30)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_fallthrough_chain.rs
+++ b/tests/unit/out/refcount/switch_fallthrough_chain.rs
@@ -1,0 +1,71 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn fallthrough_chain_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    let r: Value<i32> = Rc::new(RefCell::new(0));
+    'switch: {
+        let __match_cond = (*x.borrow());
+        match __match_cond {
+            v if v == 1 => {
+                (*r.borrow_mut()) += 1;
+            }
+            v if v == 2 => {
+                (*r.borrow_mut()) += 2;
+            }
+            v if v == 3 => {
+                (*r.borrow_mut()) += 4;
+            }
+            v if v == 4 => {
+                (*r.borrow_mut()) += 8;
+                break 'switch;
+            }
+            _ => {
+                (*r.borrow_mut()) = -1_i32;
+                break 'switch;
+            }
+        }
+    };
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = 1;
+            fallthrough_chain_0(_x)
+        }) == 15)
+    );
+    assert!(
+        (({
+            let _x: i32 = 2;
+            fallthrough_chain_0(_x)
+        }) == 14)
+    );
+    assert!(
+        (({
+            let _x: i32 = 3;
+            fallthrough_chain_0(_x)
+        }) == 12)
+    );
+    assert!(
+        (({
+            let _x: i32 = 4;
+            fallthrough_chain_0(_x)
+        }) == 8)
+    );
+    assert!(
+        (({
+            let _x: i32 = 99;
+            fallthrough_chain_0(_x)
+        }) == -1_i32)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_fallthrough_default.rs
+++ b/tests/unit/out/refcount/switch_fallthrough_default.rs
@@ -1,0 +1,56 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn fallthrough_default_0(x: i32, flag: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    let flag: Value<i32> = Rc::new(RefCell::new(flag));
+    let r: Value<i32> = Rc::new(RefCell::new(0));
+    'switch: {
+        let __match_cond = (*x.borrow());
+        match __match_cond {
+            v if v == 7 => {
+                if ((*flag.borrow()) != 0) {
+                    (*r.borrow_mut()) = 100;
+                    break 'switch;
+                };
+            }
+            _ => {
+                (*r.borrow_mut()) = 42;
+                break 'switch;
+            }
+        }
+    };
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = 7;
+            let _flag: i32 = 0;
+            fallthrough_default_0(_x, _flag)
+        }) == 42)
+    );
+    assert!(
+        (({
+            let _x: i32 = 7;
+            let _flag: i32 = 1;
+            fallthrough_default_0(_x, _flag)
+        }) == 100)
+    );
+    assert!(
+        (({
+            let _x: i32 = 99;
+            let _flag: i32 = 0;
+            fallthrough_default_0(_x, _flag)
+        }) == 42)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_fallthrough_into_block.rs
+++ b/tests/unit/out/refcount/switch_fallthrough_into_block.rs
@@ -1,0 +1,54 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn fallthrough_into_block_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    let r: Value<i32> = Rc::new(RefCell::new(0));
+    'switch: {
+        let __match_cond = (*x.borrow());
+        match __match_cond {
+            v if v == 1 => {
+                (*r.borrow_mut()) += 1;
+            }
+            v if v == 2 => {
+                let tmp: Value<i32> = Rc::new(RefCell::new(((*r.borrow()) * 10)));
+                (*r.borrow_mut()) = ((*tmp.borrow()) + 5);
+                break 'switch;
+            }
+            _ => {
+                (*r.borrow_mut()) = -1_i32;
+                break 'switch;
+            }
+        }
+    };
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = 1;
+            fallthrough_into_block_0(_x)
+        }) == 15)
+    );
+    assert!(
+        (({
+            let _x: i32 = 2;
+            fallthrough_into_block_0(_x)
+        }) == 5)
+    );
+    assert!(
+        (({
+            let _x: i32 = 99;
+            fallthrough_into_block_0(_x)
+        }) == -1_i32)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_fallthrough_one.rs
+++ b/tests/unit/out/refcount/switch_fallthrough_one.rs
@@ -1,0 +1,53 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn fallthrough_one_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    let r: Value<i32> = Rc::new(RefCell::new(0));
+    'switch: {
+        let __match_cond = (*x.borrow());
+        match __match_cond {
+            v if v == 1 => {
+                (*r.borrow_mut()) += 10;
+            }
+            v if v == 2 => {
+                (*r.borrow_mut()) += 20;
+                break 'switch;
+            }
+            _ => {
+                (*r.borrow_mut()) = -1_i32;
+                break 'switch;
+            }
+        }
+    };
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = 1;
+            fallthrough_one_0(_x)
+        }) == 30)
+    );
+    assert!(
+        (({
+            let _x: i32 = 2;
+            fallthrough_one_0(_x)
+        }) == 20)
+    );
+    assert!(
+        (({
+            let _x: i32 = 99;
+            fallthrough_one_0(_x)
+        }) == -1_i32)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_for_in_switch_break.rs
+++ b/tests/unit/out/refcount/switch_for_in_switch_break.rs
@@ -1,0 +1,52 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn for_in_switch_break_0(n: i32) -> i32 {
+    let n: Value<i32> = Rc::new(RefCell::new(n));
+    let r: Value<i32> = Rc::new(RefCell::new(0));
+    'switch: {
+        let __match_cond = (*n.borrow());
+        match __match_cond {
+            v if v == 0 => {
+                let i: Value<i32> = Rc::new(RefCell::new(0));
+                'loop_: while ((*i.borrow()) < 10) {
+                    if ((*i.borrow()) == 3) {
+                        break 'switch;
+                    }
+                    (*r.borrow_mut()) += (*i.borrow());
+                    (*i.borrow_mut()).prefix_inc();
+                }
+                (*r.borrow_mut()) += 100;
+                break 'switch;
+            }
+            _ => {
+                (*r.borrow_mut()) = -1_i32;
+                break 'switch;
+            }
+        }
+    };
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _n: i32 = 0;
+            for_in_switch_break_0(_n)
+        }) == 103)
+    );
+    assert!(
+        (({
+            let _n: i32 = 99;
+            for_in_switch_break_0(_n)
+        }) == -1_i32)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_for_in_switch_continue.rs
+++ b/tests/unit/out/refcount/switch_for_in_switch_continue.rs
@@ -1,0 +1,52 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn for_in_switch_continue_0(n: i32) -> i32 {
+    let n: Value<i32> = Rc::new(RefCell::new(n));
+    let r: Value<i32> = Rc::new(RefCell::new(0));
+    'switch: {
+        let __match_cond = (*n.borrow());
+        match __match_cond {
+            v if v == 0 => {
+                let i: Value<i32> = Rc::new(RefCell::new(0));
+                'loop_: while ((*i.borrow()) < 5) {
+                    if (((*i.borrow()) % 2) == 0) {
+                        (*i.borrow_mut()).prefix_inc();
+                        continue 'loop_;
+                    }
+                    (*r.borrow_mut()) += (*i.borrow());
+                    (*i.borrow_mut()).prefix_inc();
+                }
+                break 'switch;
+            }
+            _ => {
+                (*r.borrow_mut()) = -1_i32;
+                break 'switch;
+            }
+        }
+    };
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _n: i32 = 0;
+            for_in_switch_continue_0(_n)
+        }) == 4)
+    );
+    assert!(
+        (({
+            let _n: i32 = 99;
+            for_in_switch_continue_0(_n)
+        }) == -1_i32)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_for_switch_for_break.rs
+++ b/tests/unit/out/refcount/switch_for_switch_for_break.rs
@@ -1,0 +1,50 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn for_switch_for_break_0(n: i32) -> i32 {
+    let n: Value<i32> = Rc::new(RefCell::new(n));
+    let r: Value<i32> = Rc::new(RefCell::new(0));
+    let i: Value<i32> = Rc::new(RefCell::new(0));
+    'loop_: while ((*i.borrow()) < (*n.borrow())) {
+        'switch: {
+            let __match_cond = (*i.borrow());
+            match __match_cond {
+                v if v == 1 => {
+                    let j: Value<i32> = Rc::new(RefCell::new(0));
+                    'loop_: while ((*j.borrow()) < 10) {
+                        if ((*j.borrow()) == 2) {
+                            break 'switch;
+                        }
+                        (*r.borrow_mut()) += 1;
+                        (*j.borrow_mut()).prefix_inc();
+                    }
+                    (*r.borrow_mut()) += 100;
+                    break 'switch;
+                }
+                _ => {
+                    (*r.borrow_mut()) += 10;
+                    break 'switch;
+                }
+            }
+        };
+        (*i.borrow_mut()).prefix_inc();
+    }
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _n: i32 = 3;
+            for_switch_for_break_0(_n)
+        }) == 122)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_in_dowhile.rs
+++ b/tests/unit/out/refcount/switch_in_dowhile.rs
@@ -1,0 +1,55 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn switch_in_dowhile_0(n: i32) -> i32 {
+    let n: Value<i32> = Rc::new(RefCell::new(n));
+    let r: Value<i32> = Rc::new(RefCell::new(0));
+    let i: Value<i32> = Rc::new(RefCell::new(0));
+    'loop_: loop {
+        'switch: {
+            let __match_cond = (*i.borrow());
+            match __match_cond {
+                v if v == 0 => {
+                    (*r.borrow_mut()) += 1;
+                    break 'switch;
+                }
+                v if v == 1 => {
+                    (*r.borrow_mut()) += 10;
+                    break 'switch;
+                }
+                _ => {
+                    (*r.borrow_mut()) += 100;
+                    break 'switch;
+                }
+            }
+        };
+        (*i.borrow_mut()).prefix_inc();
+        if !((*i.borrow()) < (*n.borrow())) {
+            break;
+        }
+    }
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _n: i32 = 1;
+            switch_in_dowhile_0(_n)
+        }) == 1)
+    );
+    assert!(
+        (({
+            let _n: i32 = 3;
+            switch_in_dowhile_0(_n)
+        }) == ((1 + 10) + 100))
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_in_loop.rs
+++ b/tests/unit/out/refcount/switch_in_loop.rs
@@ -1,0 +1,47 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn switch_in_loop_0(n: i32) -> i32 {
+    let n: Value<i32> = Rc::new(RefCell::new(n));
+    let r: Value<i32> = Rc::new(RefCell::new(0));
+    let i: Value<i32> = Rc::new(RefCell::new(0));
+    'loop_: while ((*i.borrow()) < (*n.borrow())) {
+        'switch: {
+            let __match_cond = ((*i.borrow()) % 3);
+            match __match_cond {
+                v if v == 0 => {
+                    (*r.borrow_mut()) += 1;
+                    break 'switch;
+                }
+                v if v == 1 => {
+                    (*r.borrow_mut()) += 2;
+                    break 'switch;
+                }
+                _ => {
+                    (*r.borrow_mut()) += 3;
+                    break 'switch;
+                }
+            }
+        };
+        (*r.borrow_mut()) += 10;
+        (*i.borrow_mut()).prefix_inc();
+    }
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _n: i32 = 6;
+            switch_in_loop_0(_n)
+        }) == 72)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_mixed_literal_cases.rs
+++ b/tests/unit/out/refcount/switch_mixed_literal_cases.rs
@@ -1,0 +1,68 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn mixed_literal_cases_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    'switch: {
+        let __match_cond = (*x.borrow());
+        match __match_cond {
+            v if v == -1_i32 => {
+                return 1;
+            }
+            v if v == 16 => {
+                return 2;
+            }
+            v if v == 65152 => {
+                return 3;
+            }
+            v if v == -255_i32 => {
+                return 4;
+            }
+            _ => {
+                return 0;
+            }
+        }
+    };
+    panic!("ub: non-void function does not return a value")
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = -1_i32;
+            mixed_literal_cases_0(_x)
+        }) == 1)
+    );
+    assert!(
+        (({
+            let _x: i32 = 16;
+            mixed_literal_cases_0(_x)
+        }) == 2)
+    );
+    assert!(
+        (({
+            let _x: i32 = 65152;
+            mixed_literal_cases_0(_x)
+        }) == 3)
+    );
+    assert!(
+        (({
+            let _x: i32 = -255_i32;
+            mixed_literal_cases_0(_x)
+        }) == 4)
+    );
+    assert!(
+        (({
+            let _x: i32 = 7;
+            mixed_literal_cases_0(_x)
+        }) == 0)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_mixed_return_break.rs
+++ b/tests/unit/out/refcount/switch_mixed_return_break.rs
@@ -1,0 +1,62 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn mixed_return_break_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    let r: Value<i32> = Rc::new(RefCell::new(-1_i32));
+    'switch: {
+        let __match_cond = (*x.borrow());
+        match __match_cond {
+            v if v == 0 => {
+                return 100;
+            }
+            v if v == 1 => {
+                (*r.borrow_mut()) = 10;
+                break 'switch;
+            }
+            v if v == 2 => {
+                return 200;
+            }
+            _ => {
+                (*r.borrow_mut()) = 99;
+                break 'switch;
+            }
+        }
+    };
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = 0;
+            mixed_return_break_0(_x)
+        }) == 100)
+    );
+    assert!(
+        (({
+            let _x: i32 = 1;
+            mixed_return_break_0(_x)
+        }) == 10)
+    );
+    assert!(
+        (({
+            let _x: i32 = 2;
+            mixed_return_break_0(_x)
+        }) == 200)
+    );
+    assert!(
+        (({
+            let _x: i32 = 99;
+            mixed_return_break_0(_x)
+        }) == 99)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_nested.rs
+++ b/tests/unit/out/refcount/switch_nested.rs
@@ -1,0 +1,82 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn nested_0(a: i32, b: i32) -> i32 {
+    let a: Value<i32> = Rc::new(RefCell::new(a));
+    let b: Value<i32> = Rc::new(RefCell::new(b));
+    let r: Value<i32> = Rc::new(RefCell::new(0));
+    'switch: {
+        let __match_cond = (*a.borrow());
+        match __match_cond {
+            v if v == 1 => {
+                'switch: {
+                    let __match_cond = (*b.borrow());
+                    match __match_cond {
+                        v if v == 10 => {
+                            (*r.borrow_mut()) = 11;
+                            break 'switch;
+                        }
+                        v if v == 20 => {
+                            (*r.borrow_mut()) = 12;
+                            break 'switch;
+                        }
+                        _ => {
+                            (*r.borrow_mut()) = 13;
+                            break 'switch;
+                        }
+                    }
+                };
+                (*r.borrow_mut()) += 1;
+                break;
+            }
+            v if v == 2 => {
+                (*r.borrow_mut()) = 2;
+                break;
+            }
+            _ => {
+                (*r.borrow_mut()) = -1_i32;
+                break;
+            }
+        }
+    };
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _a: i32 = 1;
+            let _b: i32 = 10;
+            nested_0(_a, _b)
+        }) == 12)
+    );
+    assert!(
+        (({
+            let _a: i32 = 1;
+            let _b: i32 = 99;
+            nested_0(_a, _b)
+        }) == 14)
+    );
+    assert!(
+        (({
+            let _a: i32 = 2;
+            let _b: i32 = 0;
+            nested_0(_a, _b)
+        }) == 2)
+    );
+    assert!(
+        (({
+            let _a: i32 = 3;
+            let _b: i32 = 3;
+            nested_0(_a, _b)
+        }) == -1_i32)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_no_default.rs
+++ b/tests/unit/out/refcount/switch_no_default.rs
@@ -1,0 +1,45 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn no_default_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    let r: Value<i32> = Rc::new(RefCell::new(-1_i32));
+    'switch: {
+        let __match_cond = (*x.borrow());
+        match __match_cond {
+            v if v == 7 => {
+                (*r.borrow_mut()) = 1;
+                break 'switch;
+            }
+            v if v == 8 => {
+                (*r.borrow_mut()) = 2;
+                break 'switch;
+            }
+            _ => {}
+        }
+    };
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = 7;
+            no_default_0(_x)
+        }) == 1)
+    );
+    assert!(
+        (({
+            let _x: i32 = 42;
+            no_default_0(_x)
+        }) == -1_i32)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_on_assignment.rs
+++ b/tests/unit/out/refcount/switch_on_assignment.rs
@@ -1,0 +1,58 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn switch_on_assignment_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    let y: Value<i32> = Rc::new(RefCell::new(0));
+    let r: Value<i32> = Rc::new(RefCell::new(0));
+    'switch: {
+        let __match_cond = {
+            (*y.borrow_mut()) = ((*x.borrow()) + 1);
+            (*y.borrow())
+        };
+        match __match_cond {
+            v if v == 1 => {
+                (*r.borrow_mut()) = 10;
+                break 'switch;
+            }
+            v if v == 2 => {
+                (*r.borrow_mut()) = 20;
+                break 'switch;
+            }
+            _ => {
+                (*r.borrow_mut()) = (*y.borrow());
+                break 'switch;
+            }
+        }
+    };
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = 0;
+            switch_on_assignment_0(_x)
+        }) == 10)
+    );
+    assert!(
+        (({
+            let _x: i32 = 1;
+            switch_on_assignment_0(_x)
+        }) == 20)
+    );
+    assert!(
+        (({
+            let _x: i32 = 9;
+            switch_on_assignment_0(_x)
+        }) == 10)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_on_call.rs
+++ b/tests/unit/out/refcount/switch_on_call.rs
@@ -1,0 +1,66 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn double_it_0(v: i32) -> i32 {
+    let v: Value<i32> = Rc::new(RefCell::new(v));
+    return ((*v.borrow()) * 2);
+}
+pub fn switch_on_call_1(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    'switch: {
+        let __match_cond = ({
+            let _v: i32 = (*x.borrow());
+            double_it_0(_v)
+        });
+        match __match_cond {
+            v if v == 0 => {
+                return 100;
+            }
+            v if v == 2 => {
+                return 200;
+            }
+            v if v == 4 => {
+                return 400;
+            }
+            _ => {
+                return -1_i32;
+            }
+        }
+    };
+    panic!("ub: non-void function does not return a value")
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = 0;
+            switch_on_call_1(_x)
+        }) == 100)
+    );
+    assert!(
+        (({
+            let _x: i32 = 1;
+            switch_on_call_1(_x)
+        }) == 200)
+    );
+    assert!(
+        (({
+            let _x: i32 = 2;
+            switch_on_call_1(_x)
+        }) == 400)
+    );
+    assert!(
+        (({
+            let _x: i32 = 99;
+            switch_on_call_1(_x)
+        }) == -1_i32)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_only_default.rs
+++ b/tests/unit/out/refcount/switch_only_default.rs
@@ -1,0 +1,34 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn only_default_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    let r: Value<i32> = Rc::new(RefCell::new(0));
+    'switch: {
+        let __match_cond = (*x.borrow());
+        match __match_cond {
+            _ => {
+                (*r.borrow_mut()) = 42;
+                break 'switch;
+            }
+        }
+    };
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = 1;
+            only_default_0(_x)
+        }) == 42)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_stacked.rs
+++ b/tests/unit/out/refcount/switch_stacked.rs
@@ -1,0 +1,60 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn stacked_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    let r: Value<i32> = Rc::new(RefCell::new(0));
+    'switch: {
+        let __match_cond = (*x.borrow());
+        match __match_cond {
+            v if v == 1 || v == 2 || v == 3 => {
+                (*r.borrow_mut()) = 100;
+                break 'switch;
+            }
+            v if v == 4 || v == 5 => {
+                (*r.borrow_mut()) = 200;
+                break 'switch;
+            }
+            _ => {
+                (*r.borrow_mut()) = 300;
+                break 'switch;
+            }
+        }
+    };
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = 1;
+            stacked_0(_x)
+        }) == 100)
+    );
+    assert!(
+        (({
+            let _x: i32 = 3;
+            stacked_0(_x)
+        }) == 100)
+    );
+    assert!(
+        (({
+            let _x: i32 = 5;
+            stacked_0(_x)
+        }) == 200)
+    );
+    assert!(
+        (({
+            let _x: i32 = 9;
+            stacked_0(_x)
+        }) == 300)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_stacked_block.rs
+++ b/tests/unit/out/refcount/switch_stacked_block.rs
@@ -1,0 +1,45 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn stacked_block_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    let r: Value<i32> = Rc::new(RefCell::new(0));
+    'switch: {
+        let __match_cond = (*x.borrow());
+        match __match_cond {
+            v if v == 1 || v == 2 || v == 3 => {
+                let y: Value<i32> = Rc::new(RefCell::new(((*x.borrow()) * 2)));
+                (*r.borrow_mut()) = ((*y.borrow()) + 1);
+                break 'switch;
+            }
+            _ => {
+                (*r.borrow_mut()) = 0;
+                break 'switch;
+            }
+        }
+    };
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = 2;
+            stacked_block_0(_x)
+        }) == 5)
+    );
+    assert!(
+        (({
+            let _x: i32 = 9;
+            stacked_block_0(_x)
+        }) == 0)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_stacked_with_inner_fallthrough.rs
+++ b/tests/unit/out/refcount/switch_stacked_with_inner_fallthrough.rs
@@ -1,0 +1,56 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn stacked_with_inner_fallthrough_0(x: i32, flag: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    let flag: Value<i32> = Rc::new(RefCell::new(flag));
+    let r: Value<i32> = Rc::new(RefCell::new(0));
+    'switch: {
+        let __match_cond = (*x.borrow());
+        match __match_cond {
+            v if v == 1 || v == 2 || v == 3 => {
+                if !((*flag.borrow()) != 0) {
+                    (*r.borrow_mut()) = 50;
+                    break 'switch;
+                };
+            }
+            _ => {
+                (*r.borrow_mut()) = 999;
+                break 'switch;
+            }
+        }
+    };
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _x: i32 = 1;
+            let _flag: i32 = 0;
+            stacked_with_inner_fallthrough_0(_x, _flag)
+        }) == 50)
+    );
+    assert!(
+        (({
+            let _x: i32 = 2;
+            let _flag: i32 = 1;
+            stacked_with_inner_fallthrough_0(_x, _flag)
+        }) == 999)
+    );
+    assert!(
+        (({
+            let _x: i32 = 99;
+            let _flag: i32 = 0;
+            stacked_with_inner_fallthrough_0(_x, _flag)
+        }) == 999)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_while_in_switch_break.rs
+++ b/tests/unit/out/refcount/switch_while_in_switch_break.rs
@@ -1,0 +1,52 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn while_in_switch_break_0(n: i32) -> i32 {
+    let n: Value<i32> = Rc::new(RefCell::new(n));
+    let r: Value<i32> = Rc::new(RefCell::new(0));
+    'switch: {
+        let __match_cond = (*n.borrow());
+        match __match_cond {
+            v if v == 0 => {
+                let i: Value<i32> = Rc::new(RefCell::new(0));
+                'loop_: while ((*i.borrow()) < 10) {
+                    if ((*i.borrow()) == 4) {
+                        break 'switch;
+                    }
+                    (*r.borrow_mut()) += (*i.borrow());
+                    (*i.borrow_mut()).prefix_inc();
+                }
+                (*r.borrow_mut()) += 1000;
+                break 'switch;
+            }
+            _ => {
+                (*r.borrow_mut()) = -1_i32;
+                break 'switch;
+            }
+        }
+    };
+    return (*r.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _n: i32 = 0;
+            while_in_switch_break_0(_n)
+        }) == 1006)
+    );
+    assert!(
+        (({
+            let _n: i32 = 99;
+            while_in_switch_break_0(_n)
+        }) == -1_i32)
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_basic.rs
+++ b/tests/unit/out/unsafe/switch_basic.rs
@@ -1,0 +1,59 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn basic_0(mut x: i32) -> i32 {
+    let mut r: i32 = 0;
+    'switch: {
+        let __match_cond = x;
+        match __match_cond {
+            v if v == 0 => {
+                r = 10;
+                break 'switch;
+            }
+            v if v == 1 => {
+                r = 20;
+                break 'switch;
+            }
+            v if v == 2 => {
+                r = 30;
+                break 'switch;
+            }
+            _ => {
+                r = 40;
+                break 'switch;
+            }
+        }
+    };
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = 0;
+            basic_0(_x)
+        }) == (10))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 2;
+            basic_0(_x)
+        }) == (30))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 99;
+            basic_0(_x)
+        }) == (40))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_borrow_in_condition_and_in_body.rs
+++ b/tests/unit/out/unsafe/switch_borrow_in_condition_and_in_body.rs
@@ -1,0 +1,40 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn borrow_in_condition_and_in_body_0(mut x: i32) -> i32 {
+    'switch: {
+        let __match_cond = x;
+        match __match_cond {
+            v if v == 0 => {}
+            _ => {
+                return ((x) + (1));
+            }
+        }
+    };
+    panic!("ub: non-void function does not return a value")
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = 0;
+            borrow_in_condition_and_in_body_0(_x)
+        }) == (1))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 1;
+            borrow_in_condition_and_in_body_0(_x)
+        }) == (2))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_char.rs
+++ b/tests/unit/out/unsafe/switch_char.rs
@@ -1,0 +1,76 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn switch_char_0(mut c: u8) -> i32 {
+    'switch: {
+        let __match_cond = (c as i32);
+        match __match_cond {
+            v if v == (('a' as u8) as i32) => {
+                return 1;
+            }
+            v if v == (('b' as u8) as i32) => {
+                return 2;
+            }
+            v if v == (('\n' as u8) as i32) => {
+                return 3;
+            }
+            v if v == (('\0' as u8) as i32) => {
+                return 4;
+            }
+            _ => {
+                return 0;
+            }
+        }
+    };
+    panic!("ub: non-void function does not return a value")
+}
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+enum Color {
+    #[default]
+    kRed = 0,
+    kGreen = 1,
+    kBlue = 2,
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _c: u8 = ('a' as u8);
+            switch_char_0(_c)
+        }) == (1))
+    );
+    assert!(
+        ((unsafe {
+            let _c: u8 = ('b' as u8);
+            switch_char_0(_c)
+        }) == (2))
+    );
+    assert!(
+        ((unsafe {
+            let _c: u8 = ('\n' as u8);
+            switch_char_0(_c)
+        }) == (3))
+    );
+    assert!(
+        ((unsafe {
+            let _c: u8 = ('\0' as u8);
+            switch_char_0(_c)
+        }) == (4))
+    );
+    assert!(
+        ((unsafe {
+            let _c: u8 = ('z' as u8);
+            switch_char_0(_c)
+        }) == (0))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_complex_cond.rs
+++ b/tests/unit/out/unsafe/switch_complex_cond.rs
@@ -1,0 +1,65 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn switch_complex_cond_0(mut p: *mut i32, mut bias: i32) -> i32 {
+    'switch: {
+        let __match_cond = ((*p) + (bias));
+        match __match_cond {
+            v if v == 0 => {
+                return 1;
+            }
+            v if v == 5 => {
+                return 2;
+            }
+            v if v == 10 => {
+                return 3;
+            }
+            _ => {
+                return 0;
+            }
+        }
+    };
+    panic!("ub: non-void function does not return a value")
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut p_val: i32 = 5;
+    assert!(
+        ((unsafe {
+            let _p: *mut i32 = (&mut p_val as *mut i32);
+            let _bias: i32 = 0;
+            switch_complex_cond_0(_p, _bias)
+        }) == (2))
+    );
+    assert!(
+        ((unsafe {
+            let _p: *mut i32 = (&mut p_val as *mut i32);
+            let _bias: i32 = 5;
+            switch_complex_cond_0(_p, _bias)
+        }) == (3))
+    );
+    assert!(
+        ((unsafe {
+            let _p: *mut i32 = (&mut p_val as *mut i32);
+            let _bias: i32 = -5_i32;
+            switch_complex_cond_0(_p, _bias)
+        }) == (1))
+    );
+    assert!(
+        ((unsafe {
+            let _p: *mut i32 = (&mut p_val as *mut i32);
+            let _bias: i32 = 99;
+            switch_complex_cond_0(_p, _bias)
+        }) == (0))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_compound_case_body.rs
+++ b/tests/unit/out/unsafe/switch_compound_case_body.rs
@@ -1,0 +1,58 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn compound_case_body_0(mut x: i32) -> i32 {
+    let mut r: i32 = 0;
+    'switch: {
+        let __match_cond = x;
+        match __match_cond {
+            v if v == 1 => {
+                let mut y: i32 = 10;
+                let mut z: i32 = 20;
+                r = ((y) + (z));
+                break 'switch;
+            }
+            v if v == 2 => {
+                let mut y: i32 = 100;
+                r = ((y) - (1));
+                break 'switch;
+            }
+            _ => {
+                r = -1_i32;
+                break 'switch;
+            }
+        }
+    };
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = 1;
+            compound_case_body_0(_x)
+        }) == (30))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 2;
+            compound_case_body_0(_x)
+        }) == (99))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 9;
+            compound_case_body_0(_x)
+        }) == (-1_i32))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_continue_inside_switch.rs
+++ b/tests/unit/out/unsafe/switch_continue_inside_switch.rs
@@ -1,0 +1,44 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn continue_inside_switch_0(mut n: i32) -> i32 {
+    let mut r: i32 = 0;
+    let mut i: i32 = 0;
+    'loop_: while ((i) < (n)) {
+        'switch: {
+            let __match_cond = i;
+            match __match_cond {
+                v if v == 0 || v == 2 || v == 4 => {
+                    i.prefix_inc();
+                    continue 'loop_;
+                }
+                _ => {
+                    r += i;
+                    break 'switch;
+                }
+            }
+        };
+        r += 1000;
+        i.prefix_inc();
+    }
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _n: i32 = 6;
+            continue_inside_switch_0(_n)
+        }) == (((((1) + (3)) + (5)) as i32) + ((3) * (1000))))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_default_first.rs
+++ b/tests/unit/out/unsafe/switch_default_first.rs
@@ -1,0 +1,49 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn default_first_0(mut x: i32) -> i32 {
+    let mut r: i32 = 0;
+    'switch: {
+        let __match_cond = x;
+        match __match_cond {
+            _ => {
+                r = 7;
+                break 'switch;
+            }
+            v if v == 1 => {
+                r = 1;
+                break 'switch;
+            }
+            v if v == 2 => {
+                r = 2;
+                break 'switch;
+            }
+        }
+    };
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = 1;
+            default_first_0(_x)
+        }) == (1))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 99;
+            default_first_0(_x)
+        }) == (7))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_default_middle.rs
+++ b/tests/unit/out/unsafe/switch_default_middle.rs
@@ -1,0 +1,55 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn default_middle_0(mut x: i32) -> i32 {
+    let mut r: i32 = 0;
+    'switch: {
+        let __match_cond = x;
+        match __match_cond {
+            v if v == 1 => {
+                r = 1;
+                break 'switch;
+            }
+            _ => {
+                r = 99;
+                break 'switch;
+            }
+            v if v == 2 => {
+                r = 2;
+                break 'switch;
+            }
+        }
+    };
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = 1;
+            default_middle_0(_x)
+        }) == (1))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 2;
+            default_middle_0(_x)
+        }) == (2))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 99;
+            default_middle_0(_x)
+        }) == (99))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_empty_case_with_break.rs
+++ b/tests/unit/out/unsafe/switch_empty_case_with_break.rs
@@ -1,0 +1,54 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn empty_case_with_break_0(mut x: i32) -> i32 {
+    let mut r: i32 = 5;
+    'switch: {
+        let __match_cond = x;
+        match __match_cond {
+            v if v == 1 => {
+                break 'switch;
+            }
+            v if v == 2 => {
+                r = 2;
+                break 'switch;
+            }
+            _ => {
+                r = 9;
+                break 'switch;
+            }
+        }
+    };
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = 1;
+            empty_case_with_break_0(_x)
+        }) == (5))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 2;
+            empty_case_with_break_0(_x)
+        }) == (2))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 9;
+            empty_case_with_break_0(_x)
+        }) == (9))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_empty_switch.rs
+++ b/tests/unit/out/unsafe/switch_empty_switch.rs
@@ -1,0 +1,31 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn empty_switch_0(mut x: i32) -> i32 {
+    'switch: {
+        let __match_cond = x;
+        match __match_cond {
+            _ => {}
+        }
+    };
+    return x;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = 5;
+            empty_switch_0(_x)
+        }) == (5))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_enum.rs
+++ b/tests/unit/out/unsafe/switch_enum.rs
@@ -1,0 +1,59 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+enum Color {
+    #[default]
+    kRed = 0,
+    kGreen = 1,
+    kBlue = 2,
+}
+pub unsafe fn switch_enum_0(mut c: Color) -> i32 {
+    'switch: {
+        let __match_cond = (c as i32);
+        match __match_cond {
+            v if v == (Color::kRed as i32) => {
+                return 10;
+            }
+            v if v == (Color::kGreen as i32) => {
+                return 20;
+            }
+            v if v == (Color::kBlue as i32) => {
+                return 30;
+            }
+            _ => {}
+        }
+    };
+    return -1_i32;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _c: Color = Color::kRed;
+            switch_enum_0(_c)
+        }) == (10))
+    );
+    assert!(
+        ((unsafe {
+            let _c: Color = Color::kGreen;
+            switch_enum_0(_c)
+        }) == (20))
+    );
+    assert!(
+        ((unsafe {
+            let _c: Color = Color::kBlue;
+            switch_enum_0(_c)
+        }) == (30))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_fallthrough_chain.rs
+++ b/tests/unit/out/unsafe/switch_fallthrough_chain.rs
@@ -1,0 +1,72 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn fallthrough_chain_0(mut x: i32) -> i32 {
+    let mut r: i32 = 0;
+    'switch: {
+        let __match_cond = x;
+        match __match_cond {
+            v if v == 1 => {
+                r += 1;
+            }
+            v if v == 2 => {
+                r += 2;
+            }
+            v if v == 3 => {
+                r += 4;
+            }
+            v if v == 4 => {
+                r += 8;
+                break 'switch;
+            }
+            _ => {
+                r = -1_i32;
+                break 'switch;
+            }
+        }
+    };
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = 1;
+            fallthrough_chain_0(_x)
+        }) == (15))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 2;
+            fallthrough_chain_0(_x)
+        }) == (14))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 3;
+            fallthrough_chain_0(_x)
+        }) == (12))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 4;
+            fallthrough_chain_0(_x)
+        }) == (8))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 99;
+            fallthrough_chain_0(_x)
+        }) == (-1_i32))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_fallthrough_default.rs
+++ b/tests/unit/out/unsafe/switch_fallthrough_default.rs
@@ -1,0 +1,56 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn fallthrough_default_0(mut x: i32, mut flag: i32) -> i32 {
+    let mut r: i32 = 0;
+    'switch: {
+        let __match_cond = x;
+        match __match_cond {
+            v if v == 7 => {
+                if (flag != 0) {
+                    r = 100;
+                    break 'switch;
+                };
+            }
+            _ => {
+                r = 42;
+                break 'switch;
+            }
+        }
+    };
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = 7;
+            let _flag: i32 = 0;
+            fallthrough_default_0(_x, _flag)
+        }) == (42))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 7;
+            let _flag: i32 = 1;
+            fallthrough_default_0(_x, _flag)
+        }) == (100))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 99;
+            let _flag: i32 = 0;
+            fallthrough_default_0(_x, _flag)
+        }) == (42))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_fallthrough_into_block.rs
+++ b/tests/unit/out/unsafe/switch_fallthrough_into_block.rs
@@ -1,0 +1,55 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn fallthrough_into_block_0(mut x: i32) -> i32 {
+    let mut r: i32 = 0;
+    'switch: {
+        let __match_cond = x;
+        match __match_cond {
+            v if v == 1 => {
+                r += 1;
+            }
+            v if v == 2 => {
+                let mut tmp: i32 = ((r) * (10));
+                r = ((tmp) + (5));
+                break 'switch;
+            }
+            _ => {
+                r = -1_i32;
+                break 'switch;
+            }
+        }
+    };
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = 1;
+            fallthrough_into_block_0(_x)
+        }) == (15))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 2;
+            fallthrough_into_block_0(_x)
+        }) == (5))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 99;
+            fallthrough_into_block_0(_x)
+        }) == (-1_i32))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_fallthrough_one.rs
+++ b/tests/unit/out/unsafe/switch_fallthrough_one.rs
@@ -1,0 +1,54 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn fallthrough_one_0(mut x: i32) -> i32 {
+    let mut r: i32 = 0;
+    'switch: {
+        let __match_cond = x;
+        match __match_cond {
+            v if v == 1 => {
+                r += 10;
+            }
+            v if v == 2 => {
+                r += 20;
+                break 'switch;
+            }
+            _ => {
+                r = -1_i32;
+                break 'switch;
+            }
+        }
+    };
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = 1;
+            fallthrough_one_0(_x)
+        }) == (30))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 2;
+            fallthrough_one_0(_x)
+        }) == (20))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 99;
+            fallthrough_one_0(_x)
+        }) == (-1_i32))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_for_in_switch_break.rs
+++ b/tests/unit/out/unsafe/switch_for_in_switch_break.rs
@@ -1,0 +1,53 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn for_in_switch_break_0(mut n: i32) -> i32 {
+    let mut r: i32 = 0;
+    'switch: {
+        let __match_cond = n;
+        match __match_cond {
+            v if v == 0 => {
+                let mut i: i32 = 0;
+                'loop_: while ((i) < (10)) {
+                    if ((i) == (3)) {
+                        break 'switch;
+                    }
+                    r += i;
+                    i.prefix_inc();
+                }
+                r += 100;
+                break 'switch;
+            }
+            _ => {
+                r = -1_i32;
+                break 'switch;
+            }
+        }
+    };
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _n: i32 = 0;
+            for_in_switch_break_0(_n)
+        }) == (103))
+    );
+    assert!(
+        ((unsafe {
+            let _n: i32 = 99;
+            for_in_switch_break_0(_n)
+        }) == (-1_i32))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_for_in_switch_continue.rs
+++ b/tests/unit/out/unsafe/switch_for_in_switch_continue.rs
@@ -1,0 +1,53 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn for_in_switch_continue_0(mut n: i32) -> i32 {
+    let mut r: i32 = 0;
+    'switch: {
+        let __match_cond = n;
+        match __match_cond {
+            v if v == 0 => {
+                let mut i: i32 = 0;
+                'loop_: while ((i) < (5)) {
+                    if (((i) % (2)) == (0)) {
+                        i.prefix_inc();
+                        continue 'loop_;
+                    }
+                    r += i;
+                    i.prefix_inc();
+                }
+                break 'switch;
+            }
+            _ => {
+                r = -1_i32;
+                break 'switch;
+            }
+        }
+    };
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _n: i32 = 0;
+            for_in_switch_continue_0(_n)
+        }) == (4))
+    );
+    assert!(
+        ((unsafe {
+            let _n: i32 = 99;
+            for_in_switch_continue_0(_n)
+        }) == (-1_i32))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_for_switch_for_break.rs
+++ b/tests/unit/out/unsafe/switch_for_switch_for_break.rs
@@ -1,0 +1,51 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn for_switch_for_break_0(mut n: i32) -> i32 {
+    let mut r: i32 = 0;
+    let mut i: i32 = 0;
+    'loop_: while ((i) < (n)) {
+        'switch: {
+            let __match_cond = i;
+            match __match_cond {
+                v if v == 1 => {
+                    let mut j: i32 = 0;
+                    'loop_: while ((j) < (10)) {
+                        if ((j) == (2)) {
+                            break 'switch;
+                        }
+                        r += 1;
+                        j.prefix_inc();
+                    }
+                    r += 100;
+                    break 'switch;
+                }
+                _ => {
+                    r += 10;
+                    break 'switch;
+                }
+            }
+        };
+        i.prefix_inc();
+    }
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _n: i32 = 3;
+            for_switch_for_break_0(_n)
+        }) == (122))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_in_dowhile.rs
+++ b/tests/unit/out/unsafe/switch_in_dowhile.rs
@@ -1,0 +1,56 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn switch_in_dowhile_0(mut n: i32) -> i32 {
+    let mut r: i32 = 0;
+    let mut i: i32 = 0;
+    'loop_: loop {
+        'switch: {
+            let __match_cond = i;
+            match __match_cond {
+                v if v == 0 => {
+                    r += 1;
+                    break 'switch;
+                }
+                v if v == 1 => {
+                    r += 10;
+                    break 'switch;
+                }
+                _ => {
+                    r += 100;
+                    break 'switch;
+                }
+            }
+        };
+        i.prefix_inc();
+        if !((i) < (n)) {
+            break;
+        }
+    }
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _n: i32 = 1;
+            switch_in_dowhile_0(_n)
+        }) == (1))
+    );
+    assert!(
+        ((unsafe {
+            let _n: i32 = 3;
+            switch_in_dowhile_0(_n)
+        }) == (((1) + (10)) + (100)))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_in_loop.rs
+++ b/tests/unit/out/unsafe/switch_in_loop.rs
@@ -1,0 +1,48 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn switch_in_loop_0(mut n: i32) -> i32 {
+    let mut r: i32 = 0;
+    let mut i: i32 = 0;
+    'loop_: while ((i) < (n)) {
+        'switch: {
+            let __match_cond = ((i) % (3));
+            match __match_cond {
+                v if v == 0 => {
+                    r += 1;
+                    break 'switch;
+                }
+                v if v == 1 => {
+                    r += 2;
+                    break 'switch;
+                }
+                _ => {
+                    r += 3;
+                    break 'switch;
+                }
+            }
+        };
+        r += 10;
+        i.prefix_inc();
+    }
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _n: i32 = 6;
+            switch_in_loop_0(_n)
+        }) == (72))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_mixed_literal_cases.rs
+++ b/tests/unit/out/unsafe/switch_mixed_literal_cases.rs
@@ -1,0 +1,69 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn mixed_literal_cases_0(mut x: i32) -> i32 {
+    'switch: {
+        let __match_cond = x;
+        match __match_cond {
+            v if v == -1_i32 => {
+                return 1;
+            }
+            v if v == 16 => {
+                return 2;
+            }
+            v if v == 65152 => {
+                return 3;
+            }
+            v if v == -255_i32 => {
+                return 4;
+            }
+            _ => {
+                return 0;
+            }
+        }
+    };
+    panic!("ub: non-void function does not return a value")
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = -1_i32;
+            mixed_literal_cases_0(_x)
+        }) == (1))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 16;
+            mixed_literal_cases_0(_x)
+        }) == (2))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 65152;
+            mixed_literal_cases_0(_x)
+        }) == (3))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = -255_i32;
+            mixed_literal_cases_0(_x)
+        }) == (4))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 7;
+            mixed_literal_cases_0(_x)
+        }) == (0))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_mixed_return_break.rs
+++ b/tests/unit/out/unsafe/switch_mixed_return_break.rs
@@ -1,0 +1,63 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn mixed_return_break_0(mut x: i32) -> i32 {
+    let mut r: i32 = -1_i32;
+    'switch: {
+        let __match_cond = x;
+        match __match_cond {
+            v if v == 0 => {
+                return 100;
+            }
+            v if v == 1 => {
+                r = 10;
+                break 'switch;
+            }
+            v if v == 2 => {
+                return 200;
+            }
+            _ => {
+                r = 99;
+                break 'switch;
+            }
+        }
+    };
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = 0;
+            mixed_return_break_0(_x)
+        }) == (100))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 1;
+            mixed_return_break_0(_x)
+        }) == (10))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 2;
+            mixed_return_break_0(_x)
+        }) == (200))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 99;
+            mixed_return_break_0(_x)
+        }) == (99))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_nested.rs
+++ b/tests/unit/out/unsafe/switch_nested.rs
@@ -1,0 +1,82 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn nested_0(mut a: i32, mut b: i32) -> i32 {
+    let mut r: i32 = 0;
+    'switch: {
+        let __match_cond = a;
+        match __match_cond {
+            v if v == 1 => {
+                'switch: {
+                    let __match_cond = b;
+                    match __match_cond {
+                        v if v == 10 => {
+                            r = 11;
+                            break 'switch;
+                        }
+                        v if v == 20 => {
+                            r = 12;
+                            break 'switch;
+                        }
+                        _ => {
+                            r = 13;
+                            break 'switch;
+                        }
+                    }
+                };
+                r += 1;
+                break;
+            }
+            v if v == 2 => {
+                r = 2;
+                break;
+            }
+            _ => {
+                r = -1_i32;
+                break;
+            }
+        }
+    };
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _a: i32 = 1;
+            let _b: i32 = 10;
+            nested_0(_a, _b)
+        }) == (12))
+    );
+    assert!(
+        ((unsafe {
+            let _a: i32 = 1;
+            let _b: i32 = 99;
+            nested_0(_a, _b)
+        }) == (14))
+    );
+    assert!(
+        ((unsafe {
+            let _a: i32 = 2;
+            let _b: i32 = 0;
+            nested_0(_a, _b)
+        }) == (2))
+    );
+    assert!(
+        ((unsafe {
+            let _a: i32 = 3;
+            let _b: i32 = 3;
+            nested_0(_a, _b)
+        }) == (-1_i32))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_no_default.rs
+++ b/tests/unit/out/unsafe/switch_no_default.rs
@@ -1,0 +1,46 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn no_default_0(mut x: i32) -> i32 {
+    let mut r: i32 = -1_i32;
+    'switch: {
+        let __match_cond = x;
+        match __match_cond {
+            v if v == 7 => {
+                r = 1;
+                break 'switch;
+            }
+            v if v == 8 => {
+                r = 2;
+                break 'switch;
+            }
+            _ => {}
+        }
+    };
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = 7;
+            no_default_0(_x)
+        }) == (1))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 42;
+            no_default_0(_x)
+        }) == (-1_i32))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_on_assignment.rs
+++ b/tests/unit/out/unsafe/switch_on_assignment.rs
@@ -1,0 +1,59 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn switch_on_assignment_0(mut x: i32) -> i32 {
+    let mut y: i32 = 0;
+    let mut r: i32 = 0;
+    'switch: {
+        let __match_cond = {
+            y = ((x) + (1));
+            y
+        };
+        match __match_cond {
+            v if v == 1 => {
+                r = 10;
+                break 'switch;
+            }
+            v if v == 2 => {
+                r = 20;
+                break 'switch;
+            }
+            _ => {
+                r = y;
+                break 'switch;
+            }
+        }
+    };
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = 0;
+            switch_on_assignment_0(_x)
+        }) == (10))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 1;
+            switch_on_assignment_0(_x)
+        }) == (20))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 9;
+            switch_on_assignment_0(_x)
+        }) == (10))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_on_call.rs
+++ b/tests/unit/out/unsafe/switch_on_call.rs
@@ -1,0 +1,66 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn double_it_0(mut v: i32) -> i32 {
+    return ((v) * (2));
+}
+pub unsafe fn switch_on_call_1(mut x: i32) -> i32 {
+    'switch: {
+        let __match_cond = (unsafe {
+            let _v: i32 = x;
+            double_it_0(_v)
+        });
+        match __match_cond {
+            v if v == 0 => {
+                return 100;
+            }
+            v if v == 2 => {
+                return 200;
+            }
+            v if v == 4 => {
+                return 400;
+            }
+            _ => {
+                return -1_i32;
+            }
+        }
+    };
+    panic!("ub: non-void function does not return a value")
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = 0;
+            switch_on_call_1(_x)
+        }) == (100))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 1;
+            switch_on_call_1(_x)
+        }) == (200))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 2;
+            switch_on_call_1(_x)
+        }) == (400))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 99;
+            switch_on_call_1(_x)
+        }) == (-1_i32))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_only_default.rs
+++ b/tests/unit/out/unsafe/switch_only_default.rs
@@ -1,0 +1,35 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn only_default_0(mut x: i32) -> i32 {
+    let mut r: i32 = 0;
+    'switch: {
+        let __match_cond = x;
+        match __match_cond {
+            _ => {
+                r = 42;
+                break 'switch;
+            }
+        }
+    };
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = 1;
+            only_default_0(_x)
+        }) == (42))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_stacked.rs
+++ b/tests/unit/out/unsafe/switch_stacked.rs
@@ -1,0 +1,61 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn stacked_0(mut x: i32) -> i32 {
+    let mut r: i32 = 0;
+    'switch: {
+        let __match_cond = x;
+        match __match_cond {
+            v if v == 1 || v == 2 || v == 3 => {
+                r = 100;
+                break 'switch;
+            }
+            v if v == 4 || v == 5 => {
+                r = 200;
+                break 'switch;
+            }
+            _ => {
+                r = 300;
+                break 'switch;
+            }
+        }
+    };
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = 1;
+            stacked_0(_x)
+        }) == (100))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 3;
+            stacked_0(_x)
+        }) == (100))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 5;
+            stacked_0(_x)
+        }) == (200))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 9;
+            stacked_0(_x)
+        }) == (300))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_stacked_block.rs
+++ b/tests/unit/out/unsafe/switch_stacked_block.rs
@@ -1,0 +1,46 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn stacked_block_0(mut x: i32) -> i32 {
+    let mut r: i32 = 0;
+    'switch: {
+        let __match_cond = x;
+        match __match_cond {
+            v if v == 1 || v == 2 || v == 3 => {
+                let mut y: i32 = ((x) * (2));
+                r = ((y) + (1));
+                break 'switch;
+            }
+            _ => {
+                r = 0;
+                break 'switch;
+            }
+        }
+    };
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = 2;
+            stacked_block_0(_x)
+        }) == (5))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 9;
+            stacked_block_0(_x)
+        }) == (0))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_stacked_with_inner_fallthrough.rs
+++ b/tests/unit/out/unsafe/switch_stacked_with_inner_fallthrough.rs
@@ -1,0 +1,56 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn stacked_with_inner_fallthrough_0(mut x: i32, mut flag: i32) -> i32 {
+    let mut r: i32 = 0;
+    'switch: {
+        let __match_cond = x;
+        match __match_cond {
+            v if v == 1 || v == 2 || v == 3 => {
+                if !(flag != 0) {
+                    r = 50;
+                    break 'switch;
+                };
+            }
+            _ => {
+                r = 999;
+                break 'switch;
+            }
+        }
+    };
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _x: i32 = 1;
+            let _flag: i32 = 0;
+            stacked_with_inner_fallthrough_0(_x, _flag)
+        }) == (50))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 2;
+            let _flag: i32 = 1;
+            stacked_with_inner_fallthrough_0(_x, _flag)
+        }) == (999))
+    );
+    assert!(
+        ((unsafe {
+            let _x: i32 = 99;
+            let _flag: i32 = 0;
+            stacked_with_inner_fallthrough_0(_x, _flag)
+        }) == (999))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/switch_while_in_switch_break.rs
+++ b/tests/unit/out/unsafe/switch_while_in_switch_break.rs
@@ -1,0 +1,53 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn while_in_switch_break_0(mut n: i32) -> i32 {
+    let mut r: i32 = 0;
+    'switch: {
+        let __match_cond = n;
+        match __match_cond {
+            v if v == 0 => {
+                let mut i: i32 = 0;
+                'loop_: while ((i) < (10)) {
+                    if ((i) == (4)) {
+                        break 'switch;
+                    }
+                    r += i;
+                    i.prefix_inc();
+                }
+                r += 1000;
+                break 'switch;
+            }
+            _ => {
+                r = -1_i32;
+                break 'switch;
+            }
+        }
+    };
+    return r;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _n: i32 = 0;
+            while_in_switch_break_0(_n)
+        }) == (1006))
+    );
+    assert!(
+        ((unsafe {
+            let _n: i32 = 99;
+            while_in_switch_break_0(_n)
+        }) == (-1_i32))
+    );
+    return 0;
+}

--- a/tests/unit/switch_basic.cpp
+++ b/tests/unit/switch_basic.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+
+int basic(int x) {
+  int r = 0;
+  switch (x) {
+  case 0:
+    r = 10;
+    break;
+  case 1:
+    r = 20;
+    break;
+  case 2:
+    r = 30;
+    break;
+  default:
+    r = 40;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(basic(0) == 10);
+  assert(basic(2) == 30);
+  assert(basic(99) == 40);
+  return 0;
+}

--- a/tests/unit/switch_basic.cpp
+++ b/tests/unit/switch_basic.cpp
@@ -22,7 +22,6 @@ int basic(int x) {
   return r;
 }
 
-
 int main() {
   assert(basic(0) == 10);
   assert(basic(2) == 30);

--- a/tests/unit/switch_basic.cpp
+++ b/tests/unit/switch_basic.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 #include <cassert>
 
 int basic(int x) {

--- a/tests/unit/switch_borrow_in_condition_and_in_body.cpp
+++ b/tests/unit/switch_borrow_in_condition_and_in_body.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+// panic
+#include <cassert>
+
+int borrow_in_condition_and_in_body(int x) {
+  switch (x) {
+  case 0:
+    [[fallthrough]];
+  default:
+    return x + 1;
+  }
+}
+
+
+int main() {
+  assert(borrow_in_condition_and_in_body(0) == 1);
+  assert(borrow_in_condition_and_in_body(1) == 2);
+  return 0;
+}

--- a/tests/unit/switch_borrow_in_condition_and_in_body.cpp
+++ b/tests/unit/switch_borrow_in_condition_and_in_body.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 // panic
 #include <cassert>
 

--- a/tests/unit/switch_borrow_in_condition_and_in_body.cpp
+++ b/tests/unit/switch_borrow_in_condition_and_in_body.cpp
@@ -13,7 +13,6 @@ int borrow_in_condition_and_in_body(int x) {
   }
 }
 
-
 int main() {
   assert(borrow_in_condition_and_in_body(0) == 1);
   assert(borrow_in_condition_and_in_body(1) == 2);

--- a/tests/unit/switch_case_then_default.cpp
+++ b/tests/unit/switch_case_then_default.cpp
@@ -18,7 +18,6 @@ int case_then_default(int x) {
   return r;
 }
 
-
 int main() {
   assert(case_then_default(1) == 10);
   assert(case_then_default(2) == 20);

--- a/tests/unit/switch_case_then_default.cpp
+++ b/tests/unit/switch_case_then_default.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+// translation-fail
+#include <cassert>
+
+int case_then_default(int x) {
+  int r = 0;
+  switch (x) {
+  case 1:
+  default:
+    r = 10;
+    break;
+  case 2:
+    r = 20;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(case_then_default(1) == 10);
+  assert(case_then_default(2) == 20);
+  assert(case_then_default(99) == 10);
+  return 0;
+}

--- a/tests/unit/switch_case_then_default.cpp
+++ b/tests/unit/switch_case_then_default.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 // translation-fail
 #include <cassert>
 

--- a/tests/unit/switch_cases_and_default_stacked.cpp
+++ b/tests/unit/switch_cases_and_default_stacked.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+// translation-fail
+#include <cassert>
+
+int cases_and_default_stacked(int x) {
+  int r = 0;
+  switch (x) {
+  case 1:
+  case 2:
+  default:
+    r = 42;
+    break;
+  case 3:
+    r = 3;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(cases_and_default_stacked(1) == 42);
+  assert(cases_and_default_stacked(2) == 42);
+  assert(cases_and_default_stacked(3) == 3);
+  assert(cases_and_default_stacked(99) == 42);
+  return 0;
+}

--- a/tests/unit/switch_cases_and_default_stacked.cpp
+++ b/tests/unit/switch_cases_and_default_stacked.cpp
@@ -19,7 +19,6 @@ int cases_and_default_stacked(int x) {
   return r;
 }
 
-
 int main() {
   assert(cases_and_default_stacked(1) == 42);
   assert(cases_and_default_stacked(2) == 42);

--- a/tests/unit/switch_cases_and_default_stacked.cpp
+++ b/tests/unit/switch_cases_and_default_stacked.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 // translation-fail
 #include <cassert>
 

--- a/tests/unit/switch_char.cpp
+++ b/tests/unit/switch_char.cpp
@@ -20,7 +20,6 @@ int switch_char(char c) {
 
 enum Color { kRed, kGreen, kBlue };
 
-
 int main() {
   assert(switch_char('a') == 1);
   assert(switch_char('b') == 2);

--- a/tests/unit/switch_char.cpp
+++ b/tests/unit/switch_char.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+
+int switch_char(char c) {
+  switch (c) {
+  case 'a':
+    return 1;
+  case 'b':
+    return 2;
+  case '\n':
+    return 3;
+  case '\0':
+    return 4;
+  default:
+    return 0;
+  }
+}
+
+enum Color { kRed, kGreen, kBlue };
+
+
+int main() {
+  assert(switch_char('a') == 1);
+  assert(switch_char('b') == 2);
+  assert(switch_char('\n') == 3);
+  assert(switch_char('\0') == 4);
+  assert(switch_char('z') == 0);
+  return 0;
+}

--- a/tests/unit/switch_char.cpp
+++ b/tests/unit/switch_char.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 #include <cassert>
 
 int switch_char(char c) {

--- a/tests/unit/switch_complex_cond.cpp
+++ b/tests/unit/switch_complex_cond.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 #include <cassert>
 
 int switch_complex_cond(int *p, int bias) {

--- a/tests/unit/switch_complex_cond.cpp
+++ b/tests/unit/switch_complex_cond.cpp
@@ -16,7 +16,6 @@ int switch_complex_cond(int *p, int bias) {
   }
 }
 
-
 int main() {
   int p_val = 5;
   assert(switch_complex_cond(&p_val, 0) == 2);

--- a/tests/unit/switch_complex_cond.cpp
+++ b/tests/unit/switch_complex_cond.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+
+int switch_complex_cond(int *p, int bias) {
+  switch (*p + bias) {
+  case 0:
+    return 1;
+  case 5:
+    return 2;
+  case 10:
+    return 3;
+  default:
+    return 0;
+  }
+}
+
+
+int main() {
+  int p_val = 5;
+  assert(switch_complex_cond(&p_val, 0) == 2);
+  assert(switch_complex_cond(&p_val, 5) == 3);
+  assert(switch_complex_cond(&p_val, -5) == 1);
+  assert(switch_complex_cond(&p_val, 99) == 0);
+  return 0;
+}

--- a/tests/unit/switch_compound_case_body.cpp
+++ b/tests/unit/switch_compound_case_body.cpp
@@ -24,7 +24,6 @@ int compound_case_body(int x) {
   return r;
 }
 
-
 int main() {
   assert(compound_case_body(1) == 30);
   assert(compound_case_body(2) == 99);

--- a/tests/unit/switch_compound_case_body.cpp
+++ b/tests/unit/switch_compound_case_body.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 #include <cassert>
 
 int compound_case_body(int x) {

--- a/tests/unit/switch_compound_case_body.cpp
+++ b/tests/unit/switch_compound_case_body.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+
+int compound_case_body(int x) {
+  int r = 0;
+  switch (x) {
+  case 1: {
+    int y = 10;
+    int z = 20;
+    r = y + z;
+    break;
+  }
+  case 2: {
+    int y = 100;
+    r = y - 1;
+    break;
+  }
+  default:
+    r = -1;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(compound_case_body(1) == 30);
+  assert(compound_case_body(2) == 99);
+  assert(compound_case_body(9) == -1);
+  return 0;
+}

--- a/tests/unit/switch_continue_inside_switch.cpp
+++ b/tests/unit/switch_continue_inside_switch.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+
+int continue_inside_switch(int n) {
+  int r = 0;
+  for (int i = 0; i < n; ++i) {
+    switch (i) {
+    case 0:
+    case 2:
+    case 4:
+      continue;
+    default:
+      r += i;
+      break;
+    }
+    r += 1000;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(continue_inside_switch(6) == (1 + 3 + 5) + 3 * 1000);
+  return 0;
+}

--- a/tests/unit/switch_continue_inside_switch.cpp
+++ b/tests/unit/switch_continue_inside_switch.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 #include <cassert>
 
 int continue_inside_switch(int n) {

--- a/tests/unit/switch_continue_inside_switch.cpp
+++ b/tests/unit/switch_continue_inside_switch.cpp
@@ -20,7 +20,6 @@ int continue_inside_switch(int n) {
   return r;
 }
 
-
 int main() {
   assert(continue_inside_switch(6) == (1 + 3 + 5) + 3 * 1000);
   return 0;

--- a/tests/unit/switch_default_first.cpp
+++ b/tests/unit/switch_default_first.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+// panic
+#include <cassert>
+
+int default_first(int x) {
+  int r = 0;
+  switch (x) {
+  default:
+    r = 7;
+    break;
+  case 1:
+    r = 1;
+    break;
+  case 2:
+    r = 2;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(default_first(1) == 1);
+  assert(default_first(99) == 7);
+  return 0;
+}

--- a/tests/unit/switch_default_first.cpp
+++ b/tests/unit/switch_default_first.cpp
@@ -20,7 +20,6 @@ int default_first(int x) {
   return r;
 }
 
-
 int main() {
   assert(default_first(1) == 1);
   assert(default_first(99) == 7);

--- a/tests/unit/switch_default_first.cpp
+++ b/tests/unit/switch_default_first.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 // panic
 #include <cassert>
 

--- a/tests/unit/switch_default_middle.cpp
+++ b/tests/unit/switch_default_middle.cpp
@@ -20,7 +20,6 @@ int default_middle(int x) {
   return r;
 }
 
-
 int main() {
   assert(default_middle(1) == 1);
   assert(default_middle(2) == 2);

--- a/tests/unit/switch_default_middle.cpp
+++ b/tests/unit/switch_default_middle.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 // panic
 #include <cassert>
 

--- a/tests/unit/switch_default_middle.cpp
+++ b/tests/unit/switch_default_middle.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+// panic
+#include <cassert>
+
+int default_middle(int x) {
+  int r = 0;
+  switch (x) {
+  case 1:
+    r = 1;
+    break;
+  default:
+    r = 99;
+    break;
+  case 2:
+    r = 2;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(default_middle(1) == 1);
+  assert(default_middle(2) == 2);
+  assert(default_middle(99) == 99);
+  return 0;
+}

--- a/tests/unit/switch_default_then_case.cpp
+++ b/tests/unit/switch_default_then_case.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 // translation-fail
 #include <cassert>
 

--- a/tests/unit/switch_default_then_case.cpp
+++ b/tests/unit/switch_default_then_case.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+// translation-fail
+#include <cassert>
+
+int default_then_case(int x) {
+  int r = 0;
+  switch (x) {
+  case 1:
+    r = 1;
+    break;
+  default:
+  case 2:
+    r = 77;
+    break;
+  case 3:
+    r = 3;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(default_then_case(1) == 1);
+  assert(default_then_case(2) == 77);
+  assert(default_then_case(3) == 3);
+  assert(default_then_case(99) == 77);
+  return 0;
+}

--- a/tests/unit/switch_default_then_case.cpp
+++ b/tests/unit/switch_default_then_case.cpp
@@ -21,7 +21,6 @@ int default_then_case(int x) {
   return r;
 }
 
-
 int main() {
   assert(default_then_case(1) == 1);
   assert(default_then_case(2) == 77);

--- a/tests/unit/switch_empty_case_with_break.cpp
+++ b/tests/unit/switch_empty_case_with_break.cpp
@@ -18,7 +18,6 @@ int empty_case_with_break(int x) {
   return r;
 }
 
-
 int main() {
   assert(empty_case_with_break(1) == 5);
   assert(empty_case_with_break(2) == 2);

--- a/tests/unit/switch_empty_case_with_break.cpp
+++ b/tests/unit/switch_empty_case_with_break.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+
+int empty_case_with_break(int x) {
+  int r = 5;
+  switch (x) {
+  case 1:
+    break;
+  case 2:
+    r = 2;
+    break;
+  default:
+    r = 9;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(empty_case_with_break(1) == 5);
+  assert(empty_case_with_break(2) == 2);
+  assert(empty_case_with_break(9) == 9);
+  return 0;
+}

--- a/tests/unit/switch_empty_case_with_break.cpp
+++ b/tests/unit/switch_empty_case_with_break.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 #include <cassert>
 
 int empty_case_with_break(int x) {

--- a/tests/unit/switch_empty_switch.cpp
+++ b/tests/unit/switch_empty_switch.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+
+int empty_switch(int x) {
+  switch (x) {}
+  return x;
+}
+
+
+int main() {
+  assert(empty_switch(5) == 5);
+  return 0;
+}

--- a/tests/unit/switch_empty_switch.cpp
+++ b/tests/unit/switch_empty_switch.cpp
@@ -8,7 +8,6 @@ int empty_switch(int x) {
   return x;
 }
 
-
 int main() {
   assert(empty_switch(5) == 5);
   return 0;

--- a/tests/unit/switch_empty_switch.cpp
+++ b/tests/unit/switch_empty_switch.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 #include <cassert>
 
 int empty_switch(int x) {

--- a/tests/unit/switch_enum.cpp
+++ b/tests/unit/switch_enum.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 #include <cassert>
 
 enum Color { kRed, kGreen, kBlue };

--- a/tests/unit/switch_enum.cpp
+++ b/tests/unit/switch_enum.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+
+enum Color { kRed, kGreen, kBlue };
+
+int switch_enum(Color c) {
+  switch (c) {
+  case kRed:
+    return 10;
+  case kGreen:
+    return 20;
+  case kBlue:
+    return 30;
+  }
+  return -1;
+}
+
+
+int main() {
+  assert(switch_enum(kRed) == 10);
+  assert(switch_enum(kGreen) == 20);
+  assert(switch_enum(kBlue) == 30);
+  return 0;
+}

--- a/tests/unit/switch_enum.cpp
+++ b/tests/unit/switch_enum.cpp
@@ -17,7 +17,6 @@ int switch_enum(Color c) {
   return -1;
 }
 
-
 int main() {
   assert(switch_enum(kRed) == 10);
   assert(switch_enum(kGreen) == 20);

--- a/tests/unit/switch_fallthrough_chain.cpp
+++ b/tests/unit/switch_fallthrough_chain.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 // panic
 #include <cassert>
 

--- a/tests/unit/switch_fallthrough_chain.cpp
+++ b/tests/unit/switch_fallthrough_chain.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+// panic
+#include <cassert>
+
+int fallthrough_chain(int x) {
+  int r = 0;
+  switch (x) {
+  case 1:
+    r += 1;
+    [[fallthrough]];
+  case 2:
+    r += 2;
+    [[fallthrough]];
+  case 3:
+    r += 4;
+    [[fallthrough]];
+  case 4:
+    r += 8;
+    break;
+  default:
+    r = -1;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(fallthrough_chain(1) == 15);
+  assert(fallthrough_chain(2) == 14);
+  assert(fallthrough_chain(3) == 12);
+  assert(fallthrough_chain(4) == 8);
+  assert(fallthrough_chain(99) == -1);
+  return 0;
+}

--- a/tests/unit/switch_fallthrough_chain.cpp
+++ b/tests/unit/switch_fallthrough_chain.cpp
@@ -26,7 +26,6 @@ int fallthrough_chain(int x) {
   return r;
 }
 
-
 int main() {
   assert(fallthrough_chain(1) == 15);
   assert(fallthrough_chain(2) == 14);

--- a/tests/unit/switch_fallthrough_default.cpp
+++ b/tests/unit/switch_fallthrough_default.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+// panic
+#include <cassert>
+
+int fallthrough_default(int x, int flag) {
+  int r = 0;
+  switch (x) {
+  case 7:
+    if (flag) {
+      r = 100;
+      break;
+    }
+    [[fallthrough]];
+  default:
+    r = 42;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(fallthrough_default(7, 0) == 42);
+  assert(fallthrough_default(7, 1) == 100);
+  assert(fallthrough_default(99, 0) == 42);
+  return 0;
+}

--- a/tests/unit/switch_fallthrough_default.cpp
+++ b/tests/unit/switch_fallthrough_default.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 // panic
 #include <cassert>
 

--- a/tests/unit/switch_fallthrough_default.cpp
+++ b/tests/unit/switch_fallthrough_default.cpp
@@ -20,7 +20,6 @@ int fallthrough_default(int x, int flag) {
   return r;
 }
 
-
 int main() {
   assert(fallthrough_default(7, 0) == 42);
   assert(fallthrough_default(7, 1) == 100);

--- a/tests/unit/switch_fallthrough_into_block.cpp
+++ b/tests/unit/switch_fallthrough_into_block.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 // panic
 #include <cassert>
 

--- a/tests/unit/switch_fallthrough_into_block.cpp
+++ b/tests/unit/switch_fallthrough_into_block.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+// panic
+#include <cassert>
+
+int fallthrough_into_block(int x) {
+  int r = 0;
+  switch (x) {
+  case 1:
+    r += 1;
+    [[fallthrough]];
+  case 2: {
+    int tmp = r * 10;
+    r = tmp + 5;
+    break;
+  }
+  default:
+    r = -1;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(fallthrough_into_block(1) == 15);
+  assert(fallthrough_into_block(2) == 5);
+  assert(fallthrough_into_block(99) == -1);
+  return 0;
+}

--- a/tests/unit/switch_fallthrough_into_block.cpp
+++ b/tests/unit/switch_fallthrough_into_block.cpp
@@ -22,7 +22,6 @@ int fallthrough_into_block(int x) {
   return r;
 }
 
-
 int main() {
   assert(fallthrough_into_block(1) == 15);
   assert(fallthrough_into_block(2) == 5);

--- a/tests/unit/switch_fallthrough_one.cpp
+++ b/tests/unit/switch_fallthrough_one.cpp
@@ -19,7 +19,6 @@ int fallthrough_one(int x) {
   return r;
 }
 
-
 int main() {
   assert(fallthrough_one(1) == 30);
   assert(fallthrough_one(2) == 20);

--- a/tests/unit/switch_fallthrough_one.cpp
+++ b/tests/unit/switch_fallthrough_one.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 // panic
 #include <cassert>
 

--- a/tests/unit/switch_fallthrough_one.cpp
+++ b/tests/unit/switch_fallthrough_one.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+// panic
+#include <cassert>
+
+int fallthrough_one(int x) {
+  int r = 0;
+  switch (x) {
+  case 1:
+    r += 10;
+  case 2:
+    r += 20;
+    break;
+  default:
+    r = -1;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(fallthrough_one(1) == 30);
+  assert(fallthrough_one(2) == 20);
+  assert(fallthrough_one(99) == -1);
+  return 0;
+}

--- a/tests/unit/switch_for_in_switch_break.cpp
+++ b/tests/unit/switch_for_in_switch_break.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 // panic
 #include <cassert>
 

--- a/tests/unit/switch_for_in_switch_break.cpp
+++ b/tests/unit/switch_for_in_switch_break.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+// panic
+#include <cassert>
+
+int for_in_switch_break(int n) {
+  int r = 0;
+  switch (n) {
+  case 0:
+    for (int i = 0; i < 10; ++i) {
+      if (i == 3) break;
+      r += i;
+    }
+    r += 100;
+    break;
+  default:
+    r = -1;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(for_in_switch_break(0) == 103);
+  assert(for_in_switch_break(99) == -1);
+  return 0;
+}

--- a/tests/unit/switch_for_in_switch_break.cpp
+++ b/tests/unit/switch_for_in_switch_break.cpp
@@ -9,7 +9,8 @@ int for_in_switch_break(int n) {
   switch (n) {
   case 0:
     for (int i = 0; i < 10; ++i) {
-      if (i == 3) break;
+      if (i == 3)
+        break;
       r += i;
     }
     r += 100;
@@ -20,7 +21,6 @@ int for_in_switch_break(int n) {
   }
   return r;
 }
-
 
 int main() {
   assert(for_in_switch_break(0) == 103);

--- a/tests/unit/switch_for_in_switch_continue.cpp
+++ b/tests/unit/switch_for_in_switch_continue.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+
+int for_in_switch_continue(int n) {
+  int r = 0;
+  switch (n) {
+  case 0:
+    for (int i = 0; i < 5; ++i) {
+      if (i % 2 == 0) continue;
+      r += i;
+    }
+    break;
+  default:
+    r = -1;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(for_in_switch_continue(0) == 4);
+  assert(for_in_switch_continue(99) == -1);
+  return 0;
+}

--- a/tests/unit/switch_for_in_switch_continue.cpp
+++ b/tests/unit/switch_for_in_switch_continue.cpp
@@ -8,7 +8,8 @@ int for_in_switch_continue(int n) {
   switch (n) {
   case 0:
     for (int i = 0; i < 5; ++i) {
-      if (i % 2 == 0) continue;
+      if (i % 2 == 0)
+        continue;
       r += i;
     }
     break;
@@ -18,7 +19,6 @@ int for_in_switch_continue(int n) {
   }
   return r;
 }
-
 
 int main() {
   assert(for_in_switch_continue(0) == 4);

--- a/tests/unit/switch_for_in_switch_continue.cpp
+++ b/tests/unit/switch_for_in_switch_continue.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 #include <cassert>
 
 int for_in_switch_continue(int n) {

--- a/tests/unit/switch_for_switch_for_break.cpp
+++ b/tests/unit/switch_for_switch_for_break.cpp
@@ -10,7 +10,8 @@ int for_switch_for_break(int n) {
     switch (i) {
     case 1:
       for (int j = 0; j < 10; ++j) {
-        if (j == 2) break;
+        if (j == 2)
+          break;
         r += 1;
       }
       r += 100;
@@ -22,7 +23,6 @@ int for_switch_for_break(int n) {
   }
   return r;
 }
-
 
 int main() {
   assert(for_switch_for_break(3) == 122);

--- a/tests/unit/switch_for_switch_for_break.cpp
+++ b/tests/unit/switch_for_switch_for_break.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 // panic
 #include <cassert>
 

--- a/tests/unit/switch_for_switch_for_break.cpp
+++ b/tests/unit/switch_for_switch_for_break.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+// panic
+#include <cassert>
+
+int for_switch_for_break(int n) {
+  int r = 0;
+  for (int i = 0; i < n; ++i) {
+    switch (i) {
+    case 1:
+      for (int j = 0; j < 10; ++j) {
+        if (j == 2) break;
+        r += 1;
+      }
+      r += 100;
+      break;
+    default:
+      r += 10;
+      break;
+    }
+  }
+  return r;
+}
+
+
+int main() {
+  assert(for_switch_for_break(3) == 122);
+  return 0;
+}

--- a/tests/unit/switch_in_dowhile.cpp
+++ b/tests/unit/switch_in_dowhile.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+
+int switch_in_dowhile(int n) {
+  int r = 0;
+  int i = 0;
+  do {
+    switch (i) {
+    case 0:
+      r += 1;
+      break;
+    case 1:
+      r += 10;
+      break;
+    default:
+      r += 100;
+      break;
+    }
+    ++i;
+  } while (i < n);
+  return r;
+}
+
+
+int main() {
+  assert(switch_in_dowhile(1) == 1);
+  assert(switch_in_dowhile(3) == 1 + 10 + 100);
+  return 0;
+}

--- a/tests/unit/switch_in_dowhile.cpp
+++ b/tests/unit/switch_in_dowhile.cpp
@@ -23,7 +23,6 @@ int switch_in_dowhile(int n) {
   return r;
 }
 
-
 int main() {
   assert(switch_in_dowhile(1) == 1);
   assert(switch_in_dowhile(3) == 1 + 10 + 100);

--- a/tests/unit/switch_in_dowhile.cpp
+++ b/tests/unit/switch_in_dowhile.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 #include <cassert>
 
 int switch_in_dowhile(int n) {

--- a/tests/unit/switch_in_loop.cpp
+++ b/tests/unit/switch_in_loop.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+
+int switch_in_loop(int n) {
+  int r = 0;
+  for (int i = 0; i < n; ++i) {
+    switch (i % 3) {
+    case 0:
+      r += 1;
+      break;
+    case 1:
+      r += 2;
+      break;
+    default:
+      r += 3;
+      break;
+    }
+    r += 10;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(switch_in_loop(6) == 72);
+  return 0;
+}

--- a/tests/unit/switch_in_loop.cpp
+++ b/tests/unit/switch_in_loop.cpp
@@ -22,7 +22,6 @@ int switch_in_loop(int n) {
   return r;
 }
 
-
 int main() {
   assert(switch_in_loop(6) == 72);
   return 0;

--- a/tests/unit/switch_in_loop.cpp
+++ b/tests/unit/switch_in_loop.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 #include <cassert>
 
 int switch_in_loop(int n) {

--- a/tests/unit/switch_mixed_literal_cases.cpp
+++ b/tests/unit/switch_mixed_literal_cases.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 #include <cassert>
 
 int mixed_literal_cases(int x) {

--- a/tests/unit/switch_mixed_literal_cases.cpp
+++ b/tests/unit/switch_mixed_literal_cases.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+
+int mixed_literal_cases(int x) {
+  switch (x) {
+  case -1:
+    return 1;
+  case 0x10:
+    return 2;
+  case 0xFE80:
+    return 3;
+  case -0xFF:
+    return 4;
+  default:
+    return 0;
+  }
+}
+
+
+int main() {
+  assert(mixed_literal_cases(-1) == 1);
+  assert(mixed_literal_cases(0x10) == 2);
+  assert(mixed_literal_cases(0xFE80) == 3);
+  assert(mixed_literal_cases(-0xFF) == 4);
+  assert(mixed_literal_cases(7) == 0);
+  return 0;
+}

--- a/tests/unit/switch_mixed_literal_cases.cpp
+++ b/tests/unit/switch_mixed_literal_cases.cpp
@@ -18,7 +18,6 @@ int mixed_literal_cases(int x) {
   }
 }
 
-
 int main() {
   assert(mixed_literal_cases(-1) == 1);
   assert(mixed_literal_cases(0x10) == 2);

--- a/tests/unit/switch_mixed_return_break.cpp
+++ b/tests/unit/switch_mixed_return_break.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+
+int mixed_return_break(int x) {
+  int r = -1;
+  switch (x) {
+  case 0:
+    return 100;
+  case 1:
+    r = 10;
+    break;
+  case 2:
+    return 200;
+  default:
+    r = 99;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(mixed_return_break(0) == 100);
+  assert(mixed_return_break(1) == 10);
+  assert(mixed_return_break(2) == 200);
+  assert(mixed_return_break(99) == 99);
+  return 0;
+}

--- a/tests/unit/switch_mixed_return_break.cpp
+++ b/tests/unit/switch_mixed_return_break.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 #include <cassert>
 
 int mixed_return_break(int x) {

--- a/tests/unit/switch_mixed_return_break.cpp
+++ b/tests/unit/switch_mixed_return_break.cpp
@@ -20,7 +20,6 @@ int mixed_return_break(int x) {
   return r;
 }
 
-
 int main() {
   assert(mixed_return_break(0) == 100);
   assert(mixed_return_break(1) == 10);

--- a/tests/unit/switch_nested.cpp
+++ b/tests/unit/switch_nested.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 // no-compile
 #include <cassert>
 

--- a/tests/unit/switch_nested.cpp
+++ b/tests/unit/switch_nested.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+// no-compile
+#include <cassert>
+
+int nested(int a, int b) {
+  int r = 0;
+  switch (a) {
+  case 1:
+    switch (b) {
+    case 10:
+      r = 11;
+      break;
+    case 20:
+      r = 12;
+      break;
+    default:
+      r = 13;
+      break;
+    }
+    r += 1;
+    break;
+  case 2:
+    r = 2;
+    break;
+  default:
+    r = -1;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(nested(1, 10) == 12);
+  assert(nested(1, 99) == 14);
+  assert(nested(2, 0) == 2);
+  assert(nested(3, 3) == -1);
+  return 0;
+}

--- a/tests/unit/switch_nested.cpp
+++ b/tests/unit/switch_nested.cpp
@@ -31,7 +31,6 @@ int nested(int a, int b) {
   return r;
 }
 
-
 int main() {
   assert(nested(1, 10) == 12);
   assert(nested(1, 99) == 14);

--- a/tests/unit/switch_no_default.cpp
+++ b/tests/unit/switch_no_default.cpp
@@ -16,7 +16,6 @@ int no_default(int x) {
   return r;
 }
 
-
 int main() {
   assert(no_default(7) == 1);
   assert(no_default(42) == -1);

--- a/tests/unit/switch_no_default.cpp
+++ b/tests/unit/switch_no_default.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 #include <cassert>
 
 int no_default(int x) {

--- a/tests/unit/switch_no_default.cpp
+++ b/tests/unit/switch_no_default.cpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+
+int no_default(int x) {
+  int r = -1;
+  switch (x) {
+  case 7:
+    r = 1;
+    break;
+  case 8:
+    r = 2;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(no_default(7) == 1);
+  assert(no_default(42) == -1);
+  return 0;
+}

--- a/tests/unit/switch_on_assignment.cpp
+++ b/tests/unit/switch_on_assignment.cpp
@@ -20,7 +20,6 @@ int switch_on_assignment(int x) {
   return r;
 }
 
-
 int main() {
   assert(switch_on_assignment(0) == 10);
   assert(switch_on_assignment(1) == 20);

--- a/tests/unit/switch_on_assignment.cpp
+++ b/tests/unit/switch_on_assignment.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 #include <cassert>
 
 int switch_on_assignment(int x) {

--- a/tests/unit/switch_on_assignment.cpp
+++ b/tests/unit/switch_on_assignment.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+
+int switch_on_assignment(int x) {
+  int y = 0;
+  int r = 0;
+  switch (y = x + 1) {
+  case 1:
+    r = 10;
+    break;
+  case 2:
+    r = 20;
+    break;
+  default:
+    r = y;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(switch_on_assignment(0) == 10);
+  assert(switch_on_assignment(1) == 20);
+  assert(switch_on_assignment(9) == 10);
+  return 0;
+}

--- a/tests/unit/switch_on_call.cpp
+++ b/tests/unit/switch_on_call.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 #include <cassert>
 
 int double_it(int v) { return v * 2; }

--- a/tests/unit/switch_on_call.cpp
+++ b/tests/unit/switch_on_call.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+
+int double_it(int v) { return v * 2; }
+
+int switch_on_call(int x) {
+  switch (double_it(x)) {
+  case 0:
+    return 100;
+  case 2:
+    return 200;
+  case 4:
+    return 400;
+  default:
+    return -1;
+  }
+}
+
+
+int main() {
+  assert(switch_on_call(0) == 100);
+  assert(switch_on_call(1) == 200);
+  assert(switch_on_call(2) == 400);
+  assert(switch_on_call(99) == -1);
+  return 0;
+}

--- a/tests/unit/switch_on_call.cpp
+++ b/tests/unit/switch_on_call.cpp
@@ -18,7 +18,6 @@ int switch_on_call(int x) {
   }
 }
 
-
 int main() {
   assert(switch_on_call(0) == 100);
   assert(switch_on_call(1) == 200);

--- a/tests/unit/switch_only_default.cpp
+++ b/tests/unit/switch_only_default.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 #include <cassert>
 
 int only_default(int x) {

--- a/tests/unit/switch_only_default.cpp
+++ b/tests/unit/switch_only_default.cpp
@@ -13,7 +13,6 @@ int only_default(int x) {
   return r;
 }
 
-
 int main() {
   assert(only_default(1) == 42);
   return 0;

--- a/tests/unit/switch_only_default.cpp
+++ b/tests/unit/switch_only_default.cpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+
+int only_default(int x) {
+  int r = 0;
+  switch (x) {
+  default:
+    r = 42;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(only_default(1) == 42);
+  return 0;
+}

--- a/tests/unit/switch_stacked.cpp
+++ b/tests/unit/switch_stacked.cpp
@@ -22,7 +22,6 @@ int stacked(int x) {
   return r;
 }
 
-
 int main() {
   assert(stacked(1) == 100);
   assert(stacked(3) == 100);

--- a/tests/unit/switch_stacked.cpp
+++ b/tests/unit/switch_stacked.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 #include <cassert>
 
 int stacked(int x) {

--- a/tests/unit/switch_stacked.cpp
+++ b/tests/unit/switch_stacked.cpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+
+int stacked(int x) {
+  int r = 0;
+  switch (x) {
+  case 1:
+  case 2:
+  case 3:
+    r = 100;
+    break;
+  case 4:
+  case 5:
+    r = 200;
+    break;
+  default:
+    r = 300;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(stacked(1) == 100);
+  assert(stacked(3) == 100);
+  assert(stacked(5) == 200);
+  assert(stacked(9) == 300);
+  return 0;
+}

--- a/tests/unit/switch_stacked_block.cpp
+++ b/tests/unit/switch_stacked_block.cpp
@@ -20,7 +20,6 @@ int stacked_block(int x) {
   return r;
 }
 
-
 int main() {
   assert(stacked_block(2) == 5);
   assert(stacked_block(9) == 0);

--- a/tests/unit/switch_stacked_block.cpp
+++ b/tests/unit/switch_stacked_block.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 #include <cassert>
 
 int stacked_block(int x) {

--- a/tests/unit/switch_stacked_block.cpp
+++ b/tests/unit/switch_stacked_block.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+
+int stacked_block(int x) {
+  int r = 0;
+  switch (x) {
+  case 1:
+  case 2:
+  case 3: {
+    int y = x * 2;
+    r = y + 1;
+    break;
+  }
+  default:
+    r = 0;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(stacked_block(2) == 5);
+  assert(stacked_block(9) == 0);
+  return 0;
+}

--- a/tests/unit/switch_stacked_with_inner_fallthrough.cpp
+++ b/tests/unit/switch_stacked_with_inner_fallthrough.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 // panic
 #include <cassert>
 

--- a/tests/unit/switch_stacked_with_inner_fallthrough.cpp
+++ b/tests/unit/switch_stacked_with_inner_fallthrough.cpp
@@ -22,7 +22,6 @@ int stacked_with_inner_fallthrough(int x, int flag) {
   return r;
 }
 
-
 int main() {
   assert(stacked_with_inner_fallthrough(1, 0) == 50);
   assert(stacked_with_inner_fallthrough(2, 1) == 999);

--- a/tests/unit/switch_stacked_with_inner_fallthrough.cpp
+++ b/tests/unit/switch_stacked_with_inner_fallthrough.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+// panic
+#include <cassert>
+
+int stacked_with_inner_fallthrough(int x, int flag) {
+  int r = 0;
+  switch (x) {
+  case 1:
+  case 2:
+  case 3:
+    if (!flag) {
+      r = 50;
+      break;
+    }
+    [[fallthrough]];
+  default:
+    r = 999;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(stacked_with_inner_fallthrough(1, 0) == 50);
+  assert(stacked_with_inner_fallthrough(2, 1) == 999);
+  assert(stacked_with_inner_fallthrough(99, 0) == 999);
+  return 0;
+}

--- a/tests/unit/switch_while_in_switch_break.cpp
+++ b/tests/unit/switch_while_in_switch_break.cpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+// panic
+#include <cassert>
+
+int while_in_switch_break(int n) {
+  int r = 0;
+  switch (n) {
+  case 0: {
+    int i = 0;
+    while (i < 10) {
+      if (i == 4) break;
+      r += i;
+      ++i;
+    }
+    r += 1000;
+    break;
+  }
+  default:
+    r = -1;
+    break;
+  }
+  return r;
+}
+
+
+int main() {
+  assert(while_in_switch_break(0) == 1006);
+  assert(while_in_switch_break(99) == -1);
+  return 0;
+}

--- a/tests/unit/switch_while_in_switch_break.cpp
+++ b/tests/unit/switch_while_in_switch_break.cpp
@@ -1,6 +1,3 @@
-// Copyright (c) 2022-present INESC-ID.
-// Distributed under the MIT license that can be found in the LICENSE file.
-
 // panic
 #include <cassert>
 

--- a/tests/unit/switch_while_in_switch_break.cpp
+++ b/tests/unit/switch_while_in_switch_break.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic
 #include <cassert>
 
 int while_in_switch_break(int n) {
@@ -10,7 +9,8 @@ int while_in_switch_break(int n) {
   case 0: {
     int i = 0;
     while (i < 10) {
-      if (i == 4) break;
+      if (i == 4)
+        break;
       r += i;
       ++i;
     }
@@ -23,7 +23,6 @@ int while_in_switch_break(int n) {
   }
   return r;
 }
-
 
 int main() {
   assert(while_in_switch_break(0) == 1006);

--- a/tests/unit/switch_while_in_switch_break.cpp
+++ b/tests/unit/switch_while_in_switch_break.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
+// panic
 #include <cassert>
 
 int while_in_switch_break(int n) {


### PR DESCRIPTION
This adds all the switch/case tests introduced in #23

Not all tests compile, but that's fine, they will be fixed in future PR's. Some tests are marked with the new

```cpp
// translation-fail
```

marker that's aded to tests which break the translator