### PR TITLE
Guard void pointer conversion

### DIFF
--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -1149,7 +1149,8 @@ bool ConverterRefCount::VisitExplicitCastExpr(clang::ExplicitCastExpr *expr) {
   case clang::Stmt::CXXStaticCastExprClass:
     if (!VisitFunctionPointerCast(expr)) {
       return false;
-    } else if (expr->getSubExpr()->getType()->isVoidPointerType()) {
+    } else if (expr->getSubExpr()->getType()->isVoidPointerType() &&
+               expr->getType()->isPointerType()) {
       Convert(expr->getSubExpr());
       PushConversionKind push(*this, ConversionKind::Unboxed);
       StrCat(std::format(".cast::<{}>().expect(\"ub:wrong type\")",


### PR DESCRIPTION
Only accept `void* -> pointer type` expressions for now. In the future we will add support for `void* -> integer type` as well