### PR TITLE
Disable verbose logging by default

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -14,6 +14,7 @@
 #include "converter/converter_lib.h"
 #include "converter/lex.h"
 #include "converter/mapper.h"
+#include "logging.h"
 
 namespace cpp2rust {
 std::unordered_map<std::string, std::string> Converter::inner_structs_;
@@ -52,8 +53,8 @@ use std::rc::Rc;
 }
 
 bool Converter::VisitRecoveryExpr(clang::RecoveryExpr *expr) {
-  llvm::errs() << "RecoveryExpr: ";
-  expr->dump();
+  verrs() << "RecoveryExpr: ";
+  expr->dump(verrs(), ctx_);
   exit(1);
   return false;
 }
@@ -122,7 +123,7 @@ bool Converter::VisitBuiltinType(clang::BuiltinType *type) {
     break;
   default:
     // FIXME: improve error handling
-    llvm::errs() << "unsupported builtin type\n";
+    verrs() << "unsupported builtin type\n";
     break;
   }
   return false;
@@ -151,7 +152,7 @@ bool Converter::VisitRecordType(clang::RecordType *type) {
 }
 
 std::string Converter::ConvertPointer(clang::Expr *expr, int line) {
-  llvm::errs() << "ConvertPointer called from line " << line << "\n";
+  verrs() << "ConvertPointer called from line " << line << "\n";
   PushExprKind push(*this, ExprKind::AddrOf);
   return ToString(expr);
 }
@@ -175,7 +176,7 @@ std::string Converter::ConvertLValue(clang::Expr *expr) {
 }
 
 std::string Converter::ConvertRValue(clang::Expr *expr, int line) {
-  llvm::errs() << "ConvertRValue called from line " << line << "\n";
+  verrs() << "ConvertRValue called from line " << line << "\n";
   PushExprKind push(*this, ExprKind::RValue);
   return ToString(expr);
 }
@@ -295,7 +296,7 @@ bool Converter::VisitFunctionDecl(clang::FunctionDecl *decl) {
   if (!IsInMainFile(decl) && !decl_ids_.insert(GetID(decl)).second) {
     return false;
   }
-  decl->dump();
+  decl->dump(verrs());
   curr_function_ = decl;
   std::string function_name;
   if (decl->isMain()) {
@@ -582,7 +583,7 @@ static bool recordDerivesCopy(const clang::RecordDecl *decl) {
 }
 
 bool Converter::VisitRecordDecl(clang::RecordDecl *decl) {
-  decl->dumpColor();
+  decl->dump(verrs());
 
   // VisitCXXRecordDecl already visited the record
   if (clang::isa<clang::CXXRecordDecl>(decl)) {
@@ -694,7 +695,7 @@ bool Converter::VisitCXXRecordDecl(clang::CXXRecordDecl *decl) {
     materializeTemplateSpecialization(decl);
   }
 
-  decl->dump();
+  decl->dump(verrs());
 
   Mapper::AddRuleForUserDefinedType(decl);
   if (!IsConvertibleCXXRecordDecl(decl)) {
@@ -741,7 +742,7 @@ bool Converter::VisitCXXRecordDecl(clang::CXXRecordDecl *decl) {
 }
 
 bool Converter::VisitCXXMethodDecl(clang::CXXMethodDecl *decl) {
-  decl->dump();
+  decl->dump(verrs());
   if (!IsConvertibleCXXMethodDecl(decl)) {
     return false;
   }
@@ -1085,10 +1086,10 @@ bool Converter::VisitCXXForRangeStmt(clang::CXXForRangeStmt *stmt) {
 
   if (!Mapper::Contains(range_init_type.getUnqualifiedType())) {
     // FIXME: improve error handling
-    llvm::errs() << "for range stmts only for types in std namespace\n";
+    verrs() << "for range stmts only for types in std namespace\n";
   }
 
-  llvm::errs() << "GetClassName: " << GetClassName(range_init_type) << "\n";
+  verrs() << "GetClassName: " << GetClassName(range_init_type) << "\n";
 
   if (GetClassName(range_init_type) == "std::map") {
     return VisitCXXForRangeStmtMap(stmt);
@@ -2363,8 +2364,8 @@ bool Converter::ConvertCXXOperatorCallExpr(clang::CXXOperatorCallExpr *expr) {
     break;
   default:
     // FIXME: improve error handling
-    llvm::errs() << "unsupported CXXOperatorCallExpr: "
-                 << clang::getOperatorSpelling(expr->getOperator()) << '\n';
+    verrs() << "unsupported CXXOperatorCallExpr: "
+            << clang::getOperatorSpelling(expr->getOperator()) << '\n';
     assert(0);
   }
   return false;
@@ -2692,7 +2693,7 @@ bool Converter::VisitUnaryExprOrTypeTraitExpr(
     break;
   default:
     // FIXME: improve error handling
-    llvm::errs() << "unsupported unary expr or type trait expr\n";
+    verrs() << "unsupported unary expr or type trait expr\n";
   }
   return false;
 }
@@ -3344,8 +3345,7 @@ void Converter::AddOrdTrait(const clang::CXXRecordDecl *decl) {
   }
 
   if (methods.size() > 1) {
-    llvm::errs()
-        << "Currently supporting only one overloaded comparison operator\n";
+    verrs() << "Currently supporting only one overloaded comparison operator\n";
     abort();
   }
 
@@ -3436,8 +3436,8 @@ void Converter::ConvertUnsignedArithBinaryOperator(clang::BinaryOperator *op,
     break;
   default:
     // FIXME: improve error handling
-    llvm::errs() << "unsupported unsigned binary operator: " << opcode << '\n';
-    op->dumpColor();
+    verrs() << "unsupported unsigned binary operator: " << opcode << '\n';
+    op->dump(verrs(), ctx_);
     assert(0);
   }
   PushParen paren(*this);
@@ -3747,9 +3747,9 @@ void Converter::SetFreshType(clang::QualType type) {
 }
 
 void Converter::dump_expr_kinds() {
-  llvm::errs() << "isRValue: " << isRValue() << ", isXValue: " << isXValue()
-               << ", isAddrOf: " << isAddrOf() << ", isObject: " << isObject()
-               << ", isVoid: " << isVoid() << "\n";
+  verrs() << "isRValue: " << isRValue() << ", isXValue: " << isXValue()
+          << ", isAddrOf: " << isAddrOf() << ", isObject: " << isObject()
+          << ", isVoid: " << isVoid() << "\n";
 }
 
 void Converter::emplace_back_plugin_construct_arg(

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -14,7 +14,6 @@
 #include "converter/converter_lib.h"
 #include "converter/lex.h"
 #include "converter/mapper.h"
-#include "logging.h"
 
 namespace cpp2rust {
 std::unordered_map<std::string, std::string> Converter::inner_structs_;
@@ -54,7 +53,7 @@ use std::rc::Rc;
 
 bool Converter::VisitRecoveryExpr(clang::RecoveryExpr *expr) {
   llvm::errs() << "RecoveryExpr: ";
-  expr->dump(llvm::errs(), ctx_);
+  expr->dump();
   exit(1);
   return false;
 }
@@ -3438,7 +3437,7 @@ void Converter::ConvertUnsignedArithBinaryOperator(clang::BinaryOperator *op,
   default:
     // FIXME: improve error handling
     llvm::errs() << "unsupported unsigned binary operator: " << opcode << '\n';
-    op->dump(llvm::errs(), ctx_);
+    op->dump();
     assert(0);
   }
   PushParen paren(*this);

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -53,8 +53,8 @@ use std::rc::Rc;
 }
 
 bool Converter::VisitRecoveryExpr(clang::RecoveryExpr *expr) {
-  verrs() << "RecoveryExpr: ";
-  expr->dump(verrs(), ctx_);
+  llvm::errs() << "RecoveryExpr: ";
+  expr->dump(llvm::errs(), ctx_);
   exit(1);
   return false;
 }
@@ -123,7 +123,7 @@ bool Converter::VisitBuiltinType(clang::BuiltinType *type) {
     break;
   default:
     // FIXME: improve error handling
-    verrs() << "unsupported builtin type\n";
+    log() << "unsupported builtin type\n";
     break;
   }
   return false;
@@ -152,7 +152,7 @@ bool Converter::VisitRecordType(clang::RecordType *type) {
 }
 
 std::string Converter::ConvertPointer(clang::Expr *expr, int line) {
-  verrs() << "ConvertPointer called from line " << line << "\n";
+  log() << "ConvertPointer called from line " << line << "\n";
   PushExprKind push(*this, ExprKind::AddrOf);
   return ToString(expr);
 }
@@ -176,7 +176,7 @@ std::string Converter::ConvertLValue(clang::Expr *expr) {
 }
 
 std::string Converter::ConvertRValue(clang::Expr *expr, int line) {
-  verrs() << "ConvertRValue called from line " << line << "\n";
+  log() << "ConvertRValue called from line " << line << "\n";
   PushExprKind push(*this, ExprKind::RValue);
   return ToString(expr);
 }
@@ -296,7 +296,7 @@ bool Converter::VisitFunctionDecl(clang::FunctionDecl *decl) {
   if (!IsInMainFile(decl) && !decl_ids_.insert(GetID(decl)).second) {
     return false;
   }
-  decl->dump(verrs());
+  decl->dump(log());
   curr_function_ = decl;
   std::string function_name;
   if (decl->isMain()) {
@@ -583,7 +583,7 @@ static bool recordDerivesCopy(const clang::RecordDecl *decl) {
 }
 
 bool Converter::VisitRecordDecl(clang::RecordDecl *decl) {
-  decl->dump(verrs());
+  decl->dump(log());
 
   // VisitCXXRecordDecl already visited the record
   if (clang::isa<clang::CXXRecordDecl>(decl)) {
@@ -695,7 +695,7 @@ bool Converter::VisitCXXRecordDecl(clang::CXXRecordDecl *decl) {
     materializeTemplateSpecialization(decl);
   }
 
-  decl->dump(verrs());
+  decl->dump(log());
 
   Mapper::AddRuleForUserDefinedType(decl);
   if (!IsConvertibleCXXRecordDecl(decl)) {
@@ -742,7 +742,7 @@ bool Converter::VisitCXXRecordDecl(clang::CXXRecordDecl *decl) {
 }
 
 bool Converter::VisitCXXMethodDecl(clang::CXXMethodDecl *decl) {
-  decl->dump(verrs());
+  decl->dump(log());
   if (!IsConvertibleCXXMethodDecl(decl)) {
     return false;
   }
@@ -1086,10 +1086,10 @@ bool Converter::VisitCXXForRangeStmt(clang::CXXForRangeStmt *stmt) {
 
   if (!Mapper::Contains(range_init_type.getUnqualifiedType())) {
     // FIXME: improve error handling
-    verrs() << "for range stmts only for types in std namespace\n";
+    log() << "for range stmts only for types in std namespace\n";
   }
 
-  verrs() << "GetClassName: " << GetClassName(range_init_type) << "\n";
+  log() << "GetClassName: " << GetClassName(range_init_type) << "\n";
 
   if (GetClassName(range_init_type) == "std::map") {
     return VisitCXXForRangeStmtMap(stmt);
@@ -2364,8 +2364,8 @@ bool Converter::ConvertCXXOperatorCallExpr(clang::CXXOperatorCallExpr *expr) {
     break;
   default:
     // FIXME: improve error handling
-    verrs() << "unsupported CXXOperatorCallExpr: "
-            << clang::getOperatorSpelling(expr->getOperator()) << '\n';
+    llvm::errs() << "unsupported CXXOperatorCallExpr: "
+                 << clang::getOperatorSpelling(expr->getOperator()) << '\n';
     assert(0);
   }
   return false;
@@ -2693,7 +2693,7 @@ bool Converter::VisitUnaryExprOrTypeTraitExpr(
     break;
   default:
     // FIXME: improve error handling
-    verrs() << "unsupported unary expr or type trait expr\n";
+    log() << "unsupported unary expr or type trait expr\n";
   }
   return false;
 }
@@ -3345,7 +3345,8 @@ void Converter::AddOrdTrait(const clang::CXXRecordDecl *decl) {
   }
 
   if (methods.size() > 1) {
-    verrs() << "Currently supporting only one overloaded comparison operator\n";
+    llvm::errs()
+        << "Currently supporting only one overloaded comparison operator\n";
     abort();
   }
 
@@ -3436,8 +3437,8 @@ void Converter::ConvertUnsignedArithBinaryOperator(clang::BinaryOperator *op,
     break;
   default:
     // FIXME: improve error handling
-    verrs() << "unsupported unsigned binary operator: " << opcode << '\n';
-    op->dump(verrs(), ctx_);
+    llvm::errs() << "unsupported unsigned binary operator: " << opcode << '\n';
+    op->dump(llvm::errs(), ctx_);
     assert(0);
   }
   PushParen paren(*this);
@@ -3747,9 +3748,9 @@ void Converter::SetFreshType(clang::QualType type) {
 }
 
 void Converter::dump_expr_kinds() {
-  verrs() << "isRValue: " << isRValue() << ", isXValue: " << isXValue()
-          << ", isAddrOf: " << isAddrOf() << ", isObject: " << isObject()
-          << ", isVoid: " << isVoid() << "\n";
+  log() << "isRValue: " << isRValue() << ", isXValue: " << isXValue()
+        << ", isAddrOf: " << isAddrOf() << ", isObject: " << isObject()
+        << ", isVoid: " << isVoid() << "\n";
 }
 
 void Converter::emplace_back_plugin_construct_arg(

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -17,6 +17,7 @@
 
 #include "converter/lex.h"
 #include "converter/translation_rule.h"
+#include "logging.h"
 
 namespace cpp2rust {
 class Converter : public clang::RecursiveASTVisitor<Converter> {
@@ -329,8 +330,8 @@ protected:
 
   template <typename... Ts>
   inline void _StrCat(const char *func, int line, const Ts &...vals) {
-    llvm::errs() << '[' << func << ':' << line << "] ";
-    ((llvm::errs() << vals << '\n', *rs_code_ += vals, *rs_code_ += ' '), ...);
+    verrs() << '[' << func << ':' << line << "] ";
+    ((verrs() << vals << '\n', *rs_code_ += vals, *rs_code_ += ' '), ...);
   }
 
   class Buffer {
@@ -609,13 +610,13 @@ protected:
                  int line = __builtin_LINE())
         : c(c) {
       c.curr_expr_kind_.push_back(k);
-      llvm::errs() << "PushExprKind " << file << ':' << line << ' ';
+      verrs() << "PushExprKind " << file << ':' << line << ' ';
       c.dump_expr_kinds();
-      llvm::errs() << '[';
+      verrs() << '[';
       for (const auto k : c.curr_expr_kind_) {
-        llvm::errs() << c.expr_kind_to_string(k) << ", ";
+        verrs() << c.expr_kind_to_string(k) << ", ";
       }
-      llvm::errs() << "]\n";
+      verrs() << "]\n";
     }
     ~PushExprKind() { c.curr_expr_kind_.pop_back(); }
   };

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -330,8 +330,8 @@ protected:
 
   template <typename... Ts>
   inline void _StrCat(const char *func, int line, const Ts &...vals) {
-    verrs() << '[' << func << ':' << line << "] ";
-    ((verrs() << vals << '\n', *rs_code_ += vals, *rs_code_ += ' '), ...);
+    log() << '[' << func << ':' << line << "] ";
+    ((log() << vals << '\n', *rs_code_ += vals, *rs_code_ += ' '), ...);
   }
 
   class Buffer {
@@ -610,13 +610,13 @@ protected:
                  int line = __builtin_LINE())
         : c(c) {
       c.curr_expr_kind_.push_back(k);
-      verrs() << "PushExprKind " << file << ':' << line << ' ';
+      log() << "PushExprKind " << file << ':' << line << ' ';
       c.dump_expr_kinds();
-      verrs() << '[';
+      log() << '[';
       for (const auto k : c.curr_expr_kind_) {
-        verrs() << c.expr_kind_to_string(k) << ", ";
+        log() << c.expr_kind_to_string(k) << ", ";
       }
-      verrs() << "]\n";
+      log() << "]\n";
     }
     ~PushExprKind() { c.curr_expr_kind_.pop_back(); }
   };

--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -418,7 +418,7 @@ const char *GetOverloadedOperator(const clang::FunctionDecl *decl) {
     return "lt";
   default:
     // FIXME: improve error handling
-    verrs() << "unsupported overloaded operator\n";
+    log() << "unsupported overloaded operator\n";
     return "";
   }
 }

--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -418,7 +418,7 @@ const char *GetOverloadedOperator(const clang::FunctionDecl *decl) {
     return "lt";
   default:
     // FIXME: improve error handling
-    llvm::errs() << "unsupported overloaded operator\n";
+    verrs() << "unsupported overloaded operator\n";
     return "";
   }
 }

--- a/cpp2rust/converter/converter_lib.h
+++ b/cpp2rust/converter/converter_lib.h
@@ -118,7 +118,7 @@ void ForEachTemplateArgument(
       break;
     default:
       // FIXME: improve logging
-      verrs() << "unsupported template argument kind\n";
+      log() << "unsupported template argument kind\n";
     }
   }
 }

--- a/cpp2rust/converter/converter_lib.h
+++ b/cpp2rust/converter/converter_lib.h
@@ -14,6 +14,8 @@
 #include <string_view>
 #include <vector>
 
+#include "logging.h"
+
 namespace cpp2rust {
 
 // Order matters: each category is a superset of the previous one.
@@ -116,7 +118,7 @@ void ForEachTemplateArgument(
       break;
     default:
       // FIXME: improve logging
-      llvm::errs() << "unsupported template argument kind\n";
+      verrs() << "unsupported template argument kind\n";
     }
   }
 }

--- a/cpp2rust/converter/mapper.cpp
+++ b/cpp2rust/converter/mapper.cpp
@@ -384,11 +384,11 @@ TranslationRule::ExprRule *search(const clang::Expr *expr) {
   auto qualified_name = ToString(expr);
   auto [rule, subs] =
       search(exprs_, qualified_name, GetExprMapKey(qualified_name));
-  llvm::errs() << "search expr " << qualified_name << ", result:\n";
+  verrs() << "search expr " << qualified_name << ", result:\n";
   if (rule) {
     rule->dump();
   } else {
-    llvm::errs() << "None\n";
+    verrs() << "None\n";
   }
   return rule;
 }
@@ -396,7 +396,7 @@ TranslationRule::ExprRule *search(const clang::Expr *expr) {
 TranslationRule::TypeRule *search(clang::QualType qual_type) {
   auto type = ToString(qual_type);
   auto [rule, subs] = search(types_, type, GetTypeMapKey(type));
-  llvm::errs() << "search type " << type
+  verrs() << "search type " << type
                << ", result: " << (rule ? rule->type_info.type : "None")
                << '\n';
   return rule;
@@ -408,7 +408,7 @@ void addRulesFromDirectory(const std::filesystem::path &dir, Model model) {
     if (entry.is_regular_file() && path.extension() == ".cpp") {
       auto [expr_rules, type_rules] = TranslationRule::Load(path, model);
       if (expr_rules.empty() && type_rules.empty()) {
-        llvm::errs() << "No rules found in " << path << '\n';
+        verrs() << "No rules found in " << path << '\n';
         continue;
       }
       for (auto &[_, rule] : expr_rules) {
@@ -535,7 +535,7 @@ clang::QualType normalizeQualType(clang::QualType qual_type) {
 std::string mapTypeStringRecursive(const std::string &cpp_type) {
   auto [rule, subs] = search(types_, cpp_type, GetTypeMapKey(cpp_type));
   if (!rule) {
-    llvm::errs() << "cpp_type: " << cpp_type << '\n';
+    verrs() << "cpp_type: " << cpp_type << '\n';
     assert(0 && "Type is not present in types_");
   }
   for (auto &ty : subs) {
@@ -885,11 +885,11 @@ void LoadTranslationRules(Model model, clang::ASTContext &ctx,
 
 #if 0
   for (auto &[src, rule] : exprs_) {
-    llvm::errs() << "Expr key: " << src << '\n';
+    verrs() << "Expr key: " << src << '\n';
     rule.dump();
   }
   for (auto &[src, rule] : types_) {
-    llvm::errs() << "Type key: " << src << '\n';
+    verrs() << "Type key: " << src << '\n';
     rule.dump();
   }
 #endif

--- a/cpp2rust/converter/mapper.cpp
+++ b/cpp2rust/converter/mapper.cpp
@@ -397,8 +397,7 @@ TranslationRule::TypeRule *search(clang::QualType qual_type) {
   auto type = ToString(qual_type);
   auto [rule, subs] = search(types_, type, GetTypeMapKey(type));
   verrs() << "search type " << type
-               << ", result: " << (rule ? rule->type_info.type : "None")
-               << '\n';
+          << ", result: " << (rule ? rule->type_info.type : "None") << '\n';
   return rule;
 }
 

--- a/cpp2rust/converter/mapper.cpp
+++ b/cpp2rust/converter/mapper.cpp
@@ -384,11 +384,11 @@ TranslationRule::ExprRule *search(const clang::Expr *expr) {
   auto qualified_name = ToString(expr);
   auto [rule, subs] =
       search(exprs_, qualified_name, GetExprMapKey(qualified_name));
-  verrs() << "search expr " << qualified_name << ", result:\n";
+  log() << "search expr " << qualified_name << ", result:\n";
   if (rule) {
     rule->dump();
   } else {
-    verrs() << "None\n";
+    log() << "None\n";
   }
   return rule;
 }
@@ -396,8 +396,8 @@ TranslationRule::ExprRule *search(const clang::Expr *expr) {
 TranslationRule::TypeRule *search(clang::QualType qual_type) {
   auto type = ToString(qual_type);
   auto [rule, subs] = search(types_, type, GetTypeMapKey(type));
-  verrs() << "search type " << type
-          << ", result: " << (rule ? rule->type_info.type : "None") << '\n';
+  log() << "search type " << type
+        << ", result: " << (rule ? rule->type_info.type : "None") << '\n';
   return rule;
 }
 
@@ -407,7 +407,7 @@ void addRulesFromDirectory(const std::filesystem::path &dir, Model model) {
     if (entry.is_regular_file() && path.extension() == ".cpp") {
       auto [expr_rules, type_rules] = TranslationRule::Load(path, model);
       if (expr_rules.empty() && type_rules.empty()) {
-        verrs() << "No rules found in " << path << '\n';
+        log() << "No rules found in " << path << '\n';
         continue;
       }
       for (auto &[_, rule] : expr_rules) {
@@ -534,7 +534,7 @@ clang::QualType normalizeQualType(clang::QualType qual_type) {
 std::string mapTypeStringRecursive(const std::string &cpp_type) {
   auto [rule, subs] = search(types_, cpp_type, GetTypeMapKey(cpp_type));
   if (!rule) {
-    verrs() << "cpp_type: " << cpp_type << '\n';
+    llvm::errs() << "cpp_type: " << cpp_type << '\n';
     assert(0 && "Type is not present in types_");
   }
   for (auto &ty : subs) {
@@ -884,11 +884,11 @@ void LoadTranslationRules(Model model, clang::ASTContext &ctx,
 
 #if 0
   for (auto &[src, rule] : exprs_) {
-    verrs() << "Expr key: " << src << '\n';
+    log() << "Expr key: " << src << '\n';
     rule.dump();
   }
   for (auto &[src, rule] : types_) {
-    verrs() << "Type key: " << src << '\n';
+    log() << "Type key: " << src << '\n';
     rule.dump();
   }
 #endif

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -824,7 +824,7 @@ static std::vector<const char *> printf2fmt(std::string &format) {
         }
       }
     }
-    cpp2rust::verrs() << "Unknown printf format: " << format << "\n";
+    verrs() << "Unknown printf format: " << format << "\n";
     assert(0);
   }
   return types;
@@ -838,9 +838,9 @@ void ConverterRefCount::ConvertPrintf(clang::CallExpr *expr) {
           expr->getArg(is_fprintf)->IgnoreImplicit())) {
     format = GetEscapedStringLiteral(str);
   } else {
-    cpp2rust::verrs() << "Uknown fprintf format: ";
-    expr->getArg(1)->dump(cpp2rust::verrs(), ctx_);
-    cpp2rust::verrs() << "\n";
+    verrs() << "Uknown fprintf format: ";
+    expr->getArg(1)->dump(verrs(), ctx_);
+    verrs() << "\n";
     exit(1);
   }
   bool ends_newline = format.ends_with("\\n\"");
@@ -851,7 +851,7 @@ void ConverterRefCount::ConvertPrintf(clang::CallExpr *expr) {
   } else if (fd == "stderr" || fd == "__stderrp") {
     StrCat(ends_newline ? "eprintln!(" : "eprint!(");
   } else {
-    cpp2rust::verrs() << "Uknown fprintf fd: " << fd << "\n";
+    verrs() << "Uknown fprintf fd: " << fd << "\n";
     exit(1);
   }
   if (ends_newline) {

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -824,7 +824,7 @@ static std::vector<const char *> printf2fmt(std::string &format) {
         }
       }
     }
-    verrs() << "Unknown printf format: " << format << "\n";
+    llvm::errs() << "Unknown printf format: " << format << "\n";
     assert(0);
   }
   return types;
@@ -838,9 +838,9 @@ void ConverterRefCount::ConvertPrintf(clang::CallExpr *expr) {
           expr->getArg(is_fprintf)->IgnoreImplicit())) {
     format = GetEscapedStringLiteral(str);
   } else {
-    verrs() << "Uknown fprintf format: ";
-    expr->getArg(1)->dump(verrs(), ctx_);
-    verrs() << "\n";
+    llvm::errs() << "Uknown fprintf format: ";
+    expr->getArg(1)->dump(llvm::errs(), ctx_);
+    llvm::errs() << "\n";
     exit(1);
   }
   bool ends_newline = format.ends_with("\\n\"");
@@ -851,7 +851,7 @@ void ConverterRefCount::ConvertPrintf(clang::CallExpr *expr) {
   } else if (fd == "stderr" || fd == "__stderrp") {
     StrCat(ends_newline ? "eprintln!(" : "eprint!(");
   } else {
-    verrs() << "Uknown fprintf fd: " << fd << "\n";
+    llvm::errs() << "Uknown fprintf fd: " << fd << "\n";
     exit(1);
   }
   if (ends_newline) {

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -11,7 +11,6 @@
 #include "converter/converter_lib.h"
 #include "converter/lex.h"
 #include "converter/mapper.h"
-#include "logging.h"
 
 namespace cpp2rust {
 ConverterRefCount::ConverterRefCount(std::string &rs_code,
@@ -839,7 +838,7 @@ void ConverterRefCount::ConvertPrintf(clang::CallExpr *expr) {
     format = GetEscapedStringLiteral(str);
   } else {
     llvm::errs() << "Uknown fprintf format: ";
-    expr->getArg(1)->dump(llvm::errs(), ctx_);
+    expr->getArg(1)->dump();
     llvm::errs() << "\n";
     exit(1);
   }

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -11,6 +11,7 @@
 #include "converter/converter_lib.h"
 #include "converter/lex.h"
 #include "converter/mapper.h"
+#include "logging.h"
 
 namespace cpp2rust {
 ConverterRefCount::ConverterRefCount(std::string &rs_code,
@@ -823,7 +824,7 @@ static std::vector<const char *> printf2fmt(std::string &format) {
         }
       }
     }
-    llvm::errs() << "Unknown printf format: " << format << "\n";
+    cpp2rust::verrs() << "Unknown printf format: " << format << "\n";
     assert(0);
   }
   return types;
@@ -837,9 +838,9 @@ void ConverterRefCount::ConvertPrintf(clang::CallExpr *expr) {
           expr->getArg(is_fprintf)->IgnoreImplicit())) {
     format = GetEscapedStringLiteral(str);
   } else {
-    llvm::errs() << "Uknown fprintf format: ";
-    expr->getArg(1)->dump();
-    llvm::errs() << "\n";
+    cpp2rust::verrs() << "Uknown fprintf format: ";
+    expr->getArg(1)->dump(cpp2rust::verrs(), ctx_);
+    cpp2rust::verrs() << "\n";
     exit(1);
   }
   bool ends_newline = format.ends_with("\\n\"");
@@ -850,7 +851,7 @@ void ConverterRefCount::ConvertPrintf(clang::CallExpr *expr) {
   } else if (fd == "stderr" || fd == "__stderrp") {
     StrCat(ends_newline ? "eprintln!(" : "eprint!(");
   } else {
-    llvm::errs() << "Uknown fprintf fd: " << fd << "\n";
+    cpp2rust::verrs() << "Uknown fprintf fd: " << fd << "\n";
     exit(1);
   }
   if (ends_newline) {

--- a/cpp2rust/converter/models/converter_refcount.h
+++ b/cpp2rust/converter/models/converter_refcount.h
@@ -245,21 +245,21 @@ private:
       if (pushed) {
         c.conversion_kind_.push_back(k);
       }
-      llvm::errs() << "[PushConversionKind:" << line << "] ";
+      verrs() << "[PushConversionKind:" << line << "] ";
       for (auto ck : c.conversion_kind_) {
-        llvm::errs() << c.ConversionKindToString(ck) << ", ";
+        verrs() << c.ConversionKindToString(ck) << ", ";
       }
-      llvm::errs() << "\n";
+      verrs() << "\n";
     }
     ~PushConversionKind() {
       if (pushed) {
         c.conversion_kind_.pop_back();
       }
-      llvm::errs() << "[PopConversionKind] ";
+      verrs() << "[PopConversionKind] ";
       for (auto ck : c.conversion_kind_) {
-        llvm::errs() << c.ConversionKindToString(ck) << ", ";
+        verrs() << c.ConversionKindToString(ck) << ", ";
       }
-      llvm::errs() << "\n";
+      verrs() << "\n";
     }
   };
 

--- a/cpp2rust/converter/models/converter_refcount.h
+++ b/cpp2rust/converter/models/converter_refcount.h
@@ -245,21 +245,21 @@ private:
       if (pushed) {
         c.conversion_kind_.push_back(k);
       }
-      verrs() << "[PushConversionKind:" << line << "] ";
+      log() << "[PushConversionKind:" << line << "] ";
       for (auto ck : c.conversion_kind_) {
-        verrs() << c.ConversionKindToString(ck) << ", ";
+        log() << c.ConversionKindToString(ck) << ", ";
       }
-      verrs() << "\n";
+      log() << "\n";
     }
     ~PushConversionKind() {
       if (pushed) {
         c.conversion_kind_.pop_back();
       }
-      verrs() << "[PopConversionKind] ";
+      log() << "[PopConversionKind] ";
       for (auto ck : c.conversion_kind_) {
-        verrs() << c.ConversionKindToString(ck) << ", ";
+        log() << c.ConversionKindToString(ck) << ", ";
       }
-      verrs() << "\n";
+      log() << "\n";
     }
   };
 

--- a/cpp2rust/converter/plugins/emplace_back.cpp
+++ b/cpp2rust/converter/plugins/emplace_back.cpp
@@ -6,7 +6,6 @@
 #include "converter/converter_lib.h"
 #include "converter/mapper.h"
 #include "converter/models/converter_refcount.h"
-#include "logging.h"
 
 namespace cpp2rust {
 
@@ -183,7 +182,7 @@ bool Converter::emplace_back_plugin_convert(clang::CallExpr *call) {
       StrCat(GetUnsafeTypeAsString(elem_ty));
     }
   } else {
-    call->dump(llvm::errs(), ctx_);
+    call->dump();
     assert(0 && "no ctor and no pod type");
     return false;
   }

--- a/cpp2rust/converter/plugins/emplace_back.cpp
+++ b/cpp2rust/converter/plugins/emplace_back.cpp
@@ -183,7 +183,7 @@ bool Converter::emplace_back_plugin_convert(clang::CallExpr *call) {
       StrCat(GetUnsafeTypeAsString(elem_ty));
     }
   } else {
-    call->dump(verrs(), ctx_);
+    call->dump(llvm::errs(), ctx_);
     assert(0 && "no ctor and no pod type");
     return false;
   }

--- a/cpp2rust/converter/plugins/emplace_back.cpp
+++ b/cpp2rust/converter/plugins/emplace_back.cpp
@@ -183,7 +183,7 @@ bool Converter::emplace_back_plugin_convert(clang::CallExpr *call) {
       StrCat(GetUnsafeTypeAsString(elem_ty));
     }
   } else {
-    call->dump(cpp2rust::verrs(), ctx_);
+    call->dump(verrs(), ctx_);
     assert(0 && "no ctor and no pod type");
     return false;
   }

--- a/cpp2rust/converter/plugins/emplace_back.cpp
+++ b/cpp2rust/converter/plugins/emplace_back.cpp
@@ -6,6 +6,7 @@
 #include "converter/converter_lib.h"
 #include "converter/mapper.h"
 #include "converter/models/converter_refcount.h"
+#include "logging.h"
 
 namespace cpp2rust {
 
@@ -182,7 +183,7 @@ bool Converter::emplace_back_plugin_convert(clang::CallExpr *call) {
       StrCat(GetUnsafeTypeAsString(elem_ty));
     }
   } else {
-    call->dumpColor();
+    call->dump(cpp2rust::verrs(), ctx_);
     assert(0 && "no ctor and no pod type");
     return false;
   }

--- a/cpp2rust/converter/translation_rule.cpp
+++ b/cpp2rust/converter/translation_rule.cpp
@@ -568,10 +568,10 @@ private:
       }
       break;
     case clang::OverloadingResult::OR_No_Viable_Function:
-      llvm::errs() << "No viable function\n";
+      verrs() << "No viable function\n";
       break;
     case clang::OverloadingResult::OR_Deleted:
-      llvm::errs() << "Deleted function selected\n";
+      verrs() << "Deleted function selected\n";
       break;
     }
 
@@ -750,7 +750,7 @@ Access ParseAccessJSON(llvm::StringRef value) {
   } else if (value == "move") {
     return Access::kMove;
   } else {
-    llvm::errs() << "Invalid access value: " << value << '\n';
+    verrs() << "Invalid access value: " << value << '\n';
     assert(0);
     return Access::kRead;
   }
@@ -861,7 +861,7 @@ void LoadTgtFromIR(ExprRules &exprs, TypeRules &types,
 
   auto parsed = llvm::json::parse((*buf)->getBuffer());
   if (!parsed) {
-    llvm::errs() << "Failed to parse IR JSON: " << json_path << ": "
+    verrs() << "Failed to parse IR JSON: " << json_path << ": "
                  << llvm::toString(parsed.takeError()) << '\n';
     assert(0);
     return;
@@ -901,20 +901,20 @@ void BodyFragmentDump(const BodyFragment &frag) {
 } // namespace
 
 void TextFragment::dump() const {
-  llvm::errs() << "  text: \"" << text << "\"\n";
+  verrs() << "  text: \"" << text << "\"\n";
 }
 
 void PlaceholderFragment::dump() const {
-  llvm::errs() << "  placeholder: " << n;
+  verrs() << "  placeholder: " << n;
   switch (access) {
   case Access::kRead:
-    llvm::errs() << " (read)\n";
+    verrs() << " (read)\n";
     break;
   case Access::kWrite:
-    llvm::errs() << " (write)\n";
+    verrs() << " (write)\n";
     break;
   case Access::kMove:
-    llvm::errs() << " (move)\n";
+    verrs() << " (move)\n";
     break;
   }
 }
@@ -929,37 +929,37 @@ const PlaceholderFragment *MethodCallFragment::getReceiverPlaceholder() const {
 }
 
 void MethodCallFragment::dump() const {
-  llvm::errs() << "  method_call:\n"
+  verrs() << "  method_call:\n"
                   "    receiver:\n";
   for (const auto &frag : receiver) {
     BodyFragmentDump(frag);
   }
-  llvm::errs() << "    body:\n";
+  verrs() << "    body:\n";
   for (const auto &frag : body) {
     BodyFragmentDump(frag);
   }
 }
 
 void ExprRule::dump() const {
-  llvm::errs() << "Matching: " << src << '\n';
+  verrs() << "Matching: " << src << '\n';
   unsigned i = 0;
   for (auto &info : params) {
-    llvm::errs() << "  param a" << i++ << ": ";
+    verrs() << "  param a" << i++ << ": ";
     info.dump();
-    llvm::errs() << '\n';
+    verrs() << '\n';
   }
   if (!return_type.type.empty()) {
-    llvm::errs() << "  return: ";
+    verrs() << "  return: ";
     return_type.dump();
-    llvm::errs() << '\n';
+    verrs() << '\n';
   }
   i = 0;
   for (auto &bounds : generics) {
-    llvm::errs() << "  generic T" << ++i << ':';
+    verrs() << "  generic T" << ++i << ':';
     for (auto &b : bounds) {
-      llvm::errs() << ' ' << b;
+      verrs() << ' ' << b;
     }
-    llvm::errs() << '\n';
+    verrs() << '\n';
   }
   for (const auto &frag : body) {
     BodyFragmentDump(frag);
@@ -967,23 +967,23 @@ void ExprRule::dump() const {
 }
 
 void GenericFragment::dump() const {
-  llvm::errs() << "  generic: " << n << '\n';
+  verrs() << "  generic: " << n << '\n';
 }
 
 void TypeInfo::dump() const {
-  llvm::errs() << type;
+  verrs() << type;
   if (is_refcount_pointer)
-    llvm::errs() << " [rc_ptr]";
+    verrs() << " [rc_ptr]";
   if (is_unsafe_pointer)
-    llvm::errs() << " [unsafe_ptr]";
+    verrs() << " [unsafe_ptr]";
 }
 
 void TypeRule::dump() const {
-  llvm::errs() << "name: " << src << "\n  Rust type: ";
+  verrs() << "name: " << src << "\n  Rust type: ";
   type_info.dump();
-  llvm::errs() << '\n';
+  verrs() << '\n';
   if (!initializer.empty()) {
-    llvm::errs() << "  init: " << initializer << '\n';
+    verrs() << "  init: " << initializer << '\n';
   }
 }
 
@@ -1005,14 +1005,14 @@ std::pair<ExprRules, TypeRules> Load(const std::filesystem::path &path,
 
   for (auto &[name, rule] : exprs) {
     if (rule.src.empty()) {
-      llvm::errs() << name << '\n';
+      verrs() << name << '\n';
       rule.dump();
       assert(0 && "Expr rule loaded from IR but has no src");
     }
   }
   for (auto &[name, rule] : types) {
     if (rule.src.empty()) {
-      llvm::errs() << name << '\n';
+      verrs() << name << '\n';
       rule.dump();
       assert(0 && "Type rule loaded from IR but has no src");
     }

--- a/cpp2rust/converter/translation_rule.cpp
+++ b/cpp2rust/converter/translation_rule.cpp
@@ -569,10 +569,10 @@ private:
       }
       break;
     case clang::OverloadingResult::OR_No_Viable_Function:
-      verrs() << "No viable function\n";
+      llvm::errs() << "No viable function\n";
       break;
     case clang::OverloadingResult::OR_Deleted:
-      verrs() << "Deleted function selected\n";
+      llvm::errs() << "Deleted function selected\n";
       break;
     }
 
@@ -751,7 +751,7 @@ Access ParseAccessJSON(llvm::StringRef value) {
   } else if (value == "move") {
     return Access::kMove;
   } else {
-    verrs() << "Invalid access value: " << value << '\n';
+    llvm::errs() << "Invalid access value: " << value << '\n';
     assert(0);
     return Access::kRead;
   }
@@ -862,8 +862,8 @@ void LoadTgtFromIR(ExprRules &exprs, TypeRules &types,
 
   auto parsed = llvm::json::parse((*buf)->getBuffer());
   if (!parsed) {
-    verrs() << "Failed to parse IR JSON: " << json_path << ": "
-            << llvm::toString(parsed.takeError()) << '\n';
+    llvm::errs() << "Failed to parse IR JSON: " << json_path << ": "
+                 << llvm::toString(parsed.takeError()) << '\n';
     assert(0);
     return;
   }
@@ -901,19 +901,19 @@ void BodyFragmentDump(const BodyFragment &frag) {
 
 } // namespace
 
-void TextFragment::dump() const { verrs() << "  text: \"" << text << "\"\n"; }
+void TextFragment::dump() const { log() << "  text: \"" << text << "\"\n"; }
 
 void PlaceholderFragment::dump() const {
-  verrs() << "  placeholder: " << n;
+  log() << "  placeholder: " << n;
   switch (access) {
   case Access::kRead:
-    verrs() << " (read)\n";
+    log() << " (read)\n";
     break;
   case Access::kWrite:
-    verrs() << " (write)\n";
+    log() << " (write)\n";
     break;
   case Access::kMove:
-    verrs() << " (move)\n";
+    log() << " (move)\n";
     break;
   }
 }
@@ -928,59 +928,59 @@ const PlaceholderFragment *MethodCallFragment::getReceiverPlaceholder() const {
 }
 
 void MethodCallFragment::dump() const {
-  verrs() << "  method_call:\n"
-             "    receiver:\n";
+  log() << "  method_call:\n"
+           "    receiver:\n";
   for (const auto &frag : receiver) {
     BodyFragmentDump(frag);
   }
-  verrs() << "    body:\n";
+  log() << "    body:\n";
   for (const auto &frag : body) {
     BodyFragmentDump(frag);
   }
 }
 
 void ExprRule::dump() const {
-  verrs() << "Matching: " << src << '\n';
+  log() << "Matching: " << src << '\n';
   unsigned i = 0;
   for (auto &info : params) {
-    verrs() << "  param a" << i++ << ": ";
+    log() << "  param a" << i++ << ": ";
     info.dump();
-    verrs() << '\n';
+    log() << '\n';
   }
   if (!return_type.type.empty()) {
-    verrs() << "  return: ";
+    log() << "  return: ";
     return_type.dump();
-    verrs() << '\n';
+    log() << '\n';
   }
   i = 0;
   for (auto &bounds : generics) {
-    verrs() << "  generic T" << ++i << ':';
+    log() << "  generic T" << ++i << ':';
     for (auto &b : bounds) {
-      verrs() << ' ' << b;
+      log() << ' ' << b;
     }
-    verrs() << '\n';
+    log() << '\n';
   }
   for (const auto &frag : body) {
     BodyFragmentDump(frag);
   }
 }
 
-void GenericFragment::dump() const { verrs() << "  generic: " << n << '\n'; }
+void GenericFragment::dump() const { log() << "  generic: " << n << '\n'; }
 
 void TypeInfo::dump() const {
-  verrs() << type;
+  log() << type;
   if (is_refcount_pointer)
-    verrs() << " [rc_ptr]";
+    log() << " [rc_ptr]";
   if (is_unsafe_pointer)
-    verrs() << " [unsafe_ptr]";
+    log() << " [unsafe_ptr]";
 }
 
 void TypeRule::dump() const {
-  verrs() << "name: " << src << "\n  Rust type: ";
+  log() << "name: " << src << "\n  Rust type: ";
   type_info.dump();
-  verrs() << '\n';
+  log() << '\n';
   if (!initializer.empty()) {
-    verrs() << "  init: " << initializer << '\n';
+    log() << "  init: " << initializer << '\n';
   }
 }
 
@@ -1002,14 +1002,14 @@ std::pair<ExprRules, TypeRules> Load(const std::filesystem::path &path,
 
   for (auto &[name, rule] : exprs) {
     if (rule.src.empty()) {
-      verrs() << name << '\n';
+      llvm::errs() << name << '\n';
       rule.dump();
       assert(0 && "Expr rule loaded from IR but has no src");
     }
   }
   for (auto &[name, rule] : types) {
     if (rule.src.empty()) {
-      verrs() << name << '\n';
+      llvm::errs() << name << '\n';
       rule.dump();
       assert(0 && "Type rule loaded from IR but has no src");
     }

--- a/cpp2rust/converter/translation_rule.cpp
+++ b/cpp2rust/converter/translation_rule.cpp
@@ -28,6 +28,7 @@
 
 #include "compat/platform_flags.h"
 #include "converter/mapper.h"
+#include "logging.h"
 
 namespace cpp2rust::TranslationRule {
 
@@ -862,7 +863,7 @@ void LoadTgtFromIR(ExprRules &exprs, TypeRules &types,
   auto parsed = llvm::json::parse((*buf)->getBuffer());
   if (!parsed) {
     verrs() << "Failed to parse IR JSON: " << json_path << ": "
-                 << llvm::toString(parsed.takeError()) << '\n';
+            << llvm::toString(parsed.takeError()) << '\n';
     assert(0);
     return;
   }
@@ -900,9 +901,7 @@ void BodyFragmentDump(const BodyFragment &frag) {
 
 } // namespace
 
-void TextFragment::dump() const {
-  verrs() << "  text: \"" << text << "\"\n";
-}
+void TextFragment::dump() const { verrs() << "  text: \"" << text << "\"\n"; }
 
 void PlaceholderFragment::dump() const {
   verrs() << "  placeholder: " << n;
@@ -930,7 +929,7 @@ const PlaceholderFragment *MethodCallFragment::getReceiverPlaceholder() const {
 
 void MethodCallFragment::dump() const {
   verrs() << "  method_call:\n"
-                  "    receiver:\n";
+             "    receiver:\n";
   for (const auto &frag : receiver) {
     BodyFragmentDump(frag);
   }
@@ -966,9 +965,7 @@ void ExprRule::dump() const {
   }
 }
 
-void GenericFragment::dump() const {
-  verrs() << "  generic: " << n << '\n';
-}
+void GenericFragment::dump() const { verrs() << "  generic: " << n << '\n'; }
 
 void TypeInfo::dump() const {
   verrs() << type;

--- a/cpp2rust/cpp2rust.cpp
+++ b/cpp2rust/cpp2rust.cpp
@@ -19,11 +19,16 @@
 #include <llvm/Support/CommandLine.h>
 
 #include "cpp2rust_lib.h"
+#include "logging.h"
 
 namespace fs = std::filesystem;
 
 namespace {
 llvm::cl::OptionCategory cpp2rust_cmdargs("Cpp2Rust options");
+
+llvm::cl::opt<bool> Verbose("verbose", llvm::cl::desc("Enable verbose logging"),
+                            llvm::cl::init(false),
+                            llvm::cl::cat(cpp2rust_cmdargs));
 
 llvm::cl::opt<std::string> CcFile("file",
                                   llvm::cl::desc("Path to the C++ file"),
@@ -89,7 +94,7 @@ static bool ResolveRulesDir() {
   for (const auto &dir : candidates) {
     if (fs::exists(dir) && fs::is_directory(dir)) {
       RulesDir = fs::canonical(dir).string();
-      llvm::outs() << "Using rules directory: " << RulesDir << '\n';
+      llvm::errs() << "Using rules directory: " << RulesDir << '\n';
       return true;
     }
   }
@@ -99,6 +104,8 @@ static bool ResolveRulesDir() {
 int main(int argc, char *argv[]) {
   llvm::cl::HideUnrelatedOptions(cpp2rust_cmdargs);
   llvm::cl::ParseCommandLineOptions(argc, argv);
+
+  cpp2rust::SetVerbose(Verbose);
 
   if (CcFile.empty() && BuildDir.empty()) {
     llvm::errs() << "ERROR: please provide either --file or --dir\n";

--- a/cpp2rust/logging.cpp
+++ b/cpp2rust/logging.cpp
@@ -5,16 +5,13 @@
 
 namespace cpp2rust {
 namespace {
-llvm::raw_ostream *verrs_ = &llvm::nulls();
-llvm::raw_ostream *vouts_ = &llvm::nulls();
+llvm::raw_ostream *log_ = &llvm::nulls();
 } // namespace
 
 void SetVerbose(bool verbose) {
-  verrs_ = verbose ? &llvm::errs() : &llvm::nulls();
-  vouts_ = verbose ? &llvm::outs() : &llvm::nulls();
+  log_ = verbose ? &llvm::errs() : &llvm::nulls();
 }
 
-llvm::raw_ostream &verrs() { return *verrs_; }
-llvm::raw_ostream &vouts() { return *vouts_; }
+llvm::raw_ostream &log() { return *log_; }
 
 } // namespace cpp2rust

--- a/cpp2rust/logging.cpp
+++ b/cpp2rust/logging.cpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include "logging.h"
+
+namespace cpp2rust {
+namespace {
+llvm::raw_ostream *verrs_ = &llvm::nulls();
+llvm::raw_ostream *vouts_ = &llvm::nulls();
+} // namespace
+
+void SetVerbose(bool verbose) {
+  verrs_ = verbose ? &llvm::errs() : &llvm::nulls();
+  vouts_ = verbose ? &llvm::outs() : &llvm::nulls();
+}
+
+llvm::raw_ostream &verrs() { return *verrs_; }
+llvm::raw_ostream &vouts() { return *vouts_; }
+
+} // namespace cpp2rust

--- a/cpp2rust/logging.h
+++ b/cpp2rust/logging.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#pragma once
+
+#include <llvm/Support/raw_ostream.h>
+
+namespace cpp2rust {
+
+void SetVerbose(bool verbose);
+
+llvm::raw_ostream &verrs();
+llvm::raw_ostream &vouts();
+
+} // namespace cpp2rust

--- a/cpp2rust/logging.h
+++ b/cpp2rust/logging.h
@@ -9,7 +9,6 @@ namespace cpp2rust {
 
 void SetVerbose(bool verbose);
 
-llvm::raw_ostream &verrs();
-llvm::raw_ostream &vouts();
+llvm::raw_ostream &log();
 
 } // namespace cpp2rust


### PR DESCRIPTION
Logging can be re-enabled using the `--verbose` option