### PR TITLE
 Wrap BinaryOperator in integer cast in C mode

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -2067,6 +2067,7 @@ void Converter::ConvertBinaryOperator(clang::BinaryOperator *expr) {
 }
 
 void Converter::ConvertGenericBinaryOperator(clang::BinaryOperator *expr) {
+  PushParen outer(*this);
   {
     PushParen lhs_paren(*this);
     Convert(expr->getLHS());

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -1742,22 +1742,10 @@ void Converter::ConvertIntegralToBooleanCast(clang::ImplicitCastExpr *expr) {
   auto *stripped = sub_expr->IgnoreParenImpCasts();
 
   if (auto binop = clang::dyn_cast<clang::BinaryOperator>(stripped)) {
-    // Comparison already produces bool, no wrap needed.
-    if (binop->isComparisonOp()) {
+    // Comparisons and logical ops already produces bool, no wrap needed.
+    if ((binop->isComparisonOp() || binop->isLogicalOp()) &&
+        binop->getType()->isBooleanType()) {
       Convert(sub_expr);
-      return;
-    }
-    // Distribute bool conversion to each argument of the logical op.
-    if (binop->isLogicalOp()) {
-      {
-        PushParen paren(*this);
-        ConvertCondition(binop->getLHS());
-      }
-      StrCat(binop->getOpcodeStr());
-      {
-        PushParen paren(*this);
-        ConvertCondition(binop->getRHS());
-      }
       return;
     }
   }
@@ -1945,6 +1933,21 @@ bool Converter::VisitExplicitCastExpr(clang::ExplicitCastExpr *expr) {
 }
 
 bool Converter::VisitBinaryOperator(clang::BinaryOperator *expr) {
+  bool needs_cast = (expr->isComparisonOp() || expr->isLogicalOp()) &&
+                    expr->getType()->isIntegerType() &&
+                    !expr->getType()->isBooleanType();
+  PushParen outer(*this, needs_cast);
+  {
+    PushParen inner(*this, needs_cast);
+    ConvertBinaryOperator(expr);
+  }
+  if (needs_cast) {
+    ConvertCast(expr->getType());
+  }
+  return false;
+}
+
+void Converter::ConvertBinaryOperator(clang::BinaryOperator *expr) {
   auto type = expr->getType();
   auto *lhs = expr->getLHS();
   auto *rhs = expr->getRHS();
@@ -2048,14 +2051,22 @@ bool Converter::VisitBinaryOperator(clang::BinaryOperator *expr) {
     }
     ConvertCast(expr->getType());
     computed_expr_type_ = ComputedExprType::FreshValue;
+  } else if (expr->isLogicalOp()) {
+    {
+      PushParen paren(*this);
+      ConvertCondition(expr->getLHS());
+    }
+    StrCat(expr->getOpcodeStr());
+    {
+      PushParen paren(*this);
+      ConvertCondition(expr->getRHS());
+    }
   } else {
     ConvertGenericBinaryOperator(expr);
   }
-  return false;
 }
 
 void Converter::ConvertGenericBinaryOperator(clang::BinaryOperator *expr) {
-  PushParen outer(*this);
   {
     PushParen lhs_paren(*this);
     Convert(expr->getLHS());
@@ -2063,8 +2074,10 @@ void Converter::ConvertGenericBinaryOperator(clang::BinaryOperator *expr) {
 
   StrCat(expr->getOpcodeStr());
 
-  PushParen rhs_paren(*this);
-  Convert(expr->getRHS());
+  {
+    PushParen rhs_paren(*this);
+    Convert(expr->getRHS());
+  }
 }
 
 bool Converter::IsReferenceType(const clang::Expr *expr) const {

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -252,6 +252,8 @@ public:
 
   virtual bool VisitBinaryOperator(clang::BinaryOperator *expr);
 
+  virtual void ConvertBinaryOperator(clang::BinaryOperator *expr);
+
   virtual bool ConvertIncAndDec(clang::UnaryOperator *expr);
 
   virtual bool VisitUnaryOperator(clang::UnaryOperator *expr);

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -1191,7 +1191,7 @@ void ConverterRefCount::EmitStmtExprTail(clang::Expr *tail) {
   StrCat("__result");
 }
 
-bool ConverterRefCount::VisitBinaryOperator(clang::BinaryOperator *expr) {
+void ConverterRefCount::ConvertBinaryOperator(clang::BinaryOperator *expr) {
   auto *lhs = expr->getLHS();
   auto *rhs = expr->getRHS();
   auto lhs_type = lhs->getType();
@@ -1229,7 +1229,7 @@ bool ConverterRefCount::VisitBinaryOperator(clang::BinaryOperator *expr) {
     }
     StrCat(token::kSemiColon);
     EmitSetOrAssign(lhs, "rhs_0");
-    return false;
+    return;
   }
 
   if (IsUnsignedArithOp(expr)) {
@@ -1249,7 +1249,7 @@ bool ConverterRefCount::VisitBinaryOperator(clang::BinaryOperator *expr) {
       StrCat(token::kSemiColon);
       EmitSetOrAssign(lhs, "rhs_0");
     }
-    return false;
+    return;
   }
 
   // pointer subtraction. The Sub trait gets elements by Value, so we need
@@ -1263,15 +1263,15 @@ bool ConverterRefCount::VisitBinaryOperator(clang::BinaryOperator *expr) {
     }
     ConvertCast(expr->getType());
     computed_expr_type_ = ComputedExprType::FreshValue;
-    return false;
+    return;
   }
 
   if (expr->isAssignmentOp()) {
     ConvertAssignment(lhs, rhs, opcode_as_string);
-    return false;
+    return;
   }
 
-  return Converter::VisitBinaryOperator(expr);
+  Converter::ConvertBinaryOperator(expr);
 }
 
 bool ConverterRefCount::VisitInitListExpr(clang::InitListExpr *expr) {
@@ -1840,7 +1840,6 @@ void ConverterRefCount::ConvertGenericBinaryOperator(
     return;
   }
 
-  PushParen paren(*this);
   Convert(lhs);
   StrCat(opcode);
   Convert(rhs);

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -1840,6 +1840,7 @@ void ConverterRefCount::ConvertGenericBinaryOperator(
     return;
   }
 
+  PushParen outer(*this);
   Convert(lhs);
   StrCat(opcode);
   Convert(rhs);

--- a/cpp2rust/converter/models/converter_refcount.h
+++ b/cpp2rust/converter/models/converter_refcount.h
@@ -82,7 +82,7 @@ public:
 
   bool VisitExplicitCastExpr(clang::ExplicitCastExpr *expr) override;
 
-  bool VisitBinaryOperator(clang::BinaryOperator *expr) override;
+  void ConvertBinaryOperator(clang::BinaryOperator *expr) override;
 
   bool VisitStmtExpr(clang::StmtExpr *expr) override;
 

--- a/tests/benchmarks/out/refcount/bst.rs
+++ b/tests/benchmarks/out/refcount/bst.rs
@@ -26,25 +26,21 @@ impl ByteRepr for node_t {}
 pub fn find_0(node: Ptr<node_t>, value: i32) -> Ptr<node_t> {
     let node: Value<Ptr<node_t>> = Rc::new(RefCell::new(node));
     let value: Value<i32> = Rc::new(RefCell::new(value));
-    if {
-        let _lhs = {
-            let _lhs = (*value.borrow());
-            _lhs < (*(*(*node.borrow()).upgrade().deref()).value.borrow())
-        };
-        _lhs && (!((*(*(*node.borrow()).upgrade().deref()).left.borrow()).is_null())).clone()
-    } {
+    if ({
+        let _lhs = (*value.borrow());
+        _lhs < (*(*(*node.borrow()).upgrade().deref()).value.borrow())
+    }) && (!((*(*(*node.borrow()).upgrade().deref()).left.borrow()).is_null()))
+    {
         return ({
             let _node: Ptr<node_t> = (*(*(*node.borrow()).upgrade().deref()).left.borrow()).clone();
             let _value: i32 = (*value.borrow());
             find_0(_node, _value)
         });
-    } else if {
-        let _lhs = {
-            let _lhs = (*value.borrow());
-            _lhs > (*(*(*node.borrow()).upgrade().deref()).value.borrow())
-        };
-        _lhs && (!((*(*(*node.borrow()).upgrade().deref()).right.borrow()).is_null())).clone()
-    } {
+    } else if ({
+        let _lhs = (*value.borrow());
+        _lhs > (*(*(*node.borrow()).upgrade().deref()).value.borrow())
+    }) && (!((*(*(*node.borrow()).upgrade().deref()).right.borrow()).is_null()))
+    {
         return ({
             let _node: Ptr<node_t> =
                 (*(*(*node.borrow()).upgrade().deref()).right.borrow()).clone();

--- a/tests/benchmarks/out/refcount/fibonacci.rs
+++ b/tests/benchmarks/out/refcount/fibonacci.rs
@@ -8,7 +8,7 @@ use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 pub fn fib_0(n: u64) -> u64 {
     let n: Value<u64> = Rc::new(RefCell::new(n));
-    return if (((*n.borrow()) == 0_u64) || ((*n.borrow()) == 1_u64)) {
+    return if ((*n.borrow()) == 0_u64) || ((*n.borrow()) == 1_u64) {
         (*n.borrow())
     } else {
         ({

--- a/tests/benchmarks/out/refcount/ptr_fibonacci.rs
+++ b/tests/benchmarks/out/refcount/ptr_fibonacci.rs
@@ -8,7 +8,7 @@ use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 pub fn fib_0(n: Ptr<u64>) {
     let n: Value<Ptr<u64>> = Rc::new(RefCell::new(n));
-    if ((((*n.borrow()).read()) == 0_u64) || (((*n.borrow()).read()) == 1_u64)) {
+    if (((*n.borrow()).read()) == 0_u64) || (((*n.borrow()).read()) == 1_u64) {
         return;
     }
     let n_1: Value<u64> = Rc::new(RefCell::new(((*n.borrow()).read()).wrapping_sub(1_u64)));

--- a/tests/benchmarks/out/refcount/ref_fibonacci.rs
+++ b/tests/benchmarks/out/refcount/ref_fibonacci.rs
@@ -7,7 +7,7 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 pub fn fib_0(n: Ptr<u64>) {
-    if (((n.read()) == 0_u64) || ((n.read()) == 1_u64)) {
+    if ((n.read()) == 0_u64) || ((n.read()) == 1_u64) {
         return;
     }
     let n_1: Value<u64> = Rc::new(RefCell::new((n.read()).wrapping_sub(1_u64)));

--- a/tests/benchmarks/out/unsafe/bst.rs
+++ b/tests/benchmarks/out/unsafe/bst.rs
@@ -14,13 +14,13 @@ pub struct node_t {
     pub value: i32,
 }
 pub unsafe fn find_0(mut node: *mut node_t, mut value: i32) -> *mut node_t {
-    if (((value) < ((*node).value)) && (!(((*node).left).is_null()))) {
+    if ((value) < ((*node).value)) && (!(((*node).left).is_null())) {
         return (unsafe {
             let _node: *mut node_t = (*node).left;
             let _value: i32 = value;
             find_0(_node, _value)
         });
-    } else if (((value) > ((*node).value)) && (!(((*node).right).is_null()))) {
+    } else if ((value) > ((*node).value)) && (!(((*node).right).is_null())) {
         return (unsafe {
             let _node: *mut node_t = (*node).right;
             let _value: i32 = value;

--- a/tests/benchmarks/out/unsafe/fibonacci.rs
+++ b/tests/benchmarks/out/unsafe/fibonacci.rs
@@ -7,7 +7,7 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn fib_0(mut n: u64) -> u64 {
-    return if (((n) == (0_u64)) || ((n) == (1_u64))) {
+    return if ((n) == (0_u64)) || ((n) == (1_u64)) {
         n
     } else {
         (unsafe {

--- a/tests/benchmarks/out/unsafe/ptr_fibonacci.rs
+++ b/tests/benchmarks/out/unsafe/ptr_fibonacci.rs
@@ -7,7 +7,7 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn fib_0(mut n: *mut u64) {
-    if (((*n) == (0_u64)) || ((*n) == (1_u64))) {
+    if ((*n) == (0_u64)) || ((*n) == (1_u64)) {
         return;
     }
     let mut n_1: u64 = (*n).wrapping_sub(1_u64);

--- a/tests/benchmarks/out/unsafe/ref_fibonacci.rs
+++ b/tests/benchmarks/out/unsafe/ref_fibonacci.rs
@@ -7,7 +7,7 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn fib_0(n: *mut u64) {
-    if (((*n) == (0_u64)) || ((*n) == (1_u64))) {
+    if ((*n) == (0_u64)) || ((*n) == (1_u64)) {
         return;
     }
     let mut n_1: u64 = (*n).wrapping_sub(1_u64);

--- a/tests/ub/out/refcount/ub6.rs
+++ b/tests/ub/out/refcount/ub6.rs
@@ -48,13 +48,11 @@ pub fn any_2(arr: Ptr<Option<Value<Box<[Ptr<i32>]>>>>, n1: Ptr<i32>) -> bool {
         let _lhs = (*i.borrow());
         _lhs < (n1.read())
     } {
-        let __rhs = {
-            let _lhs = (*out.borrow());
-            _lhs || (((*arr.upgrade().deref()).as_ref().unwrap().borrow()
+        let __rhs = (*out.borrow())
+            || (((*arr.upgrade().deref()).as_ref().unwrap().borrow()
                 [((*i.borrow()) as u64) as usize]
                 .read())
-                == 0)
-        };
+                == 0);
         (*out.borrow_mut()) = __rhs;
         (*i.borrow_mut()).prefix_inc();
     }

--- a/tests/ub/out/unsafe/ub6.rs
+++ b/tests/ub/out/unsafe/ub6.rs
@@ -29,7 +29,7 @@ pub unsafe fn any_2(arr: *mut Option<Box<[*mut i32]>>, n1: *mut i32) -> bool {
     let mut out: bool = false;
     let mut i: i32 = 0;
     'loop_: while ((i) < (*n1)) {
-        out = ((out) || ((*(*arr).as_mut().unwrap()[(i as u64) as usize]) == (0)));
+        out = (out) || ((*(*arr).as_mut().unwrap()[(i as u64) as usize]) == (0));
         i.prefix_inc();
     }
     return out;

--- a/tests/unit/bool_condition_logical.cpp
+++ b/tests/unit/bool_condition_logical.cpp
@@ -9,6 +9,9 @@ int observe(int v) {
   return v;
 }
 
+int returns_one() { return 1; }
+int returns_zero() { return 0; }
+
 int main() {
   int n = 3;
   int zero = 0;
@@ -74,6 +77,51 @@ int main() {
   }
 
   if (((x > y)) || ((flags & 0x4u))) {
+    assert(true);
+  }
+
+  unsigned long long ull = 7ull;
+  if ((p != nullptr) && ull) {
+    assert(true);
+  }
+  if ((x > y) && ull) {
+    assert(true);
+  }
+
+  long long mask = (1ll << 4) | (1ll << 5);
+  long long bits = 1ll << 4;
+  if ((n != 0) && (bits & mask)) {
+    assert(true);
+  }
+  if ((n != 0) || (bits & 0x100ll)) {
+    assert(true);
+  }
+
+  const char *cp = "hi";
+  const char *cnp = nullptr;
+  if ((x > y) && cp) {
+    assert(true);
+  }
+  if ((x < y) || cnp) {
+    assert(false);
+  }
+  if ((x > y) && (n && cp)) {
+    assert(true);
+  }
+
+  if ((x > y) && returns_one()) {
+    assert(true);
+  }
+  if ((x > y) && !returns_zero()) {
+    assert(true);
+  }
+  if ((x < y) || returns_one()) {
+    assert(true);
+  }
+  if ((x < y) || !returns_one()) {
+    assert(false);
+  }
+  if ((p != nullptr) && returns_one() && (n != 0)) {
     assert(true);
   }
 

--- a/tests/unit/bool_condition_logical_c.c
+++ b/tests/unit/bool_condition_logical_c.c
@@ -10,6 +10,9 @@ int observe(int v) {
   return v;
 }
 
+int returns_one(void) { return 1; }
+int returns_zero(void) { return 0; }
+
 int main() {
   int n = 3;
   int zero = 0;
@@ -75,6 +78,51 @@ int main() {
   }
 
   if (((x > y)) || ((flags & 0x4u))) {
+    assert(true);
+  }
+
+  unsigned long long ull = 7ull;
+  if ((p != NULL) && ull) {
+    assert(true);
+  }
+  if ((x > y) && ull) {
+    assert(true);
+  }
+
+  long long mask = (1ll << 4) | (1ll << 5);
+  long long bits = 1ll << 4;
+  if ((n != 0) && (bits & mask)) {
+    assert(true);
+  }
+  if ((n != 0) || (bits & 0x100ll)) {
+    assert(true);
+  }
+
+  const char *cp = "hi";
+  const char *cnp = NULL;
+  if ((x > y) && cp) {
+    assert(true);
+  }
+  if ((x < y) || cnp) {
+    assert(false);
+  }
+  if ((x > y) && (n && cp)) {
+    assert(true);
+  }
+
+  if ((x > y) && returns_one()) {
+    assert(true);
+  }
+  if ((x > y) && !returns_zero()) {
+    assert(true);
+  }
+  if ((x < y) || returns_one()) {
+    assert(true);
+  }
+  if ((x < y) || !returns_one()) {
+    assert(false);
+  }
+  if ((p != NULL) && returns_one() && (n != 0)) {
     assert(true);
   }
 

--- a/tests/unit/expr_as_bool_c.c
+++ b/tests/unit/expr_as_bool_c.c
@@ -1,5 +1,12 @@
 #include <assert.h>
 #include <stdbool.h>
+#include <stddef.h>
+
+int cmp_eq(int rc) { return rc == -1; }
+int cmp_or_ptr(const char *p, const char *q) { return p || q; }
+int both_null(const char *s1, const char *s2) {
+  return (s1 == NULL) && (s2 == NULL);
+}
 
 int main() {
   int a = 0;
@@ -25,5 +32,28 @@ int main() {
   c = a;
   c = a == b;
   c = a < b;
+
+  int x = 5, y = 5;
+  int eq = x == y;
+  int lt = x < y;
+  int neq = x != y;
+  assert(eq == 1);
+  assert(lt == 0);
+  assert(neq == 0);
+
+  const char *p1 = "hi";
+  const char *p2 = NULL;
+  int either = p1 || p2;
+  int both = p1 && p2;
+  assert(either == 1);
+  assert(both == 0);
+
+  assert(cmp_eq(-1) == 1);
+  assert(cmp_eq(0) == 0);
+  assert(cmp_or_ptr(p1, p2) == 1);
+  assert(cmp_or_ptr(NULL, NULL) == 0);
+  assert(both_null(NULL, NULL) == 1);
+  assert(both_null(p1, NULL) == 0);
+
   return 0;
 }

--- a/tests/unit/expr_as_bool_cpp.cpp
+++ b/tests/unit/expr_as_bool_cpp.cpp
@@ -1,5 +1,12 @@
 #include <assert.h>
 #include <stdbool.h>
+#include <stddef.h>
+
+int cmp_eq(int rc) { return rc == -1; }
+int cmp_or_ptr(const char *p, const char *q) { return p || q; }
+int both_null(const char *s1, const char *s2) {
+  return (s1 == nullptr) && (s2 == nullptr);
+}
 
 int main() {
   int a = 0;
@@ -25,5 +32,28 @@ int main() {
   c = a;
   c = a == b;
   c = a < b;
+
+  int x = 5, y = 5;
+  int eq = x == y;
+  int lt = x < y;
+  int neq = x != y;
+  assert(eq == 1);
+  assert(lt == 0);
+  assert(neq == 0);
+
+  const char *p1 = "hi";
+  const char *p2 = nullptr;
+  int either = p1 || p2;
+  int both = p1 && p2;
+  assert(either == 1);
+  assert(both == 0);
+
+  assert(cmp_eq(-1) == 1);
+  assert(cmp_eq(0) == 0);
+  assert(cmp_or_ptr(p1, p2) == 1);
+  assert(cmp_or_ptr(nullptr, nullptr) == 0);
+  assert(both_null(nullptr, nullptr) == 1);
+  assert(both_null(p1, nullptr) == 0);
+
   return 0;
 }

--- a/tests/unit/out/refcount/anonymous-struct_c.rs
+++ b/tests/unit/out/refcount/anonymous-struct_c.rs
@@ -85,26 +85,28 @@ fn main_0() -> i32 {
     (*(*(*(*o.borrow()).anon_3.borrow()).anon_1.borrow())
         .k
         .borrow_mut()) = 11;
-    assert!(((*(*(*o.borrow()).named.borrow()).a.borrow()) == 1));
-    assert!(((*(*(*o.borrow()).named.borrow()).b.borrow()) == 2));
-    assert!(((*(*(*o.borrow()).anon0.borrow()).c.borrow()) == 3));
-    assert!(((*(*(*o.borrow()).anon0.borrow()).d.borrow()) == 4));
-    assert!(((*(*(*o.borrow()).anon1.borrow()).g.borrow()) == 5));
-    assert!(((*(*(*o.borrow()).anon1.borrow()).h.borrow()) == 6));
-    assert!(((*(*(*o.borrow()).anon_2.borrow()).e.borrow()) == 7));
-    assert!(((*(*(*o.borrow()).anon_2.borrow()).f.borrow()) == 8));
-    assert!(((*(*(*o.borrow()).anon_3.borrow()).i.borrow()) == 9));
+    assert!(((((*(*(*o.borrow()).named.borrow()).a.borrow()) == 1) as i32) != 0));
+    assert!(((((*(*(*o.borrow()).named.borrow()).b.borrow()) == 2) as i32) != 0));
+    assert!(((((*(*(*o.borrow()).anon0.borrow()).c.borrow()) == 3) as i32) != 0));
+    assert!(((((*(*(*o.borrow()).anon0.borrow()).d.borrow()) == 4) as i32) != 0));
+    assert!(((((*(*(*o.borrow()).anon1.borrow()).g.borrow()) == 5) as i32) != 0));
+    assert!(((((*(*(*o.borrow()).anon1.borrow()).h.borrow()) == 6) as i32) != 0));
+    assert!(((((*(*(*o.borrow()).anon_2.borrow()).e.borrow()) == 7) as i32) != 0));
+    assert!(((((*(*(*o.borrow()).anon_2.borrow()).f.borrow()) == 8) as i32) != 0));
+    assert!(((((*(*(*o.borrow()).anon_3.borrow()).i.borrow()) == 9) as i32) != 0));
     assert!(
-        ((*(*(*(*o.borrow()).anon_3.borrow()).inner_named.borrow())
+        ((((*(*(*(*o.borrow()).anon_3.borrow()).inner_named.borrow())
             .j
             .borrow())
-            == 10)
+            == 10) as i32)
+            != 0)
     );
     assert!(
-        ((*(*(*(*o.borrow()).anon_3.borrow()).anon_1.borrow())
+        ((((*(*(*(*o.borrow()).anon_3.borrow()).anon_1.borrow())
             .k
             .borrow())
-            == 11)
+            == 11) as i32)
+            != 0)
     );
     #[derive(Default)]
     pub struct anon_0 {

--- a/tests/unit/out/refcount/anonymous_enum_c.rs
+++ b/tests/unit/out/refcount/anonymous_enum_c.rs
@@ -96,17 +96,25 @@ fn main_0() -> i32 {
             }
         }
     };
-    assert!(((anon_enum_3::FIRST_A as i32) != (anon_enum_3::FIRST_B as i32)));
-    assert!(((anon_enum_11::SECOND_A as i32) != (anon_enum_11::SECOND_B as i32)));
-    assert!(((anon_enum_31::THIRD_A as i32) != (anon_enum_31::THIRD_B as i32)));
+    assert!(((((anon_enum_3::FIRST_A as i32) != (anon_enum_3::FIRST_B as i32)) as i32) != 0));
+    assert!(((((anon_enum_11::SECOND_A as i32) != (anon_enum_11::SECOND_B as i32)) as i32) != 0));
+    assert!(((((anon_enum_31::THIRD_A as i32) != (anon_enum_31::THIRD_B as i32)) as i32) != 0));
     let td: Value<TdEnum> = Rc::new(RefCell::new(TdEnum::from((TdEnum::TD_A as i32))));
-    assert!((((*td.borrow()) as u32) == ((TdEnum::TD_A as i32) as u32)));
+    assert!((((((*td.borrow()) as u32) == ((TdEnum::TD_A as i32) as u32)) as i32) != 0));
     (*td.borrow_mut()) = TdEnum::from((TdEnum::TD_B as i32));
-    assert!((((*td.borrow()) as u32) == ((TdEnum::TD_B as i32) as u32)));
+    assert!((((((*td.borrow()) as u32) == ((TdEnum::TD_B as i32) as u32)) as i32) != 0));
     let w: Value<WithAnonField> = <Value<WithAnonField>>::default();
     (*(*w.borrow()).field.borrow_mut()) = anon_enum_24::from((anon_enum_24::FIELD_A as i32));
-    assert!((((*(*w.borrow()).field.borrow()) as u32) == ((anon_enum_24::FIELD_A as i32) as u32)));
+    assert!(
+        (((((*(*w.borrow()).field.borrow()) as u32) == ((anon_enum_24::FIELD_A as i32) as u32))
+            as i32)
+            != 0)
+    );
     (*(*w.borrow()).field.borrow_mut()) = anon_enum_24::from((anon_enum_24::FIELD_B as i32));
-    assert!((((*(*w.borrow()).field.borrow()) as u32) == ((anon_enum_24::FIELD_B as i32) as u32)));
+    assert!(
+        (((((*(*w.borrow()).field.borrow()) as u32) == ((anon_enum_24::FIELD_B as i32) as u32))
+            as i32)
+            != 0)
+    );
     return 0;
 }

--- a/tests/unit/out/refcount/bool_condition_enum_c.rs
+++ b/tests/unit/out/refcount/bool_condition_enum_c.rs
@@ -42,7 +42,7 @@ fn main_0() -> i32 {
         assert!((0 != 0));
     }
     let t9: Value<i32> = Rc::new(RefCell::new((!((*code.borrow()) != Code::from(0)) as i32)));
-    assert!(((*t9.borrow()) == 1));
+    assert!(((((*t9.borrow()) == 1) as i32) != 0));
     let b4: Value<bool> = Rc::new(RefCell::new(((*code.borrow()) != Code::from(0)).clone()));
     assert!(((!(*b4.borrow()) as i32) != 0));
     return 0;

--- a/tests/unit/out/refcount/bool_condition_int_c.rs
+++ b/tests/unit/out/refcount/bool_condition_int_c.rs
@@ -46,25 +46,25 @@ fn main_0() -> i32 {
         (*counter.borrow_mut()).prefix_dec();
         (*loop_count.borrow_mut()).prefix_inc();
     }
-    assert!(((*loop_count.borrow()) == 3));
+    assert!(((((*loop_count.borrow()) == 3) as i32) != 0));
     let i: Value<i32> = Rc::new(RefCell::new(5));
     'loop_: while ((*i.borrow()) != 0) {
         (*loop_count.borrow_mut()).prefix_inc();
         (*i.borrow_mut()).prefix_dec();
     }
-    assert!(((*loop_count.borrow()) == 8));
+    assert!(((((*loop_count.borrow()) == 8) as i32) != 0));
     let t: Value<i32> = Rc::new(RefCell::new(if ((*n.borrow()) != 0) { 100 } else { 200 }));
-    assert!(((*t.borrow()) == 100));
+    assert!(((((*t.borrow()) == 100) as i32) != 0));
     let t2: Value<i32> = Rc::new(RefCell::new(if ((*zero.borrow()) != 0) {
         100
     } else {
         200
     }));
-    assert!(((*t2.borrow()) == 200));
+    assert!(((((*t2.borrow()) == 200) as i32) != 0));
     let t7: Value<i32> = Rc::new(RefCell::new((!((*n.borrow()) != 0) as i32)));
-    assert!(((*t7.borrow()) == 0));
+    assert!(((((*t7.borrow()) == 0) as i32) != 0));
     let t8: Value<i32> = Rc::new(RefCell::new((!((*zero.borrow()) != 0) as i32)));
-    assert!(((*t8.borrow()) == 1));
+    assert!(((((*t8.borrow()) == 1) as i32) != 0));
     let b1: Value<bool> = Rc::new(RefCell::new(((*n.borrow()) != 0)));
     assert!((*b1.borrow()));
     return 0;

--- a/tests/unit/out/refcount/bool_condition_logical.rs
+++ b/tests/unit/out/refcount/bool_condition_logical.rs
@@ -31,6 +31,12 @@ pub fn observe_0(v: i32) -> i32 {
     (*side_effect.with(Value::clone).borrow_mut()).prefix_inc();
     return (*v.borrow());
 }
+pub fn returns_one_1() -> i32 {
+    return 1;
+}
+pub fn returns_zero_2() -> i32 {
+    return 0;
+}
 pub fn main() {
     std::process::exit(main_0());
 }
@@ -42,54 +48,38 @@ fn main_0() -> i32 {
     let np: Value<Ptr<i32>> = Rc::new(RefCell::new(Default::default()));
     let u: Value<u32> = Rc::new(RefCell::new(4_u32));
     let code: Value<Code> = Rc::new(RefCell::new(Code::CODE_OK));
-    if {
-        let _lhs = ((*n.borrow()) != 0);
-        _lhs && (!(*p.borrow()).is_null()).clone()
-    } {
+    if ((*n.borrow()) != 0) && (!(*p.borrow()).is_null()) {
         assert!(true);
     }
-    if {
-        let _lhs = ((*n.borrow()) != 0);
-        _lhs && (!(*np.borrow()).is_null()).clone()
-    } {
+    if ((*n.borrow()) != 0) && (!(*np.borrow()).is_null()) {
         assert!(false);
     }
-    if {
-        let _lhs = ((*zero.borrow()) != 0);
-        _lhs || (!(*p.borrow()).is_null()).clone()
-    } {
+    if ((*zero.borrow()) != 0) || (!(*p.borrow()).is_null()) {
         assert!(true);
     }
-    if {
-        let _lhs = ((*zero.borrow()) != 0);
-        _lhs || (!(*np.borrow()).is_null()).clone()
-    } {
+    if ((*zero.borrow()) != 0) || (!(*np.borrow()).is_null()) {
         assert!(false);
     }
-    if {
-        let _lhs = {
-            let _lhs = (((*n.borrow()) != 0) && ((*u.borrow()) != 0));
-            _lhs && (!(*p.borrow()).is_null()).clone()
-        };
-        _lhs && (((*code.borrow()) as i32) == (Code::CODE_OK as i32)).clone()
-    } {
+    if ((((*n.borrow()) != 0) && ((*u.borrow()) != 0)) && (!(*p.borrow()).is_null()))
+        && (((*code.borrow()) as i32) == (Code::CODE_OK as i32))
+    {
         assert!(true);
     }
     (*side_effect.with(Value::clone).borrow_mut()) = 0;
-    if (((*zero.borrow()) != 0)
+    if ((*zero.borrow()) != 0)
         && (({
             let _v: i32 = 1;
             observe_0(_v)
-        }) != 0))
+        }) != 0)
     {
         assert!(false);
     }
     assert!(((*side_effect.with(Value::clone).borrow()) == 0));
-    if (((*n.borrow()) != 0)
+    if ((*n.borrow()) != 0)
         || (({
             let _v: i32 = 1;
             observe_0(_v)
-        }) != 0))
+        }) != 0)
     {
         assert!(true);
     }
@@ -97,31 +87,69 @@ fn main_0() -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(5));
     let y: Value<i32> = Rc::new(RefCell::new(3));
     let flags: Value<u32> = Rc::new(RefCell::new(2_u32));
-    if (((*x.borrow()) > (*y.borrow())) || (((*flags.borrow()) & 1_u32) != 0)) {
+    if ((*x.borrow()) > (*y.borrow())) || (((*flags.borrow()) & 1_u32) != 0) {
         assert!(true);
     }
-    if (((*x.borrow()) < (*y.borrow())) || (((*flags.borrow()) & 1_u32) != 0)) {
+    if ((*x.borrow()) < (*y.borrow())) || (((*flags.borrow()) & 1_u32) != 0) {
         assert!(false);
     }
     let a: Value<u32> = Rc::new(RefCell::new(1_u32));
     let b: Value<u32> = Rc::new(RefCell::new(2_u32));
     let c: Value<u32> = Rc::new(RefCell::new(3_u32));
-    if (((*a.borrow()) != (*c.borrow())) && ((*b.borrow()) != (*c.borrow()))) {
+    if ((*a.borrow()) != (*c.borrow())) && ((*b.borrow()) != (*c.borrow())) {
         assert!(true);
     }
     let s: Value<i32> = Rc::new(RefCell::new(-1_i32));
-    if {
-        let _lhs = (!((*p.borrow()).is_null())).clone();
-        _lhs && ((*s.borrow()) < 0)
-    } {
+    if (!((*p.borrow()).is_null())) && ((*s.borrow()) < 0) {
         assert!(true);
     }
     let k: Value<u32> = Rc::new(RefCell::new(2_u32));
     let done: Value<bool> = Rc::new(RefCell::new(false));
-    if (((*k.borrow()) > 1_u32) || !(*done.borrow())) {
+    if ((*k.borrow()) > 1_u32) || (!(*done.borrow())) {
         assert!(true);
     }
-    if (((*x.borrow()) > (*y.borrow())) || (((*flags.borrow()) & 4_u32) != 0)) {
+    if ((*x.borrow()) > (*y.borrow())) || (((*flags.borrow()) & 4_u32) != 0) {
+        assert!(true);
+    }
+    let ull: Value<u64> = Rc::new(RefCell::new(7_u64));
+    if (!((*p.borrow()).is_null())) && ((*ull.borrow()) != 0) {
+        assert!(true);
+    }
+    if ((*x.borrow()) > (*y.borrow())) && ((*ull.borrow()) != 0) {
+        assert!(true);
+    }
+    let mask: Value<i64> = Rc::new(RefCell::new(((1_i64 << 4) | (1_i64 << 5))));
+    let bits: Value<i64> = Rc::new(RefCell::new((1_i64 << 4)));
+    if ((*n.borrow()) != 0) && (((*bits.borrow()) & (*mask.borrow())) != 0) {
+        assert!(true);
+    }
+    if ((*n.borrow()) != 0) || (((*bits.borrow()) & 256_i64) != 0) {
+        assert!(true);
+    }
+    let cp: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal("hi")));
+    let cnp: Value<Ptr<u8>> = Rc::new(RefCell::new(Default::default()));
+    if ((*x.borrow()) > (*y.borrow())) && (!(*cp.borrow()).is_null()) {
+        assert!(true);
+    }
+    if ((*x.borrow()) < (*y.borrow())) || (!(*cnp.borrow()).is_null()) {
+        assert!(false);
+    }
+    if ((*x.borrow()) > (*y.borrow())) && (((*n.borrow()) != 0) && (!(*cp.borrow()).is_null())) {
+        assert!(true);
+    }
+    if ((*x.borrow()) > (*y.borrow())) && (({ returns_one_1() }) != 0) {
+        assert!(true);
+    }
+    if ((*x.borrow()) > (*y.borrow())) && (!(({ returns_zero_2() }) != 0)) {
+        assert!(true);
+    }
+    if ((*x.borrow()) < (*y.borrow())) || (({ returns_one_1() }) != 0) {
+        assert!(true);
+    }
+    if ((*x.borrow()) < (*y.borrow())) || (!(({ returns_one_1() }) != 0)) {
+        assert!(false);
+    }
+    if ((!((*p.borrow()).is_null())) && (({ returns_one_1() }) != 0)) && ((*n.borrow()) != 0) {
         assert!(true);
     }
     return 0;

--- a/tests/unit/out/refcount/bool_condition_logical_c.rs
+++ b/tests/unit/out/refcount/bool_condition_logical_c.rs
@@ -31,6 +31,12 @@ pub fn observe_0(v: i32) -> i32 {
     (*side_effect.with(Value::clone).borrow_mut()).prefix_inc();
     return (*v.borrow());
 }
+pub fn returns_one_1() -> i32 {
+    return 1;
+}
+pub fn returns_zero_2() -> i32 {
+    return 0;
+}
 pub fn main() {
     std::process::exit(main_0());
 }
@@ -42,67 +48,158 @@ fn main_0() -> i32 {
     let np: Value<Ptr<i32>> = Rc::new(RefCell::new(Default::default()));
     let u: Value<u32> = Rc::new(RefCell::new(4_u32));
     let code: Value<Code> = Rc::new(RefCell::new(Code::from((Code::CODE_OK as i32))));
-    if ((*n.borrow()) != 0) && (!(*p.borrow()).is_null()) {
+    if (((((*n.borrow()) != 0) && (!(*p.borrow()).is_null())) as i32) != 0) {
         assert!((1 != 0));
     }
-    if ((*n.borrow()) != 0) && (!(*np.borrow()).is_null()) {
+    if (((((*n.borrow()) != 0) && (!(*np.borrow()).is_null())) as i32) != 0) {
         assert!((0 != 0));
     }
-    if ((*zero.borrow()) != 0) || (!(*p.borrow()).is_null()) {
+    if (((((*zero.borrow()) != 0) || (!(*p.borrow()).is_null())) as i32) != 0) {
         assert!((1 != 0));
     }
-    if ((*zero.borrow()) != 0) || (!(*np.borrow()).is_null()) {
+    if (((((*zero.borrow()) != 0) || (!(*np.borrow()).is_null())) as i32) != 0) {
         assert!((0 != 0));
     }
-    if ((((*n.borrow()) != 0) && ((*u.borrow()) != 0)) && (!(*p.borrow()).is_null()))
-        && (((*code.borrow()) as u32) == ((Code::CODE_OK as i32) as u32))
+    if (((((((((((*n.borrow()) != 0) && ((*u.borrow()) != 0)) as i32) != 0)
+        && (!(*p.borrow()).is_null())) as i32)
+        != 0)
+        && (((((*code.borrow()) as u32) == ((Code::CODE_OK as i32) as u32)) as i32) != 0))
+        as i32)
+        != 0)
     {
         assert!((1 != 0));
     }
     (*side_effect.with(Value::clone).borrow_mut()) = 0;
-    if ((*zero.borrow()) != 0)
+    if (((((*zero.borrow()) != 0)
         && (({
             let _v: i32 = 1;
             observe_0(_v)
-        }) != 0)
+        }) != 0)) as i32)
+        != 0)
     {
         assert!((0 != 0));
     }
-    assert!(((*side_effect.with(Value::clone).borrow()) == 0));
-    if ((*n.borrow()) != 0)
+    assert!(((((*side_effect.with(Value::clone).borrow()) == 0) as i32) != 0));
+    if (((((*n.borrow()) != 0)
         || (({
             let _v: i32 = 1;
             observe_0(_v)
-        }) != 0)
+        }) != 0)) as i32)
+        != 0)
     {
         assert!((1 != 0));
     }
-    assert!(((*side_effect.with(Value::clone).borrow()) == 0));
+    assert!(((((*side_effect.with(Value::clone).borrow()) == 0) as i32) != 0));
     let x: Value<i32> = Rc::new(RefCell::new(5));
     let y: Value<i32> = Rc::new(RefCell::new(3));
     let flags: Value<u32> = Rc::new(RefCell::new(2_u32));
-    if ((*x.borrow()) > (*y.borrow())) || (((*flags.borrow()) & 1_u32) != 0) {
+    if (((((((*x.borrow()) > (*y.borrow())) as i32) != 0) || (((*flags.borrow()) & 1_u32) != 0))
+        as i32)
+        != 0)
+    {
         assert!((1 != 0));
     }
-    if ((*x.borrow()) < (*y.borrow())) || (((*flags.borrow()) & 1_u32) != 0) {
+    if (((((((*x.borrow()) < (*y.borrow())) as i32) != 0) || (((*flags.borrow()) & 1_u32) != 0))
+        as i32)
+        != 0)
+    {
         assert!((0 != 0));
     }
     let a: Value<u32> = Rc::new(RefCell::new(1_u32));
     let b: Value<u32> = Rc::new(RefCell::new(2_u32));
     let c: Value<u32> = Rc::new(RefCell::new(3_u32));
-    if ((*a.borrow()) != (*c.borrow())) && ((*b.borrow()) != (*c.borrow())) {
+    if (((((((*a.borrow()) != (*c.borrow())) as i32) != 0)
+        && ((((*b.borrow()) != (*c.borrow())) as i32) != 0)) as i32)
+        != 0)
+    {
         assert!((1 != 0));
     }
     let s: Value<i32> = Rc::new(RefCell::new(-1_i32));
-    if ((*p.borrow()) != (Default::default())) && ((*s.borrow()) < 0) {
+    if (((((((*p.borrow()) != (Default::default())) as i32) != 0)
+        && ((((*s.borrow()) < 0) as i32) != 0)) as i32)
+        != 0)
+    {
         assert!((1 != 0));
     }
     let k: Value<u32> = Rc::new(RefCell::new(2_u32));
     let done: Value<bool> = Rc::new(RefCell::new((0 != 0)));
-    if ((*k.borrow()) > 1_u32) || (!(*done.borrow())) {
+    if (((((((*k.borrow()) > 1_u32) as i32) != 0) || (!(*done.borrow()))) as i32) != 0) {
         assert!((1 != 0));
     }
-    if ((*x.borrow()) > (*y.borrow())) || (((*flags.borrow()) & 4_u32) != 0) {
+    if (((((((*x.borrow()) > (*y.borrow())) as i32) != 0) || (((*flags.borrow()) & 4_u32) != 0))
+        as i32)
+        != 0)
+    {
+        assert!((1 != 0));
+    }
+    let ull: Value<u64> = Rc::new(RefCell::new(7_u64));
+    if (((((((*p.borrow()) != (Default::default())) as i32) != 0) && ((*ull.borrow()) != 0))
+        as i32)
+        != 0)
+    {
+        assert!((1 != 0));
+    }
+    if (((((((*x.borrow()) > (*y.borrow())) as i32) != 0) && ((*ull.borrow()) != 0)) as i32) != 0) {
+        assert!((1 != 0));
+    }
+    let mask: Value<i64> = Rc::new(RefCell::new(((1_i64 << 4) | (1_i64 << 5))));
+    let bits: Value<i64> = Rc::new(RefCell::new((1_i64 << 4)));
+    if (((((((*n.borrow()) != 0) as i32) != 0) && (((*bits.borrow()) & (*mask.borrow())) != 0))
+        as i32)
+        != 0)
+    {
+        assert!((1 != 0));
+    }
+    if (((((((*n.borrow()) != 0) as i32) != 0) || (((*bits.borrow()) & 256_i64) != 0)) as i32) != 0)
+    {
+        assert!((1 != 0));
+    }
+    let cp: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal("hi")));
+    let cnp: Value<Ptr<u8>> = Rc::new(RefCell::new(Default::default()));
+    if (((((((*x.borrow()) > (*y.borrow())) as i32) != 0) && (!(*cp.borrow()).is_null())) as i32)
+        != 0)
+    {
+        assert!((1 != 0));
+    }
+    if (((((((*x.borrow()) < (*y.borrow())) as i32) != 0) || (!(*cnp.borrow()).is_null())) as i32)
+        != 0)
+    {
+        assert!((0 != 0));
+    }
+    if (((((((*x.borrow()) > (*y.borrow())) as i32) != 0)
+        && (((((*n.borrow()) != 0) && (!(*cp.borrow()).is_null())) as i32) != 0)) as i32)
+        != 0)
+    {
+        assert!((1 != 0));
+    }
+    if (((((((*x.borrow()) > (*y.borrow())) as i32) != 0) && (({ returns_one_1() }) != 0)) as i32)
+        != 0)
+    {
+        assert!((1 != 0));
+    }
+    if (((((((*x.borrow()) > (*y.borrow())) as i32) != 0) && (!(({ returns_zero_2() }) != 0)))
+        as i32)
+        != 0)
+    {
+        assert!((1 != 0));
+    }
+    if (((((((*x.borrow()) < (*y.borrow())) as i32) != 0) || (({ returns_one_1() }) != 0)) as i32)
+        != 0)
+    {
+        assert!((1 != 0));
+    }
+    if (((((((*x.borrow()) < (*y.borrow())) as i32) != 0) || (!(({ returns_one_1() }) != 0)))
+        as i32)
+        != 0)
+    {
+        assert!((0 != 0));
+    }
+    if ((((((((((*p.borrow()) != (Default::default())) as i32) != 0)
+        && (({ returns_one_1() }) != 0)) as i32)
+        != 0)
+        && ((((*n.borrow()) != 0) as i32) != 0)) as i32)
+        != 0)
+    {
         assert!((1 != 0));
     }
     return 0;

--- a/tests/unit/out/refcount/bool_condition_ptr_c.rs
+++ b/tests/unit/out/refcount/bool_condition_ptr_c.rs
@@ -31,15 +31,15 @@ fn main_0() -> i32 {
         (*iters.borrow_mut()).prefix_inc();
         (*iter.borrow_mut()) = Default::default();
     }
-    assert!(((*iters.borrow()) == 1));
+    assert!(((((*iters.borrow()) == 1) as i32) != 0));
     let t3: Value<i32> = Rc::new(RefCell::new(if !(*p.borrow()).is_null() { 1 } else { 0 }));
-    assert!(((*t3.borrow()) == 1));
+    assert!(((((*t3.borrow()) == 1) as i32) != 0));
     let t4: Value<i32> = Rc::new(RefCell::new(if !(*np.borrow()).is_null() { 1 } else { 0 }));
-    assert!(((*t4.borrow()) == 0));
+    assert!(((((*t4.borrow()) == 0) as i32) != 0));
     let t5: Value<i32> = Rc::new(RefCell::new((!!(*p.borrow()).is_null() as i32)));
-    assert!(((*t5.borrow()) == 0));
+    assert!(((((*t5.borrow()) == 0) as i32) != 0));
     let t6: Value<i32> = Rc::new(RefCell::new((!!(*np.borrow()).is_null() as i32)));
-    assert!(((*t6.borrow()) == 1));
+    assert!(((((*t6.borrow()) == 1) as i32) != 0));
     let b2: Value<bool> = Rc::new(RefCell::new((!(*p.borrow()).is_null()).clone()));
     let b3: Value<bool> = Rc::new(RefCell::new((!(*np.borrow()).is_null()).clone()));
     assert!((*b2.borrow()));

--- a/tests/unit/out/refcount/bst.rs
+++ b/tests/unit/out/refcount/bst.rs
@@ -26,25 +26,21 @@ impl ByteRepr for node_t {}
 pub fn find_0(node: Ptr<node_t>, value: i32) -> Ptr<node_t> {
     let node: Value<Ptr<node_t>> = Rc::new(RefCell::new(node));
     let value: Value<i32> = Rc::new(RefCell::new(value));
-    if {
-        let _lhs = {
-            let _lhs = (*value.borrow());
-            _lhs < (*(*(*node.borrow()).upgrade().deref()).value.borrow())
-        };
-        _lhs && (!((*(*(*node.borrow()).upgrade().deref()).left.borrow()).is_null())).clone()
-    } {
+    if ({
+        let _lhs = (*value.borrow());
+        _lhs < (*(*(*node.borrow()).upgrade().deref()).value.borrow())
+    }) && (!((*(*(*node.borrow()).upgrade().deref()).left.borrow()).is_null()))
+    {
         return ({
             let _node: Ptr<node_t> = (*(*(*node.borrow()).upgrade().deref()).left.borrow()).clone();
             let _value: i32 = (*value.borrow());
             find_0(_node, _value)
         });
-    } else if {
-        let _lhs = {
-            let _lhs = (*value.borrow());
-            _lhs > (*(*(*node.borrow()).upgrade().deref()).value.borrow())
-        };
-        _lhs && (!((*(*(*node.borrow()).upgrade().deref()).right.borrow()).is_null())).clone()
-    } {
+    } else if ({
+        let _lhs = (*value.borrow());
+        _lhs > (*(*(*node.borrow()).upgrade().deref()).value.borrow())
+    }) && (!((*(*(*node.borrow()).upgrade().deref()).right.borrow()).is_null()))
+    {
         return ({
             let _node: Ptr<node_t> =
                 (*(*(*node.borrow()).upgrade().deref()).right.borrow()).clone();
@@ -148,62 +144,60 @@ fn main_0() -> i32 {
         insert_1(_node, _new_node)
     });
     (*ptr1.borrow_mut()) = __rhs;
-    return (({
-        let _lhs = ((((((*(*({
+    return ((((((((*(*({
+        let _node: Ptr<node_t> = (*ptr1.borrow()).clone();
+        let _value: i32 = 0;
+        find_0(_node, _value)
+    })
+    .upgrade()
+    .deref())
+    .value
+    .borrow())
+        == 0)
+        && ((*(*({
             let _node: Ptr<node_t> = (*ptr1.borrow()).clone();
-            let _value: i32 = 0;
+            let _value: i32 = 1;
             find_0(_node, _value)
         })
         .upgrade()
         .deref())
         .value
         .borrow())
-            == 0)
-            && ((*(*({
-                let _node: Ptr<node_t> = (*ptr1.borrow()).clone();
-                let _value: i32 = 1;
-                find_0(_node, _value)
-            })
-            .upgrade()
-            .deref())
-            .value
-            .borrow())
-                == 1))
-            && ((*(*({
-                let _node: Ptr<node_t> = (*ptr1.borrow()).clone();
-                let _value: i32 = 2;
-                find_0(_node, _value)
-            })
-            .upgrade()
-            .deref())
-            .value
-            .borrow())
-                == 2))
-            && ((*(*({
-                let _node: Ptr<node_t> = (*ptr1.borrow()).clone();
-                let _value: i32 = 3;
-                find_0(_node, _value)
-            })
-            .upgrade()
-            .deref())
-            .value
-            .borrow())
-                == 3))
-            && ((*(*({
-                let _node: Ptr<node_t> = (*ptr1.borrow()).clone();
-                let _value: i32 = 4;
-                find_0(_node, _value)
-            })
-            .upgrade()
-            .deref())
-            .value
-            .borrow())
-                == 4));
-        _lhs && ({
+            == 1))
+        && ((*(*({
+            let _node: Ptr<node_t> = (*ptr1.borrow()).clone();
+            let _value: i32 = 2;
+            find_0(_node, _value)
+        })
+        .upgrade()
+        .deref())
+        .value
+        .borrow())
+            == 2))
+        && ((*(*({
+            let _node: Ptr<node_t> = (*ptr1.borrow()).clone();
+            let _value: i32 = 3;
+            find_0(_node, _value)
+        })
+        .upgrade()
+        .deref())
+        .value
+        .borrow())
+            == 3))
+        && ((*(*({
+            let _node: Ptr<node_t> = (*ptr1.borrow()).clone();
+            let _value: i32 = 4;
+            find_0(_node, _value)
+        })
+        .upgrade()
+        .deref())
+        .value
+        .borrow())
+            == 4))
+        && (({
             let _node: Ptr<node_t> = (*ptr1.borrow()).clone();
             let _value: i32 = 5;
             find_0(_node, _value)
         })
-        .is_null()
-    }) as i32);
+        .is_null())) as i32);
 }

--- a/tests/unit/out/refcount/builtin_types_compatible.rs
+++ b/tests/unit/out/refcount/builtin_types_compatible.rs
@@ -10,16 +10,16 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    assert!((1 == 1));
-    assert!((0 == 0));
+    assert!((((1 == 1) as i32) != 0));
+    assert!((((0 == 0) as i32) != 0));
     let x: Value<i32> = Rc::new(RefCell::new(0));
-    assert!((1 == 1));
-    assert!((0 == 0));
+    assert!((((1 == 1) as i32) != 0));
+    assert!((((0 == 0) as i32) != 0));
     let p: Value<Ptr<i32>> = Rc::new(RefCell::new(Default::default()));
-    assert!((1 == 1));
-    assert!((0 == 0));
+    assert!((((1 == 1) as i32) != 0));
+    assert!((((0 == 0) as i32) != 0));
     let ul: Value<u64> = Rc::new(RefCell::new(0_u64));
-    assert!((1 == 1));
-    assert!((0 == 0));
+    assert!((((1 == 1) as i32) != 0));
+    assert!((((0 == 0) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/refcount/c_struct.rs
+++ b/tests/unit/out/refcount/c_struct.rs
@@ -62,8 +62,8 @@ fn main_0() -> i32 {
         x: Rc::new(RefCell::new(10)),
         y: Rc::new(RefCell::new(20)),
     }));
-    assert!(((*(*p.borrow()).x.borrow()) == 10));
-    assert!(((*(*p.borrow()).y.borrow()) == 20));
+    assert!(((((*(*p.borrow()).x.borrow()) == 10) as i32) != 0));
+    assert!(((((*(*p.borrow()).y.borrow()) == 20) as i32) != 0));
     let l: Value<Line> = Rc::new(RefCell::new(Line {
         start: Rc::new(RefCell::new(Point {
             x: Rc::new(RefCell::new(1)),
@@ -74,8 +74,8 @@ fn main_0() -> i32 {
             y: Rc::new(RefCell::new(4)),
         })),
     }));
-    assert!(((*(*(*l.borrow()).start.borrow()).x.borrow()) == 1));
-    assert!(((*(*(*l.borrow()).end.borrow()).y.borrow()) == 4));
+    assert!(((((*(*(*l.borrow()).start.borrow()).x.borrow()) == 1) as i32) != 0));
+    assert!(((((*(*(*l.borrow()).end.borrow()).y.borrow()) == 4) as i32) != 0));
     let a: Value<Node> = Rc::new(RefCell::new(Node {
         value: Rc::new(RefCell::new(1)),
         next: Rc::new(RefCell::new(Default::default())),
@@ -85,10 +85,11 @@ fn main_0() -> i32 {
         next: Rc::new(RefCell::new((a.as_pointer()))),
     }));
     assert!(
-        ((*(*(*(*b.borrow()).next.borrow()).upgrade().deref())
+        ((((*(*(*(*b.borrow()).next.borrow()).upgrade().deref())
             .value
             .borrow())
-            == 1)
+            == 1) as i32)
+            != 0)
     );
     let c: Value<Container> = Rc::new(RefCell::new(Container {
         inner: Rc::new(RefCell::new(Inner {
@@ -98,12 +99,15 @@ fn main_0() -> i32 {
         color: Rc::new(RefCell::new(Color::from((Color::GREEN as i32)))),
         count: Rc::new(RefCell::new(42)),
     }));
-    assert!(((*(*(*c.borrow()).inner.borrow()).a.borrow()) == 5));
-    assert!(((*(*(*c.borrow()).inner.borrow()).b.borrow()) == 6));
-    assert!((((*(*c.borrow()).color.borrow()) as u32) == ((Color::GREEN as i32) as u32)));
-    assert!(((*(*c.borrow()).count.borrow()) == 42));
+    assert!(((((*(*(*c.borrow()).inner.borrow()).a.borrow()) == 5) as i32) != 0));
+    assert!(((((*(*(*c.borrow()).inner.borrow()).b.borrow()) == 6) as i32) != 0));
+    assert!(
+        (((((*(*c.borrow()).color.borrow()) as u32) == ((Color::GREEN as i32) as u32)) as i32)
+            != 0)
+    );
+    assert!(((((*(*c.borrow()).count.borrow()) == 42) as i32) != 0));
     let c2: Value<Container> = <Value<Container>>::default();
     (*(*c2.borrow()).color.borrow_mut()) = Color::from((Color::BLUE as i32));
-    assert!((((*(*c2.borrow()).color.borrow()) as u32) == 2_u32));
+    assert!((((((*(*c2.borrow()).color.borrow()) as u32) == 2_u32) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/refcount/enum_int_interop_c.rs
+++ b/tests/unit/out/refcount/enum_int_interop_c.rs
@@ -96,10 +96,10 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let c: Value<Color> = Rc::new(RefCell::new(Color::from((Color::RED as i32))));
-    assert!((((*c.borrow()) as u32) == ((Color::RED as i32) as u32)));
-    assert!((((*c.borrow()) as u32) == 0_u32));
-    assert!((((*c.borrow()) as u32) != 1_u32));
-    if (((*c.borrow()) as u32) == ((Color::GREEN as i32) as u32)) {
+    assert!((((((*c.borrow()) as u32) == ((Color::RED as i32) as u32)) as i32) != 0));
+    assert!((((((*c.borrow()) as u32) == 0_u32) as i32) != 0));
+    assert!((((((*c.borrow()) as u32) != 1_u32) as i32) != 0));
+    if (((((*c.borrow()) as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0) {
         return 1;
     }
     'switch: {
@@ -120,54 +120,54 @@ fn main_0() -> i32 {
         }
     };
     let x: Value<i32> = Rc::new(RefCell::new(((*c.borrow()) as i32).clone()));
-    assert!(((*x.borrow()) == 0));
+    assert!(((((*x.borrow()) == 0) as i32) != 0));
     let y: Value<i32> = Rc::new(RefCell::new(
         ((((*c.borrow()) as u32).wrapping_add(1_u32)) as i32),
     ));
-    assert!(((*y.borrow()) == 1));
+    assert!(((((*y.borrow()) == 1) as i32) != 0));
     (*c.borrow_mut()) = Color::from(2);
-    assert!((((*c.borrow()) as u32) == ((Color::BLUE as i32) as u32)));
-    assert!((((*c.borrow()) as u32) == 2_u32));
+    assert!((((((*c.borrow()) as u32) == ((Color::BLUE as i32) as u32)) as i32) != 0));
+    assert!((((((*c.borrow()) as u32) == 2_u32) as i32) != 0));
     (*c.borrow_mut()) = ({
         let _n: i32 = 1;
         make_color_2(_n)
     });
-    assert!((((*c.borrow()) as u32) == ((Color::GREEN as i32) as u32)));
+    assert!((((((*c.borrow()) as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0));
     let cmp: Value<Color> = Rc::new(RefCell::new(Color::from(
         (((*c.borrow()) as u32).wrapping_add(1_u32)) as i32,
     )));
-    assert!((((*cmp.borrow()) as u32) == ((Color::BLUE as i32) as u32)));
+    assert!((((((*cmp.borrow()) as u32) == ((Color::BLUE as i32) as u32)) as i32) != 0));
     let o: Value<Option> = Rc::new(RefCell::new(Option::from((Option::OPT_A as i32))));
-    assert!((((*o.borrow()) as u32) == ((Option::OPT_A as i32) as u32)));
-    assert!((((*o.borrow()) as u32) == 10_u32));
+    assert!((((((*o.borrow()) as u32) == ((Option::OPT_A as i32) as u32)) as i32) != 0));
+    assert!((((((*o.borrow()) as u32) == 10_u32) as i32) != 0));
     let oi: Value<i32> = Rc::new(RefCell::new(((*o.borrow()) as i32).clone()));
-    assert!(((*oi.borrow()) == 10));
+    assert!(((((*oi.borrow()) == 10) as i32) != 0));
     (*o.borrow_mut()) = Option::from(20);
-    assert!((((*o.borrow()) as u32) == ((Option::OPT_B as i32) as u32)));
+    assert!((((((*o.borrow()) as u32) == ((Option::OPT_B as i32) as u32)) as i32) != 0));
     let rc: Value<i32> = Rc::new(RefCell::new(
         ({
             let _option: i32 = ((*o.borrow()) as i32).clone();
             classify_option_1(_option)
         }),
     ));
-    assert!(((*rc.borrow()) == 2));
+    assert!(((((*rc.borrow()) == 2) as i32) != 0));
     (*rc.borrow_mut()) = ({
         let _option: i32 = 20;
         classify_option_1(_option)
     });
-    assert!(((*rc.borrow()) == 2));
+    assert!(((((*rc.borrow()) == 2) as i32) != 0));
     (*rc.borrow_mut()) = ({
         let _option: i32 = (Option::OPT_C as i32);
         classify_option_1(_option)
     });
-    assert!(((*rc.borrow()) == 3));
+    assert!(((((*rc.borrow()) == 3) as i32) != 0));
     let t: Value<Tag> = Rc::new(RefCell::new(Tag::from((Tag::TAG_ONE as i32))));
-    assert!((((*t.borrow()) as u32) == 1_u32));
-    assert!((((*t.borrow()) as u32) == ((Tag::TAG_ONE as i32) as u32)));
+    assert!((((((*t.borrow()) as u32) == 1_u32) as i32) != 0));
+    assert!((((((*t.borrow()) as u32) == ((Tag::TAG_ONE as i32) as u32)) as i32) != 0));
     let ti: Value<i32> = Rc::new(RefCell::new(((*t.borrow()) as i32).clone()));
-    assert!(((*ti.borrow()) == 1));
+    assert!(((((*ti.borrow()) == 1) as i32) != 0));
     (*t.borrow_mut()) = Tag::from(2);
-    assert!((((*t.borrow()) as u32) == ((Tag::TAG_TWO as i32) as u32)));
+    assert!((((((*t.borrow()) as u32) == ((Tag::TAG_TWO as i32) as u32)) as i32) != 0));
     'switch: {
         let __match_cond = ((*t.borrow()) as u32);
         match __match_cond {
@@ -186,6 +186,6 @@ fn main_0() -> i32 {
     let extra: Value<i32> = Rc::new(RefCell::new(
         (((Color::RED as i32) + (Color::GREEN as i32)) + (Color::BLUE as i32)),
     ));
-    assert!(((*extra.borrow()) == ((0 + 1) + 2)));
+    assert!(((((*extra.borrow()) == ((0 + 1) + 2)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/refcount/expr_as_bool_c.rs
+++ b/tests/unit/out/refcount/expr_as_bool_c.rs
@@ -6,6 +6,21 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
+pub fn cmp_eq_0(rc: i32) -> i32 {
+    let rc: Value<i32> = Rc::new(RefCell::new(rc));
+    return (((*rc.borrow()) == -1_i32) as i32);
+}
+pub fn cmp_or_ptr_1(p: Ptr<u8>, q: Ptr<u8>) -> i32 {
+    let p: Value<Ptr<u8>> = Rc::new(RefCell::new(p));
+    let q: Value<Ptr<u8>> = Rc::new(RefCell::new(q));
+    return (((!(*p.borrow()).is_null()) || (!(*q.borrow()).is_null())) as i32).clone();
+}
+pub fn both_null_2(s1: Ptr<u8>, s2: Ptr<u8>) -> i32 {
+    let s1: Value<Ptr<u8>> = Rc::new(RefCell::new(s1));
+    let s2: Value<Ptr<u8>> = Rc::new(RefCell::new(s2));
+    return ((((((*s1.borrow()) == (Default::default())) as i32) != 0)
+        && ((((*s2.borrow()) == (Default::default())) as i32) != 0)) as i32);
+}
 pub fn main() {
     std::process::exit(main_0());
 }
@@ -17,15 +32,16 @@ fn main_0() -> i32 {
         (*b.borrow())
     } != 0)
     {}
-    'loop_: while (({
+    'loop_: while (((({
         (*b.borrow_mut()) = (*a.borrow());
         (*b.borrow())
-    }) != 0)
+    }) != 0) as i32)
+        != 0)
     {}
     if ((*a.borrow()) != 0) {}
-    if ((*a.borrow()) == (*b.borrow())) {}
-    if ((*a.borrow()) < (*b.borrow())) {}
-    assert!(((*a.borrow()) == (*b.borrow())));
+    if ((((*a.borrow()) == (*b.borrow())) as i32) != 0) {}
+    if ((((*a.borrow()) < (*b.borrow())) as i32) != 0) {}
+    assert!(((((*a.borrow()) == (*b.borrow())) as i32) != 0));
     assert!(
         ((!(({
             (*a.borrow_mut()) = (*b.borrow());
@@ -38,12 +54,77 @@ fn main_0() -> i32 {
         (*a.borrow_mut()) = (*b.borrow());
         (*a.borrow())
     } != 0);
-    (*c.borrow_mut()) = (({
+    (*c.borrow_mut()) = (((({
         (*b.borrow_mut()) = (*a.borrow());
         (*b.borrow())
-    }) != 0);
+    }) != 0) as i32)
+        != 0);
     (*c.borrow_mut()) = ((*a.borrow()) != 0);
-    (*c.borrow_mut()) = ((*a.borrow()) == (*b.borrow()));
-    (*c.borrow_mut()) = ((*a.borrow()) < (*b.borrow()));
+    (*c.borrow_mut()) = ((((*a.borrow()) == (*b.borrow())) as i32) != 0);
+    (*c.borrow_mut()) = ((((*a.borrow()) < (*b.borrow())) as i32) != 0);
+    let x: Value<i32> = Rc::new(RefCell::new(5));
+    let y: Value<i32> = Rc::new(RefCell::new(5));
+    let eq: Value<i32> = Rc::new(RefCell::new((((*x.borrow()) == (*y.borrow())) as i32)));
+    let lt: Value<i32> = Rc::new(RefCell::new((((*x.borrow()) < (*y.borrow())) as i32)));
+    let neq: Value<i32> = Rc::new(RefCell::new((((*x.borrow()) != (*y.borrow())) as i32)));
+    assert!(((((*eq.borrow()) == 1) as i32) != 0));
+    assert!(((((*lt.borrow()) == 0) as i32) != 0));
+    assert!(((((*neq.borrow()) == 0) as i32) != 0));
+    let p1: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal("hi")));
+    let p2: Value<Ptr<u8>> = Rc::new(RefCell::new(Default::default()));
+    let either: Value<i32> = Rc::new(RefCell::new(
+        (((!(*p1.borrow()).is_null()) || (!(*p2.borrow()).is_null())) as i32).clone(),
+    ));
+    let both: Value<i32> = Rc::new(RefCell::new(
+        (((!(*p1.borrow()).is_null()) && (!(*p2.borrow()).is_null())) as i32).clone(),
+    ));
+    assert!(((((*either.borrow()) == 1) as i32) != 0));
+    assert!(((((*both.borrow()) == 0) as i32) != 0));
+    assert!(
+        (((({
+            let _rc: i32 = -1_i32;
+            cmp_eq_0(_rc)
+        }) == 1) as i32)
+            != 0)
+    );
+    assert!(
+        (((({
+            let _rc: i32 = 0;
+            cmp_eq_0(_rc)
+        }) == 0) as i32)
+            != 0)
+    );
+    assert!(
+        (((({
+            let _p: Ptr<u8> = (*p1.borrow()).clone();
+            let _q: Ptr<u8> = (*p2.borrow()).clone();
+            cmp_or_ptr_1(_p, _q)
+        }) == 1) as i32)
+            != 0)
+    );
+    assert!(
+        (((({
+            let _p: Ptr<u8> = Default::default();
+            let _q: Ptr<u8> = Default::default();
+            cmp_or_ptr_1(_p, _q)
+        }) == 0) as i32)
+            != 0)
+    );
+    assert!(
+        (((({
+            let _s1: Ptr<u8> = Default::default();
+            let _s2: Ptr<u8> = Default::default();
+            both_null_2(_s1, _s2)
+        }) == 1) as i32)
+            != 0)
+    );
+    assert!(
+        (((({
+            let _s1: Ptr<u8> = (*p1.borrow()).clone();
+            let _s2: Ptr<u8> = Default::default();
+            both_null_2(_s1, _s2)
+        }) == 0) as i32)
+            != 0)
+    );
     return 0;
 }

--- a/tests/unit/out/refcount/expr_as_bool_cpp.rs
+++ b/tests/unit/out/refcount/expr_as_bool_cpp.rs
@@ -6,6 +6,20 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
+pub fn cmp_eq_0(rc: i32) -> i32 {
+    let rc: Value<i32> = Rc::new(RefCell::new(rc));
+    return (((*rc.borrow()) == -1_i32) as i32);
+}
+pub fn cmp_or_ptr_1(p: Ptr<u8>, q: Ptr<u8>) -> i32 {
+    let p: Value<Ptr<u8>> = Rc::new(RefCell::new(p));
+    let q: Value<Ptr<u8>> = Rc::new(RefCell::new(q));
+    return (((!(*p.borrow()).is_null()) || (!(*q.borrow()).is_null())) as i32).clone();
+}
+pub fn both_null_2(s1: Ptr<u8>, s2: Ptr<u8>) -> i32 {
+    let s1: Value<Ptr<u8>> = Rc::new(RefCell::new(s1));
+    let s2: Value<Ptr<u8>> = Rc::new(RefCell::new(s2));
+    return ((((*s1.borrow()).is_null()) && ((*s2.borrow()).is_null())) as i32).clone();
+}
 pub fn main() {
     std::process::exit(main_0());
 }
@@ -44,5 +58,63 @@ fn main_0() -> i32 {
     (*c.borrow_mut()) = ((*a.borrow()) != 0);
     (*c.borrow_mut()) = ((*a.borrow()) == (*b.borrow()));
     (*c.borrow_mut()) = ((*a.borrow()) < (*b.borrow()));
+    let x: Value<i32> = Rc::new(RefCell::new(5));
+    let y: Value<i32> = Rc::new(RefCell::new(5));
+    let eq: Value<i32> = Rc::new(RefCell::new((((*x.borrow()) == (*y.borrow())) as i32)));
+    let lt: Value<i32> = Rc::new(RefCell::new((((*x.borrow()) < (*y.borrow())) as i32)));
+    let neq: Value<i32> = Rc::new(RefCell::new((((*x.borrow()) != (*y.borrow())) as i32)));
+    assert!(((*eq.borrow()) == 1));
+    assert!(((*lt.borrow()) == 0));
+    assert!(((*neq.borrow()) == 0));
+    let p1: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal("hi")));
+    let p2: Value<Ptr<u8>> = Rc::new(RefCell::new(Default::default()));
+    let either: Value<i32> = Rc::new(RefCell::new(
+        (((!(*p1.borrow()).is_null()) || (!(*p2.borrow()).is_null())) as i32).clone(),
+    ));
+    let both: Value<i32> = Rc::new(RefCell::new(
+        (((!(*p1.borrow()).is_null()) && (!(*p2.borrow()).is_null())) as i32).clone(),
+    ));
+    assert!(((*either.borrow()) == 1));
+    assert!(((*both.borrow()) == 0));
+    assert!(
+        (({
+            let _rc: i32 = -1_i32;
+            cmp_eq_0(_rc)
+        }) == 1)
+    );
+    assert!(
+        (({
+            let _rc: i32 = 0;
+            cmp_eq_0(_rc)
+        }) == 0)
+    );
+    assert!(
+        (({
+            let _p: Ptr<u8> = (*p1.borrow()).clone();
+            let _q: Ptr<u8> = (*p2.borrow()).clone();
+            cmp_or_ptr_1(_p, _q)
+        }) == 1)
+    );
+    assert!(
+        (({
+            let _p: Ptr<u8> = Default::default();
+            let _q: Ptr<u8> = Default::default();
+            cmp_or_ptr_1(_p, _q)
+        }) == 0)
+    );
+    assert!(
+        (({
+            let _s1: Ptr<u8> = Default::default();
+            let _s2: Ptr<u8> = Default::default();
+            both_null_2(_s1, _s2)
+        }) == 1)
+    );
+    assert!(
+        (({
+            let _s1: Ptr<u8> = (*p1.borrow()).clone();
+            let _s2: Ptr<u8> = Default::default();
+            both_null_2(_s1, _s2)
+        }) == 0)
+    );
     return 0;
 }

--- a/tests/unit/out/refcount/find.rs
+++ b/tests/unit/out/refcount/find.rs
@@ -63,7 +63,7 @@ fn main_0() -> i32 {
     let m_result_true: Value<bool> =
         Rc::new(RefCell::new((*m_begin.borrow()) != (*m_end.borrow())));
     return ((((*v_result_true.borrow()) && (*m_result_true.borrow()))
-        && (v.as_pointer() as Ptr<i32>).offset(
+        && ((v.as_pointer() as Ptr<i32>).offset(
             (v.as_pointer() as Ptr<i32>)
                 .clone()
                 .into_iter()
@@ -73,5 +73,5 @@ fn main_0() -> i32 {
                         && value_0.read() == 2
                 })
                 .unwrap_or((v.as_pointer() as Ptr<i32>).get_offset() as usize) as isize,
-        ) == (v.as_pointer() as Ptr<i32>)) as i32);
+        ) == (v.as_pointer() as Ptr<i32>))) as i32);
 }

--- a/tests/unit/out/refcount/huffman.rs
+++ b/tests/unit/out/refcount/huffman.rs
@@ -15,10 +15,7 @@ pub struct MinHeapNode {
 }
 impl MinHeapNode {
     pub fn IsLeaf(&self) -> bool {
-        return {
-            let _lhs = ((*self.left.borrow()).is_null()).clone();
-            _lhs && ((*self.right.borrow()).is_null()).clone()
-        };
+        return (((*self.left.borrow()).is_null()) && ((*self.right.borrow()).is_null())).clone();
     }
 }
 impl Clone for MinHeapNode {
@@ -94,7 +91,7 @@ impl MinHeap {
         let smallest: Value<i32> = Rc::new(RefCell::new((*idx.borrow())));
         let left: Value<i32> = Rc::new(RefCell::new(((2 * (*idx.borrow())) + 1)));
         let right: Value<i32> = Rc::new(RefCell::new(((2 * (*idx.borrow())) + 2)));
-        if (((*left.borrow()) < (*self.size.borrow()))
+        if ((*left.borrow()) < (*self.size.borrow()))
             && ((*(*(*self.arr.borrow()).as_ref().unwrap().borrow()
                 [((*left.borrow()) as u64) as usize]
                 .upgrade()
@@ -106,11 +103,11 @@ impl MinHeap {
                     .upgrade()
                     .deref())
                 .freq
-                .borrow())))
+                .borrow()))
         {
             (*smallest.borrow_mut()) = (*left.borrow());
         }
-        if (((*right.borrow()) < (*self.size.borrow()))
+        if ((*right.borrow()) < (*self.size.borrow()))
             && ((*(*(*self.arr.borrow()).as_ref().unwrap().borrow()
                 [((*right.borrow()) as u64) as usize]
                 .upgrade()
@@ -122,7 +119,7 @@ impl MinHeap {
                     .upgrade()
                     .deref())
                 .freq
-                .borrow())))
+                .borrow()))
         {
             (*smallest.borrow_mut()) = (*right.borrow());
         }
@@ -161,9 +158,8 @@ impl MinHeap {
         let node: Value<Ptr<MinHeapNode>> = Rc::new(RefCell::new(node));
         (*self.size.borrow_mut()).prefix_inc();
         let i: Value<i32> = Rc::new(RefCell::new(((*self.size.borrow()) - 1)));
-        'loop_: while {
-            let _lhs = ((*i.borrow()) != 0);
-            _lhs && {
+        'loop_: while ((*i.borrow()) != 0)
+            && ({
                 let _lhs = (*(*(*node.borrow()).upgrade().deref()).freq.borrow());
                 _lhs < (*(*(*self.arr.borrow()).as_ref().unwrap().borrow()
                     [((((*i.borrow()) - 1) / 2) as u64) as usize]
@@ -171,8 +167,8 @@ impl MinHeap {
                     .deref())
                 .freq
                 .borrow())
-            }
-        } {
+            })
+        {
             let __rhs = ((*self.arr.borrow()).as_ref().unwrap().borrow()
                 [((((*i.borrow()) - 1) / 2) as u64) as usize])
                 .clone();

--- a/tests/unit/out/refcount/kruskal.rs
+++ b/tests/unit/out/refcount/kruskal.rs
@@ -97,7 +97,7 @@ pub fn partition_0(arr: Ptr<Option<Value<Box<[Edge]>>>>, start: i32, end: i32) -
         };
     let i: Value<i32> = Rc::new(RefCell::new((*start.borrow())));
     let j: Value<i32> = Rc::new(RefCell::new((*end.borrow())));
-    'loop_: while (((*i.borrow()) < (*pidx.borrow())) && ((*j.borrow()) > (*pidx.borrow()))) {
+    'loop_: while ((*i.borrow()) < (*pidx.borrow())) && ((*j.borrow()) > (*pidx.borrow())) {
         'loop_: while {
             let _lhs = (*(*arr.upgrade().deref()).as_ref().unwrap().borrow()
                 [((*i.borrow()) as u64) as usize]
@@ -116,7 +116,7 @@ pub fn partition_0(arr: Ptr<Option<Value<Box<[Edge]>>>>, start: i32, end: i32) -
         } {
             (*j.borrow_mut()).prefix_dec();
         }
-        if (((*i.borrow()) < (*pidx.borrow())) && ((*j.borrow()) > (*pidx.borrow()))) {
+        if ((*i.borrow()) < (*pidx.borrow())) && ((*j.borrow()) > (*pidx.borrow())) {
             (*tmp.borrow_mut()) = Edge {
                 u: Rc::new(RefCell::new(
                     (*(*arr.upgrade().deref()).as_ref().unwrap().borrow()

--- a/tests/unit/out/refcount/linked_list.rs
+++ b/tests/unit/out/refcount/linked_list.rs
@@ -204,22 +204,20 @@ fn main_0() -> i32 {
         .val
         .borrow())
             == 1))
-        && ({
-            let _lhs = ((*(*({
-                let _head: Ptr<Node> = (*head.borrow()).clone();
-                let _idx: i32 = 4;
-                Find_0(_head, _idx)
-            })
-            .upgrade()
-            .deref())
-            .val
-            .borrow())
-                == -1_i32);
-            _lhs && (({
+        && (((*(*({
+            let _head: Ptr<Node> = (*head.borrow()).clone();
+            let _idx: i32 = 4;
+            Find_0(_head, _idx)
+        })
+        .upgrade()
+        .deref())
+        .val
+        .borrow())
+            == -1_i32)
+            && (({
                 let _head: Ptr<Node> = (*head.borrow()).clone();
                 let _idx: i32 = 5;
                 Find_0(_head, _idx)
             })
-            .is_null())
-        })) as i32);
+            .is_null()))) as i32);
 }

--- a/tests/unit/out/refcount/loop_with_postfix_inc.rs
+++ b/tests/unit/out/refcount/loop_with_postfix_inc.rs
@@ -11,7 +11,7 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(0));
-    'loop_: while (((*x.borrow_mut()).postfix_inc() < 100) && ((*x.borrow()) != 50)) {
+    'loop_: while ((*x.borrow_mut()).postfix_inc() < 100) && ((*x.borrow()) != 50) {
         (*x.borrow_mut()).prefix_inc();
     }
     return (*x.borrow());

--- a/tests/unit/out/refcount/map-reallocation.rs
+++ b/tests/unit/out/refcount/map-reallocation.rs
@@ -27,15 +27,15 @@ fn main_0() -> i32 {
     )));
     let p: Value<Ptr<i32>> = Rc::new(RefCell::new(((*it.borrow()).second().as_pointer())));
     assert!(
-        (((*(*it.borrow()).second().borrow()) == (*sentinel.borrow()))
-            && !(Ptr::from_string_literal("iterator does not have correct value before insert"))
+        ((*(*it.borrow()).second().borrow()) == (*sentinel.borrow()))
+            && (!(Ptr::from_string_literal("iterator does not have correct value before insert"))
                 .is_null())
     );
     assert!(
         ({
             let _lhs = ((*p.borrow()).read());
             _lhs == (*sentinel.borrow())
-        } && !(Ptr::from_string_literal("pointer does not have correct value before insert"))
+        }) && (!(Ptr::from_string_literal("pointer does not have correct value before insert"))
             .is_null())
     );
     let i: Value<i32> = Rc::new(RefCell::new(0));
@@ -63,22 +63,22 @@ fn main_0() -> i32 {
         (*i.borrow_mut()).prefix_inc();
     }
     assert!(
-        (((*(*it.borrow()).second().borrow()) != 0)
-            && !(Ptr::from_string_literal(
+        ((*(*it.borrow()).second().borrow()) != 0)
+            && (!(Ptr::from_string_literal(
                 "in refcount, iterator points to index 0 instead of sentinel"
             ))
             .is_null())
     );
     assert!(
-        (((*(*it.borrow()).second().borrow()) == (*sentinel.borrow()))
-            && !(Ptr::from_string_literal("iterator does not have correct value after insert"))
+        ((*(*it.borrow()).second().borrow()) == (*sentinel.borrow()))
+            && (!(Ptr::from_string_literal("iterator does not have correct value after insert"))
                 .is_null())
     );
     assert!(
         ({
             let _lhs = ((*p.borrow()).read());
             _lhs == (*sentinel.borrow())
-        } && !(Ptr::from_string_literal("pointer does not have correct value after insert"))
+        }) && (!(Ptr::from_string_literal("pointer does not have correct value after insert"))
             .is_null())
     );
     (*(*it.borrow()).second().borrow_mut()) = 57005;

--- a/tests/unit/out/refcount/new_bst.rs
+++ b/tests/unit/out/refcount/new_bst.rs
@@ -26,25 +26,21 @@ impl ByteRepr for node_t {}
 pub fn find_0(node: Ptr<node_t>, value: i32) -> Ptr<node_t> {
     let node: Value<Ptr<node_t>> = Rc::new(RefCell::new(node));
     let value: Value<i32> = Rc::new(RefCell::new(value));
-    if {
-        let _lhs = {
-            let _lhs = (*value.borrow());
-            _lhs < (*(*(*node.borrow()).upgrade().deref()).value.borrow())
-        };
-        _lhs && (!((*(*(*node.borrow()).upgrade().deref()).left.borrow()).is_null())).clone()
-    } {
+    if ({
+        let _lhs = (*value.borrow());
+        _lhs < (*(*(*node.borrow()).upgrade().deref()).value.borrow())
+    }) && (!((*(*(*node.borrow()).upgrade().deref()).left.borrow()).is_null()))
+    {
         return ({
             let _node: Ptr<node_t> = (*(*(*node.borrow()).upgrade().deref()).left.borrow()).clone();
             let _value: i32 = (*value.borrow());
             find_0(_node, _value)
         });
-    } else if {
-        let _lhs = {
-            let _lhs = (*value.borrow());
-            _lhs > (*(*(*node.borrow()).upgrade().deref()).value.borrow())
-        };
-        _lhs && (!((*(*(*node.borrow()).upgrade().deref()).right.borrow()).is_null())).clone()
-    } {
+    } else if ({
+        let _lhs = (*value.borrow());
+        _lhs > (*(*(*node.borrow()).upgrade().deref()).value.borrow())
+    }) && (!((*(*(*node.borrow()).upgrade().deref()).right.borrow()).is_null()))
+    {
         return ({
             let _node: Ptr<node_t> =
                 (*(*(*node.borrow()).upgrade().deref()).right.borrow()).clone();
@@ -143,8 +139,8 @@ fn main_0() -> i32 {
         insert_1(_node, _value)
     });
     (*root.borrow_mut()) = __rhs;
-    let out: Value<bool> = Rc::new(RefCell::new({
-        let _lhs = ((((((*(*({
+    let out: Value<bool> = Rc::new(RefCell::new(
+        ((((((*(*({
             let _node: Ptr<node_t> = (*root.borrow()).clone();
             let _value: i32 = 0;
             find_0(_node, _value)
@@ -193,14 +189,14 @@ fn main_0() -> i32 {
             .deref())
             .value
             .borrow())
-                == 4));
-        _lhs && ({
-            let _node: Ptr<node_t> = (*root.borrow()).clone();
-            let _value: i32 = 5;
-            find_0(_node, _value)
-        })
-        .is_null()
-    }));
+                == 4))
+            && (({
+                let _node: Ptr<node_t> = (*root.borrow()).clone();
+                let _value: i32 = 5;
+                find_0(_node, _value)
+            })
+            .is_null()),
+    ));
     ({
         let _node: Ptr<node_t> = (*root.borrow()).clone();
         del_2(_node)

--- a/tests/unit/out/refcount/operator_less_than.rs
+++ b/tests/unit/out/refcount/operator_less_than.rs
@@ -13,22 +13,16 @@ pub struct Pair {
 }
 impl Pair {
     pub fn lt(&self, other: Ptr<Pair>) -> bool {
-        return {
-            let _lhs = {
-                let _lhs = (*self.x.borrow());
-                _lhs < (*(*other.upgrade().deref()).x.borrow())
-            };
-            _lhs || ({
-                let _lhs = {
-                    let _lhs = (*self.x.borrow());
-                    _lhs == (*(*other.upgrade().deref()).x.borrow())
-                };
-                _lhs && {
-                    let _lhs = (*self.y.borrow());
-                    _lhs < (*(*other.upgrade().deref()).y.borrow())
-                }
-            })
-        };
+        return ({
+            let _lhs = (*self.x.borrow());
+            _lhs < (*(*other.upgrade().deref()).x.borrow())
+        }) || (({
+            let _lhs = (*self.x.borrow());
+            _lhs == (*(*other.upgrade().deref()).x.borrow())
+        }) && ({
+            let _lhs = (*self.y.borrow());
+            _lhs < (*(*other.upgrade().deref()).y.borrow())
+        }));
     }
 }
 impl Ord for Pair {

--- a/tests/unit/out/refcount/pointer_arithmetic.rs
+++ b/tests/unit/out/refcount/pointer_arithmetic.rs
@@ -25,14 +25,14 @@ fn main_0() -> i32 {
             let __tmp = __ptr.read() + 1;
             __ptr.write(__tmp)
         };
-        if (((*a.borrow())[(0) as usize] == 1) && ((*a.borrow())[(1) as usize] == 3)) {
+        if ((*a.borrow())[(0) as usize] == 1) && ((*a.borrow())[(1) as usize] == 3) {
             (*p.borrow_mut()).prefix_dec();
             {
                 let __ptr = (*p.borrow()).clone();
                 let __tmp = __ptr.read() + 1;
                 __ptr.write(__tmp)
             };
-            if (((*a.borrow())[(0) as usize] == 2) && ((*a.borrow())[(1) as usize] == 3)) {
+            if ((*a.borrow())[(0) as usize] == 2) && ((*a.borrow())[(1) as usize] == 3) {
                 (*p.borrow_mut()) = (x.as_pointer());
                 {
                     let __ptr = (*p.borrow()).clone();

--- a/tests/unit/out/refcount/polymorphism.rs
+++ b/tests/unit/out/refcount/polymorphism.rs
@@ -58,5 +58,5 @@ fn main_0() -> i32 {
     let eat2: Value<bool> = Rc::new(RefCell::new(
         ({ (*(*animal.borrow()).upgrade().deref()).bark() }),
     ));
-    return (((*eat1.borrow()) && !(*eat2.borrow())) as i32);
+    return (((*eat1.borrow()) && (!(*eat2.borrow()))) as i32);
 }

--- a/tests/unit/out/refcount/reinterpret_cast_double.rs
+++ b/tests/unit/out/refcount/reinterpret_cast_double.rs
@@ -14,6 +14,6 @@ fn main_0() -> i32 {
     let bits: Value<Ptr<u64>> = Rc::new(RefCell::new((d.as_pointer()).reinterpret_cast::<u64>()));
     assert!((((*bits.borrow()).read()) == 4607182418800017408_u64));
     (*bits.borrow()).write(4614256656552045848_u64);
-    assert!((((*d.borrow()) > 3.14E+0) && ((*d.borrow()) < 3.15E+0)));
+    assert!(((*d.borrow()) > 3.14E+0) && ((*d.borrow()) < 3.15E+0));
     return 0;
 }

--- a/tests/unit/out/refcount/string.rs
+++ b/tests/unit/out/refcount/string.rs
@@ -59,14 +59,14 @@ fn main_0() -> i32 {
     let p2: Value<Ptr<u8>> = Rc::new(RefCell::new((s2.as_pointer() as Ptr<u8>)));
     let i: Value<u32> = Rc::new(RefCell::new(0_u32));
     'loop_: while (((*i.borrow()) as u64) < ((*s2.borrow()).len() - 1) as u64) {
-        assert!({
-            let _lhs = ((((*p2.borrow()).offset((*i.borrow()) as isize).read()) as i32)
-                == (('a' as u8) as i32));
-            _lhs && ((((s2.as_pointer() as Ptr<u8>)
-                .offset(((*i.borrow()) as u64) as isize)
-                .read()) as i32)
+        assert!(
+            ((((*p2.borrow()).offset((*i.borrow()) as isize).read()) as i32)
                 == (('a' as u8) as i32))
-        });
+                && ((((s2.as_pointer() as Ptr<u8>)
+                    .offset(((*i.borrow()) as u64) as isize)
+                    .read()) as i32)
+                    == (('a' as u8) as i32))
+        );
         (*i.borrow_mut()).prefix_inc();
     }
     assert!((((*s2.borrow()).len() - 1) as u64 == 10_u64));
@@ -87,14 +87,14 @@ fn main_0() -> i32 {
     );
     let i: Value<u32> = Rc::new(RefCell::new(2_u32));
     'loop_: while (((*i.borrow()) as u64) < ((*s2.borrow()).len() - 1) as u64) {
-        assert!({
-            let _lhs = ((((*p2.borrow()).offset((*i.borrow()) as isize).read()) as i32)
-                == (('a' as u8) as i32));
-            _lhs && ((((s2.as_pointer() as Ptr<u8>)
-                .offset(((*i.borrow()) as u64) as isize)
-                .read()) as i32)
+        assert!(
+            ((((*p2.borrow()).offset((*i.borrow()) as isize).read()) as i32)
                 == (('a' as u8) as i32))
-        });
+                && ((((s2.as_pointer() as Ptr<u8>)
+                    .offset(((*i.borrow()) as u64) as isize)
+                    .read()) as i32)
+                    == (('a' as u8) as i32))
+        );
         (*i.borrow_mut()).prefix_inc();
     }
     let s3: Value<Vec<u8>> = Rc::new(RefCell::new({

--- a/tests/unit/out/refcount/string_literals_concat_c.rs
+++ b/tests/unit/out/refcount/string_literals_concat_c.rs
@@ -11,15 +11,35 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let arr: Value<Box<[u8]>> = Rc::new(RefCell::new(Box::<[u8]>::from(b"foobar\0".as_slice())));
-    assert!((((*arr.borrow())[(0) as usize] as i32) == ('f' as i32)));
-    assert!((((*arr.borrow())[(3) as usize] as i32) == ('b' as i32)));
-    assert!((((*arr.borrow())[(5) as usize] as i32) == ('r' as i32)));
-    assert!((((*arr.borrow())[(6) as usize] as i32) == ('\0' as i32)));
+    assert!((((((*arr.borrow())[(0) as usize] as i32) == ('f' as i32)) as i32) != 0));
+    assert!((((((*arr.borrow())[(3) as usize] as i32) == ('b' as i32)) as i32) != 0));
+    assert!((((((*arr.borrow())[(5) as usize] as i32) == ('r' as i32)) as i32) != 0));
+    assert!((((((*arr.borrow())[(6) as usize] as i32) == ('\0' as i32)) as i32) != 0));
     let split_pieces: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal("abcdefghi")));
-    assert!(((((*split_pieces.borrow()).offset((0) as isize).read()) as i32) == ('a' as i32)));
-    assert!(((((*split_pieces.borrow()).offset((3) as isize).read()) as i32) == ('d' as i32)));
-    assert!(((((*split_pieces.borrow()).offset((6) as isize).read()) as i32) == ('g' as i32)));
-    assert!(((((*split_pieces.borrow()).offset((8) as isize).read()) as i32) == ('i' as i32)));
-    assert!(((((*split_pieces.borrow()).offset((9) as isize).read()) as i32) == ('\0' as i32)));
+    assert!(
+        ((((((*split_pieces.borrow()).offset((0) as isize).read()) as i32) == ('a' as i32))
+            as i32)
+            != 0)
+    );
+    assert!(
+        ((((((*split_pieces.borrow()).offset((3) as isize).read()) as i32) == ('d' as i32))
+            as i32)
+            != 0)
+    );
+    assert!(
+        ((((((*split_pieces.borrow()).offset((6) as isize).read()) as i32) == ('g' as i32))
+            as i32)
+            != 0)
+    );
+    assert!(
+        ((((((*split_pieces.borrow()).offset((8) as isize).read()) as i32) == ('i' as i32))
+            as i32)
+            != 0)
+    );
+    assert!(
+        ((((((*split_pieces.borrow()).offset((9) as isize).read()) as i32) == ('\0' as i32))
+            as i32)
+            != 0)
+    );
     return 0;
 }

--- a/tests/unit/out/refcount/string_literals_return_c.rs
+++ b/tests/unit/out/refcount/string_literals_return_c.rs
@@ -14,7 +14,7 @@ pub fn get_empty_1() -> Ptr<u8> {
 }
 pub fn get_branch_2(x: i32) -> Ptr<u8> {
     let x: Value<i32> = Rc::new(RefCell::new(x));
-    if ((*x.borrow()) > 0) {
+    if ((((*x.borrow()) > 0) as i32) != 0) {
         return Ptr::from_string_literal("positive");
     }
     return Ptr::from_string_literal("non-positive");
@@ -24,28 +24,38 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let a: Value<Ptr<u8>> = Rc::new(RefCell::new(({ get_greeting_0() })));
-    assert!(((((*a.borrow()).offset((0) as isize).read()) as i32) == ('h' as i32)));
-    assert!(((((*a.borrow()).offset((4) as isize).read()) as i32) == ('o' as i32)));
-    assert!(((((*a.borrow()).offset((5) as isize).read()) as i32) == ('\0' as i32)));
+    assert!(((((((*a.borrow()).offset((0) as isize).read()) as i32) == ('h' as i32)) as i32) != 0));
+    assert!(((((((*a.borrow()).offset((4) as isize).read()) as i32) == ('o' as i32)) as i32) != 0));
+    assert!(
+        ((((((*a.borrow()).offset((5) as isize).read()) as i32) == ('\0' as i32)) as i32) != 0)
+    );
     let b: Value<Ptr<u8>> = Rc::new(RefCell::new(({ get_empty_1() })));
-    assert!(((((*b.borrow()).offset((0) as isize).read()) as i32) == ('\0' as i32)));
+    assert!(
+        ((((((*b.borrow()).offset((0) as isize).read()) as i32) == ('\0' as i32)) as i32) != 0)
+    );
     let c: Value<Ptr<u8>> = Rc::new(RefCell::new(
         ({
             let _x: i32 = 1;
             get_branch_2(_x)
         }),
     ));
-    assert!(((((*c.borrow()).offset((0) as isize).read()) as i32) == ('p' as i32)));
-    assert!(((((*c.borrow()).offset((7) as isize).read()) as i32) == ('e' as i32)));
-    assert!(((((*c.borrow()).offset((8) as isize).read()) as i32) == ('\0' as i32)));
+    assert!(((((((*c.borrow()).offset((0) as isize).read()) as i32) == ('p' as i32)) as i32) != 0));
+    assert!(((((((*c.borrow()).offset((7) as isize).read()) as i32) == ('e' as i32)) as i32) != 0));
+    assert!(
+        ((((((*c.borrow()).offset((8) as isize).read()) as i32) == ('\0' as i32)) as i32) != 0)
+    );
     let d: Value<Ptr<u8>> = Rc::new(RefCell::new(
         ({
             let _x: i32 = -1_i32;
             get_branch_2(_x)
         }),
     ));
-    assert!(((((*d.borrow()).offset((0) as isize).read()) as i32) == ('n' as i32)));
-    assert!(((((*d.borrow()).offset((11) as isize).read()) as i32) == ('e' as i32)));
-    assert!(((((*d.borrow()).offset((12) as isize).read()) as i32) == ('\0' as i32)));
+    assert!(((((((*d.borrow()).offset((0) as isize).read()) as i32) == ('n' as i32)) as i32) != 0));
+    assert!(
+        ((((((*d.borrow()).offset((11) as isize).read()) as i32) == ('e' as i32)) as i32) != 0)
+    );
+    assert!(
+        ((((((*d.borrow()).offset((12) as isize).read()) as i32) == ('\0' as i32)) as i32) != 0)
+    );
     return 0;
 }

--- a/tests/unit/out/refcount/string_literals_sized_c.rs
+++ b/tests/unit/out/refcount/string_literals_sized_c.rs
@@ -11,29 +11,36 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let empty_buf: Value<Box<[u8]>> = Rc::new(RefCell::new(vec![0u8; 256].into_boxed_slice()));
-    assert!((((*empty_buf.borrow())[(0) as usize] as i32) == ('\0' as i32)));
-    assert!((((*empty_buf.borrow())[(255) as usize] as i32) == ('\0' as i32)));
+    assert!((((((*empty_buf.borrow())[(0) as usize] as i32) == ('\0' as i32)) as i32) != 0));
+    assert!((((((*empty_buf.borrow())[(255) as usize] as i32) == ('\0' as i32)) as i32) != 0));
     let prefix_buf: Value<Box<[u8]>> = Rc::new(RefCell::new(Box::<[u8]>::from(
         b"%\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0".as_slice(),
     )));
-    assert!((((*prefix_buf.borrow())[(0) as usize] as i32) == ('%' as i32)));
-    assert!((((*prefix_buf.borrow())[(1) as usize] as i32) == ('\0' as i32)));
-    assert!((((*prefix_buf.borrow())[(31) as usize] as i32) == ('\0' as i32)));
+    assert!((((((*prefix_buf.borrow())[(0) as usize] as i32) == ('%' as i32)) as i32) != 0));
+    assert!((((((*prefix_buf.borrow())[(1) as usize] as i32) == ('\0' as i32)) as i32) != 0));
+    assert!((((((*prefix_buf.borrow())[(31) as usize] as i32) == ('\0' as i32)) as i32) != 0));
     let short_buf: Value<Box<[u8]>> = Rc::new(RefCell::new(Box::<[u8]>::from(
         b"hi\0\0\0\0\0\0\0\0\0\0\0\0\0\0".as_slice(),
     )));
-    assert!((((*short_buf.borrow())[(0) as usize] as i32) == ('h' as i32)));
-    assert!((((*short_buf.borrow())[(1) as usize] as i32) == ('i' as i32)));
-    assert!((((*short_buf.borrow())[(2) as usize] as i32) == ('\0' as i32)));
-    assert!((((*short_buf.borrow())[(15) as usize] as i32) == ('\0' as i32)));
+    assert!((((((*short_buf.borrow())[(0) as usize] as i32) == ('h' as i32)) as i32) != 0));
+    assert!((((((*short_buf.borrow())[(1) as usize] as i32) == ('i' as i32)) as i32) != 0));
+    assert!((((((*short_buf.borrow())[(2) as usize] as i32) == ('\0' as i32)) as i32) != 0));
+    assert!((((((*short_buf.borrow())[(15) as usize] as i32) == ('\0' as i32)) as i32) != 0));
     let exact_buf: Value<Box<[u8]>> =
         Rc::new(RefCell::new(Box::<[u8]>::from(b"hello\0".as_slice())));
-    assert!((((*exact_buf.borrow())[(0) as usize] as i32) == ('h' as i32)));
-    assert!((((*exact_buf.borrow())[(4) as usize] as i32) == ('o' as i32)));
-    assert!((((*exact_buf.borrow())[(5) as usize] as i32) == ('\0' as i32)));
-    assert!((::std::mem::size_of::<[u8; 6]>() as u64 == 6_u64));
-    assert!(((::std::mem::size_of::<[u8; 6]>() as u64 as u64).wrapping_sub(1_u64) == 5_u64));
-    assert!((::std::mem::size_of::<[u8; 1]>() as u64 == 1_u64));
-    assert!(((::std::mem::size_of::<[u8; 16]>() as u64 as u64).wrapping_sub(1_u64) == 15_u64));
+    assert!((((((*exact_buf.borrow())[(0) as usize] as i32) == ('h' as i32)) as i32) != 0));
+    assert!((((((*exact_buf.borrow())[(4) as usize] as i32) == ('o' as i32)) as i32) != 0));
+    assert!((((((*exact_buf.borrow())[(5) as usize] as i32) == ('\0' as i32)) as i32) != 0));
+    assert!((((::std::mem::size_of::<[u8; 6]>() as u64 == 6_u64) as i32) != 0));
+    assert!(
+        ((((::std::mem::size_of::<[u8; 6]>() as u64 as u64).wrapping_sub(1_u64) == 5_u64) as i32)
+            != 0)
+    );
+    assert!((((::std::mem::size_of::<[u8; 1]>() as u64 == 1_u64) as i32) != 0));
+    assert!(
+        ((((::std::mem::size_of::<[u8; 16]>() as u64 as u64).wrapping_sub(1_u64) == 15_u64)
+            as i32)
+            != 0)
+    );
     return 0;
 }

--- a/tests/unit/out/refcount/va_arg_chain.rs
+++ b/tests/unit/out/refcount/va_arg_chain.rs
@@ -10,7 +10,7 @@ pub fn extract_nth_0(n: i32, ap: VaList) -> i32 {
     let n: Value<i32> = Rc::new(RefCell::new(n));
     let ap: Value<VaList> = Rc::new(RefCell::new(ap));
     let i: Value<i32> = Rc::new(RefCell::new(0));
-    'loop_: while ((*i.borrow()) < (*n.borrow())) {
+    'loop_: while ((((*i.borrow()) < (*n.borrow())) as i32) != 0) {
         (*ap.borrow_mut()).arg::<i32>();
         (*i.borrow_mut()).postfix_inc();
     }
@@ -43,22 +43,25 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     assert!(
-        (({
+        (((({
             let _n: i32 = 2;
             top_level_2(_n, &[100.into(), 200.into(), 300.into(), 400.into()])
-        }) == 300)
+        }) == 300) as i32)
+            != 0)
     );
     assert!(
-        (({
+        (((({
             let _n: i32 = 0;
             top_level_2(_n, &[42.into(), 99.into()])
-        }) == 42)
+        }) == 42) as i32)
+            != 0)
     );
     assert!(
-        (({
+        (((({
             let _n: i32 = 3;
             top_level_2(_n, &[1.into(), 2.into(), 3.into(), 4.into()])
-        }) == 4)
+        }) == 4) as i32)
+            != 0)
     );
     return 0;
 }

--- a/tests/unit/out/refcount/va_arg_concat.rs
+++ b/tests/unit/out/refcount/va_arg_concat.rs
@@ -12,10 +12,11 @@ pub fn sum_ints_0(first: i32, args: &[VaArg]) -> i32 {
     let total: Value<i32> = Rc::new(RefCell::new((*first.borrow())));
     (*ap.borrow_mut()) = VaList::new(args);
     let val: Value<i32> = <Value<i32>>::default();
-    'loop_: while (({
+    'loop_: while (((({
         (*val.borrow_mut()) = ((*ap.borrow_mut()).arg::<i32>()).clone();
         (*val.borrow())
-    }) != 0)
+    }) != 0) as i32)
+        != 0)
     {
         (*total.borrow_mut()) += (*val.borrow());
     }
@@ -26,22 +27,25 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     assert!(
-        (({
+        (((({
             let _first: i32 = 1;
             sum_ints_0(_first, &[2.into(), 3.into(), 4.into(), 0.into()])
-        }) == 10)
+        }) == 10) as i32)
+            != 0)
     );
     assert!(
-        (({
+        (((({
             let _first: i32 = 100;
             sum_ints_0(_first, &[0.into()])
-        }) == 100)
+        }) == 100) as i32)
+            != 0)
     );
     assert!(
-        (({
+        (((({
             let _first: i32 = 5;
             sum_ints_0(_first, &[5.into(), 5.into(), 5.into(), 5.into(), 0.into()])
-        }) == 25)
+        }) == 25) as i32)
+            != 0)
     );
     return 0;
 }

--- a/tests/unit/out/refcount/va_arg_conditional.rs
+++ b/tests/unit/out/refcount/va_arg_conditional.rs
@@ -22,18 +22,20 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     assert!(
-        (({
+        (((({
             let _verbose: i32 = 1;
             let _fmt: Ptr<u8> = Ptr::from_string_literal("%d");
             conditional_log_0(_verbose, _fmt, &[42.into()])
-        }) == 42)
+        }) == 42) as i32)
+            != 0)
     );
     assert!(
-        (({
+        (((({
             let _verbose: i32 = 0;
             let _fmt: Ptr<u8> = Ptr::from_string_literal("%d");
             conditional_log_0(_verbose, _fmt, &[99.into()])
-        }) == -1_i32)
+        }) == -1_i32) as i32)
+            != 0)
     );
     return 0;
 }

--- a/tests/unit/out/refcount/va_arg_copy.rs
+++ b/tests/unit/out/refcount/va_arg_copy.rs
@@ -14,17 +14,17 @@ pub fn sum_with_copy_0(count: i32, args: &[VaArg]) -> i32 {
     (*aq.borrow_mut()) = (*ap.borrow_mut()).clone();
     let sum1: Value<i32> = Rc::new(RefCell::new(0));
     let i: Value<i32> = Rc::new(RefCell::new(0));
-    'loop_: while ((*i.borrow()) < (*count.borrow())) {
+    'loop_: while ((((*i.borrow()) < (*count.borrow())) as i32) != 0) {
         (*sum1.borrow_mut()) += ((*ap.borrow_mut()).arg::<i32>()).clone();
         (*i.borrow_mut()).postfix_inc();
     }
     let sum2: Value<i32> = Rc::new(RefCell::new(0));
     let i: Value<i32> = Rc::new(RefCell::new(0));
-    'loop_: while ((*i.borrow()) < (*count.borrow())) {
+    'loop_: while ((((*i.borrow()) < (*count.borrow())) as i32) != 0) {
         (*sum2.borrow_mut()) += ((*aq.borrow_mut()).arg::<i32>()).clone();
         (*i.borrow_mut()).postfix_inc();
     }
-    assert!(((*sum1.borrow()) == (*sum2.borrow())));
+    assert!(((((*sum1.borrow()) == (*sum2.borrow())) as i32) != 0));
     return ((*sum1.borrow()) + (*sum2.borrow()));
 }
 pub fn main() {
@@ -32,10 +32,11 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     assert!(
-        (({
+        (((({
             let _count: i32 = 3;
             sum_with_copy_0(_count, &[10.into(), 20.into(), 30.into()])
-        }) == 120)
+        }) == 120) as i32)
+            != 0)
     );
     return 0;
 }

--- a/tests/unit/out/refcount/va_arg_forward.rs
+++ b/tests/unit/out/refcount/va_arg_forward.rs
@@ -11,7 +11,7 @@ pub fn inner_0(count: i32, ap: VaList) -> i32 {
     let ap: Value<VaList> = Rc::new(RefCell::new(ap));
     let total: Value<i32> = Rc::new(RefCell::new(0));
     let i: Value<i32> = Rc::new(RefCell::new(0));
-    'loop_: while ((*i.borrow()) < (*count.borrow())) {
+    'loop_: while ((((*i.borrow()) < (*count.borrow())) as i32) != 0) {
         (*total.borrow_mut()) += ((*ap.borrow_mut()).arg::<i32>()).clone();
         (*i.borrow_mut()).postfix_inc();
     }
@@ -35,22 +35,25 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     assert!(
-        (({
+        (((({
             let _count: i32 = 3;
             outer_1(_count, &[10.into(), 20.into(), 30.into()])
-        }) == 60)
+        }) == 60) as i32)
+            != 0)
     );
     assert!(
-        (({
+        (((({
             let _count: i32 = 1;
             outer_1(_count, &[42.into()])
-        }) == 42)
+        }) == 42) as i32)
+            != 0)
     );
     assert!(
-        (({
+        (((({
             let _count: i32 = 0;
             outer_1(_count, &[])
-        }) == 0)
+        }) == 0) as i32)
+            != 0)
     );
     return 0;
 }

--- a/tests/unit/out/refcount/va_arg_mixed_int_ptr.rs
+++ b/tests/unit/out/refcount/va_arg_mixed_int_ptr.rs
@@ -12,9 +12,9 @@ pub fn mixed_args_0(count: i32, args: &[VaArg]) -> i32 {
     (*ap.borrow_mut()) = VaList::new(args);
     let total: Value<i32> = Rc::new(RefCell::new(0));
     let i: Value<i32> = Rc::new(RefCell::new(0));
-    'loop_: while ((*i.borrow()) < (*count.borrow())) {
+    'loop_: while ((((*i.borrow()) < (*count.borrow())) as i32) != 0) {
         let tag: Value<i32> = Rc::new(RefCell::new(((*ap.borrow_mut()).arg::<i32>()).clone()));
-        if ((*tag.borrow()) == 0) {
+        if ((((*tag.borrow()) == 0) as i32) != 0) {
             (*total.borrow_mut()) += ((*ap.borrow_mut()).arg::<i32>()).clone();
         } else {
             let ptr: Value<Ptr<i32>> =
@@ -32,7 +32,7 @@ pub fn main() {
 fn main_0() -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(100));
     assert!(
-        (({
+        (((({
             let _count: i32 = 3;
             mixed_args_0(
                 _count,
@@ -45,20 +45,23 @@ fn main_0() -> i32 {
                     20.into(),
                 ],
             )
-        }) == 130)
+        }) == 130) as i32)
+            != 0)
     );
     let y: Value<i32> = Rc::new(RefCell::new(50));
     assert!(
-        (({
+        (((({
             let _count: i32 = 1;
             mixed_args_0(_count, &[1.into(), (y.as_pointer()).into()])
-        }) == 50)
+        }) == 50) as i32)
+            != 0)
     );
     assert!(
-        (({
+        (((({
             let _count: i32 = 2;
             mixed_args_0(_count, &[0.into(), 5.into(), 0.into(), 3.into()])
-        }) == 8)
+        }) == 8) as i32)
+            != 0)
     );
     return 0;
 }

--- a/tests/unit/out/refcount/va_arg_mixed_types.rs
+++ b/tests/unit/out/refcount/va_arg_mixed_types.rs
@@ -12,11 +12,11 @@ pub fn sum_mixed_0(count: i32, args: &[VaArg]) -> i32 {
     (*ap.borrow_mut()) = VaList::new(args);
     let total: Value<i32> = Rc::new(RefCell::new(0));
     let i: Value<i32> = Rc::new(RefCell::new(0));
-    'loop_: while ((*i.borrow()) < (*count.borrow())) {
+    'loop_: while ((((*i.borrow()) < (*count.borrow())) as i32) != 0) {
         let tag: Value<i32> = Rc::new(RefCell::new(((*ap.borrow_mut()).arg::<i32>()).clone()));
-        if ((*tag.borrow()) == 0) {
+        if ((((*tag.borrow()) == 0) as i32) != 0) {
             (*total.borrow_mut()) += ((*ap.borrow_mut()).arg::<i32>()).clone();
-        } else if ((*tag.borrow()) == 1) {
+        } else if ((((*tag.borrow()) == 1) as i32) != 0) {
             (*total.borrow_mut()) += ((*ap.borrow_mut()).arg::<f64>() as i32).clone();
         } else {
             let val: Value<i64> = Rc::new(RefCell::new(((*ap.borrow_mut()).arg::<i64>()).clone()));
@@ -31,7 +31,7 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     assert!(
-        (({
+        (((({
             let _count: i32 = 3;
             sum_mixed_0(
                 _count,
@@ -44,19 +44,22 @@ fn main_0() -> i32 {
                     30_i64.into(),
                 ],
             )
-        }) == 60)
+        }) == 60) as i32)
+            != 0)
     );
     assert!(
-        (({
+        (((({
             let _count: i32 = 1;
             sum_mixed_0(_count, &[0.into(), 42.into()])
-        }) == 42)
+        }) == 42) as i32)
+            != 0)
     );
     assert!(
-        (({
+        (((({
             let _count: i32 = 2;
             sum_mixed_0(_count, &[1.into(), 3.7E+0.into(), 2.into(), 100_i64.into()])
-        }) == 103)
+        }) == 103) as i32)
+            != 0)
     );
     return 0;
 }

--- a/tests/unit/out/refcount/va_arg_printf.rs
+++ b/tests/unit/out/refcount/va_arg_printf.rs
@@ -33,16 +33,18 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     assert!(
-        (({
+        (((({
             let _fmt: Ptr<u8> = Ptr::from_string_literal("hello %d %d");
             logf_1(_fmt, &[10.into(), 32.into()])
-        }) == 42)
+        }) == 42) as i32)
+            != 0)
     );
     assert!(
-        (({
+        (((({
             let _fmt: Ptr<u8> = Ptr::from_string_literal("x %d %d");
             logf_1(_fmt, &[1.into(), 2.into()])
-        }) == 3)
+        }) == 3) as i32)
+            != 0)
     );
     return 0;
 }

--- a/tests/unit/out/refcount/va_arg_promotion.rs
+++ b/tests/unit/out/refcount/va_arg_promotion.rs
@@ -13,9 +13,9 @@ pub fn test_promotions_0(count: i32, args: &[VaArg]) -> i32 {
     let a: Value<i32> = Rc::new(RefCell::new(((*ap.borrow_mut()).arg::<i32>()).clone()));
     let b: Value<i32> = Rc::new(RefCell::new(((*ap.borrow_mut()).arg::<i32>()).clone()));
     let c: Value<f64> = Rc::new(RefCell::new(((*ap.borrow_mut()).arg::<f64>()).clone()));
-    assert!(((*a.borrow()) == 65));
-    assert!(((*b.borrow()) == 10));
-    assert!(((*c.borrow()) == 3.0E+0));
+    assert!(((((*a.borrow()) == 65) as i32) != 0));
+    assert!(((((*b.borrow()) == 10) as i32) != 0));
+    assert!(((((*c.borrow()) == 3.0E+0) as i32) != 0));
     return (((*a.borrow()) + (*b.borrow())) + ((*c.borrow()) as i32));
 }
 pub fn main() {
@@ -26,7 +26,7 @@ fn main_0() -> i32 {
     let y: Value<i16> = Rc::new(RefCell::new(10_i16));
     let z: Value<f32> = Rc::new(RefCell::new(3.0E+0));
     assert!(
-        (({
+        (((({
             let _count: i32 = 3;
             test_promotions_0(
                 _count,
@@ -36,7 +36,8 @@ fn main_0() -> i32 {
                     ((*z.borrow()) as f64).into(),
                 ],
             )
-        }) == 78)
+        }) == 78) as i32)
+            != 0)
     );
     return 0;
 }

--- a/tests/unit/out/refcount/va_arg_snprintf.rs
+++ b/tests/unit/out/refcount/va_arg_snprintf.rs
@@ -25,22 +25,24 @@ fn main_0() -> i32 {
         (0..64).map(|_| <u8>::default()).collect::<Box<[u8]>>(),
     ));
     assert!(
-        (({
+        (((({
             let _buf: Ptr<u8> = (buf.as_pointer() as Ptr<u8>);
             let _size: i32 = 1;
             let _fmt: Ptr<u8> = Ptr::from_string_literal("%d");
             extract_first_0(_buf, _size, _fmt, &[42.into()])
-        }) == 42)
+        }) == 42) as i32)
+            != 0)
     );
-    assert!((((*buf.borrow())[(0) as usize] as i32) == 42));
+    assert!((((((*buf.borrow())[(0) as usize] as i32) == 42) as i32) != 0));
     assert!(
-        (({
+        (((({
             let _buf: Ptr<u8> = (buf.as_pointer() as Ptr<u8>);
             let _size: i32 = 1;
             let _fmt: Ptr<u8> = Ptr::from_string_literal("%d");
             extract_first_0(_buf, _size, _fmt, &[65.into()])
-        }) == 65)
+        }) == 65) as i32)
+            != 0)
     );
-    assert!((((*buf.borrow())[(0) as usize] as i32) == ('A' as i32)));
+    assert!((((((*buf.borrow())[(0) as usize] as i32) == ('A' as i32)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/refcount/va_arg_struct_ctx.rs
+++ b/tests/unit/out/refcount/va_arg_struct_ctx.rs
@@ -34,13 +34,13 @@ fn main_0() -> i32 {
         let _fmt: Ptr<u8> = Ptr::from_string_literal("error %d");
         set_error_0(_ctx, _fmt, &[42.into()])
     });
-    assert!(((*(*ctx.borrow()).last_error.borrow()) == 42));
+    assert!(((((*(*ctx.borrow()).last_error.borrow()) == 42) as i32) != 0));
     (*(*ctx.borrow()).verbose.borrow_mut()) = 0;
     ({
         let _ctx: Ptr<context> = (ctx.as_pointer());
         let _fmt: Ptr<u8> = Ptr::from_string_literal("error %d");
         set_error_0(_ctx, _fmt, &[99.into()])
     });
-    assert!(((*(*ctx.borrow()).last_error.borrow()) == 42));
+    assert!(((((*(*ctx.borrow()).last_error.borrow()) == 42) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/refcount/va_arg_two_passes.rs
+++ b/tests/unit/out/refcount/va_arg_two_passes.rs
@@ -13,18 +13,20 @@ pub fn sum_then_product_0(first: i32, args: &[VaArg]) -> i32 {
     let product: Value<i32> = Rc::new(RefCell::new((*first.borrow())));
     (*ap.borrow_mut()) = VaList::new(args);
     let val: Value<i32> = <Value<i32>>::default();
-    'loop_: while (({
+    'loop_: while (((({
         (*val.borrow_mut()) = ((*ap.borrow_mut()).arg::<i32>()).clone();
         (*val.borrow())
-    }) != 0)
+    }) != 0) as i32)
+        != 0)
     {
         (*sum.borrow_mut()) += (*val.borrow());
     }
     (*ap.borrow_mut()) = VaList::new(args);
-    'loop_: while (({
+    'loop_: while (((({
         (*val.borrow_mut()) = ((*ap.borrow_mut()).arg::<i32>()).clone();
         (*val.borrow())
-    }) != 0)
+    }) != 0) as i32)
+        != 0)
     {
         (*product.borrow_mut()) *= (*val.borrow());
     }
@@ -35,10 +37,11 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     assert!(
-        (({
+        (((({
             let _first: i32 = 2;
             sum_then_product_0(_first, &[3.into(), 4.into(), 0.into()])
-        }) == 33)
+        }) == 33) as i32)
+            != 0)
     );
     return 0;
 }

--- a/tests/unit/out/refcount/vector.rs
+++ b/tests/unit/out/refcount/vector.rs
@@ -123,23 +123,22 @@ fn main_0() -> i32 {
     assert!(((*v7.borrow()).len() as u64 == 200_u64));
     let i: Value<u32> = Rc::new(RefCell::new(0_u32));
     'loop_: while ((*i.borrow()) < 200_u32) {
-        assert!({
-            let _lhs = ((*(*(v7.as_pointer() as Ptr<(Value<Ptr<i32>>, Value<i32>)>)
+        assert!(
+            ((*(*(v7.as_pointer() as Ptr<(Value<Ptr::<i32>>, Value<i32>)>)
                 .offset(((*i.borrow()) as u64) as isize)
                 .upgrade()
                 .deref())
             .0
             .borrow())
             .is_null())
-            .clone();
-            _lhs && ((*(*(v7.as_pointer() as Ptr<(Value<Ptr<i32>>, Value<i32>)>)
-                .offset(((*i.borrow()) as u64) as isize)
-                .upgrade()
-                .deref())
-            .1
-            .borrow())
-                == 0)
-        });
+                && ((*(*(v7.as_pointer() as Ptr<(Value<Ptr::<i32>>, Value<i32>)>)
+                    .offset(((*i.borrow()) as u64) as isize)
+                    .upgrade()
+                    .deref())
+                .1
+                .borrow())
+                    == 0)
+        );
         (*i.borrow_mut()).prefix_inc();
     }
     let p1: Value<Ptr<f64>> = Rc::new(RefCell::new((v6.as_pointer() as Ptr<f64>)));

--- a/tests/unit/out/unsafe/anonymous-struct_c.rs
+++ b/tests/unit/out/unsafe/anonymous-struct_c.rs
@@ -80,17 +80,17 @@ unsafe fn main_0() -> i32 {
     o.anon_3.i = 9;
     o.anon_3.inner_named.j = 10;
     o.anon_3.anon_1.k = 11;
-    assert!(((o.named.a) == (1)));
-    assert!(((o.named.b) == (2)));
-    assert!(((o.anon0.c) == (3)));
-    assert!(((o.anon0.d) == (4)));
-    assert!(((o.anon1.g) == (5)));
-    assert!(((o.anon1.h) == (6)));
-    assert!(((o.anon_2.e) == (7)));
-    assert!(((o.anon_2.f) == (8)));
-    assert!(((o.anon_3.i) == (9)));
-    assert!(((o.anon_3.inner_named.j) == (10)));
-    assert!(((o.anon_3.anon_1.k) == (11)));
+    assert!(((((o.named.a) == (1)) as i32) != 0));
+    assert!(((((o.named.b) == (2)) as i32) != 0));
+    assert!(((((o.anon0.c) == (3)) as i32) != 0));
+    assert!(((((o.anon0.d) == (4)) as i32) != 0));
+    assert!(((((o.anon1.g) == (5)) as i32) != 0));
+    assert!(((((o.anon1.h) == (6)) as i32) != 0));
+    assert!(((((o.anon_2.e) == (7)) as i32) != 0));
+    assert!(((((o.anon_2.f) == (8)) as i32) != 0));
+    assert!(((((o.anon_3.i) == (9)) as i32) != 0));
+    assert!(((((o.anon_3.inner_named.j) == (10)) as i32) != 0));
+    assert!(((((o.anon_3.anon_1.k) == (11)) as i32) != 0));
     #[repr(C)]
     #[derive(Copy, Clone, Default)]
     pub struct anon_0 {

--- a/tests/unit/out/unsafe/anonymous_enum_c.rs
+++ b/tests/unit/out/unsafe/anonymous_enum_c.rs
@@ -98,17 +98,17 @@ unsafe fn main_0() -> i32 {
             }
         }
     };
-    assert!(((anon_enum_3::FIRST_A as i32) != (anon_enum_3::FIRST_B as i32)));
-    assert!(((anon_enum_11::SECOND_A as i32) != (anon_enum_11::SECOND_B as i32)));
-    assert!(((anon_enum_31::THIRD_A as i32) != (anon_enum_31::THIRD_B as i32)));
+    assert!(((((anon_enum_3::FIRST_A as i32) != (anon_enum_3::FIRST_B as i32)) as i32) != 0));
+    assert!(((((anon_enum_11::SECOND_A as i32) != (anon_enum_11::SECOND_B as i32)) as i32) != 0));
+    assert!(((((anon_enum_31::THIRD_A as i32) != (anon_enum_31::THIRD_B as i32)) as i32) != 0));
     let mut td: TdEnum = TdEnum::from((TdEnum::TD_A as i32));
-    assert!(((td as u32) == ((TdEnum::TD_A as i32) as u32)));
+    assert!(((((td as u32) == ((TdEnum::TD_A as i32) as u32)) as i32) != 0));
     td = (TdEnum::from((TdEnum::TD_B as i32))).clone();
-    assert!(((td as u32) == ((TdEnum::TD_B as i32) as u32)));
+    assert!(((((td as u32) == ((TdEnum::TD_B as i32) as u32)) as i32) != 0));
     let mut w: WithAnonField = <WithAnonField>::default();
     w.field = anon_enum_24::from((anon_enum_24::FIELD_A as i32));
-    assert!(((w.field as u32) == ((anon_enum_24::FIELD_A as i32) as u32)));
+    assert!(((((w.field as u32) == ((anon_enum_24::FIELD_A as i32) as u32)) as i32) != 0));
     w.field = (anon_enum_24::from((anon_enum_24::FIELD_B as i32))).clone();
-    assert!(((w.field as u32) == ((anon_enum_24::FIELD_B as i32) as u32)));
+    assert!(((((w.field as u32) == ((anon_enum_24::FIELD_B as i32) as u32)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/bool_condition_enum_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_enum_c.rs
@@ -44,7 +44,7 @@ unsafe fn main_0() -> i32 {
         assert!((0 != 0));
     }
     let mut t9: i32 = (!(code != Code::from(0)) as i32);
-    assert!(((t9) == (1)));
+    assert!(((((t9) == (1)) as i32) != 0));
     let mut b4: bool = (code != Code::from(0));
     assert!(((!b4 as i32) != 0));
     return 0;

--- a/tests/unit/out/unsafe/bool_condition_int_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_int_c.rs
@@ -48,21 +48,21 @@ unsafe fn main_0() -> i32 {
         counter.prefix_dec();
         loop_count.prefix_inc();
     }
-    assert!(((loop_count) == (3)));
+    assert!(((((loop_count) == (3)) as i32) != 0));
     let mut i: i32 = 5;
     'loop_: while (i != 0) {
         loop_count.prefix_inc();
         i.prefix_dec();
     }
-    assert!(((loop_count) == (8)));
+    assert!(((((loop_count) == (8)) as i32) != 0));
     let mut t: i32 = if (n != 0) { 100 } else { 200 };
-    assert!(((t) == (100)));
+    assert!(((((t) == (100)) as i32) != 0));
     let mut t2: i32 = if (zero != 0) { 100 } else { 200 };
-    assert!(((t2) == (200)));
+    assert!(((((t2) == (200)) as i32) != 0));
     let mut t7: i32 = (!(n != 0) as i32);
-    assert!(((t7) == (0)));
+    assert!(((((t7) == (0)) as i32) != 0));
     let mut t8: i32 = (!(zero != 0) as i32);
-    assert!(((t8) == (1)));
+    assert!(((((t8) == (1)) as i32) != 0));
     let mut b1: bool = (n != 0);
     assert!(b1);
     return 0;

--- a/tests/unit/out/unsafe/bool_condition_logical.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical.rs
@@ -28,6 +28,12 @@ pub unsafe fn observe_0(mut v: i32) -> i32 {
     side_effect.prefix_inc();
     return v;
 }
+pub unsafe fn returns_one_1() -> i32 {
+    return 1;
+}
+pub unsafe fn returns_zero_2() -> i32 {
+    return 0;
+}
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
@@ -41,36 +47,36 @@ unsafe fn main_0() -> i32 {
     let mut np: *mut i32 = Default::default();
     let mut u: u32 = 4_u32;
     let mut code: Code = Code::CODE_OK;
-    if ((n != 0) && (!(p).is_null())) {
+    if (n != 0) && (!(p).is_null()) {
         assert!(true);
     }
-    if ((n != 0) && (!(np).is_null())) {
+    if (n != 0) && (!(np).is_null()) {
         assert!(false);
     }
-    if ((zero != 0) || (!(p).is_null())) {
+    if (zero != 0) || (!(p).is_null()) {
         assert!(true);
     }
-    if ((zero != 0) || (!(np).is_null())) {
+    if (zero != 0) || (!(np).is_null()) {
         assert!(false);
     }
-    if ((((n != 0) && (u != 0)) && (!(p).is_null())) && ((code as i32) == (Code::CODE_OK as i32))) {
+    if (((n != 0) && (u != 0)) && (!(p).is_null())) && ((code as i32) == (Code::CODE_OK as i32)) {
         assert!(true);
     }
     side_effect = 0;
-    if ((zero != 0)
+    if (zero != 0)
         && ((unsafe {
             let _v: i32 = 1;
             observe_0(_v)
-        }) != 0))
+        }) != 0)
     {
         assert!(false);
     }
     assert!(((side_effect) == (0)));
-    if ((n != 0)
+    if (n != 0)
         || ((unsafe {
             let _v: i32 = 1;
             observe_0(_v)
-        }) != 0))
+        }) != 0)
     {
         assert!(true);
     }
@@ -78,28 +84,69 @@ unsafe fn main_0() -> i32 {
     let mut x: i32 = 5;
     let mut y: i32 = 3;
     let mut flags: u32 = 2_u32;
-    if (((x) > (y)) || (((flags) & (1_u32)) != 0)) {
+    if ((x) > (y)) || (((flags) & (1_u32)) != 0) {
         assert!(true);
     }
-    if (((x) < (y)) || (((flags) & (1_u32)) != 0)) {
+    if ((x) < (y)) || (((flags) & (1_u32)) != 0) {
         assert!(false);
     }
     let mut a: u32 = 1_u32;
     let mut b: u32 = 2_u32;
     let mut c: u32 = 3_u32;
-    if (((a) != (c)) && ((b) != (c))) {
+    if ((a) != (c)) && ((b) != (c)) {
         assert!(true);
     }
     let mut s: i32 = -1_i32;
-    if ((!((p).is_null())) && ((s) < (0))) {
+    if (!((p).is_null())) && ((s) < (0)) {
         assert!(true);
     }
     let mut k: u32 = 2_u32;
     let mut done: bool = false;
-    if (((k) > (1_u32)) || (!done)) {
+    if ((k) > (1_u32)) || (!done) {
         assert!(true);
     }
-    if (((x) > (y)) || (((flags) & (4_u32)) != 0)) {
+    if ((x) > (y)) || (((flags) & (4_u32)) != 0) {
+        assert!(true);
+    }
+    let mut ull: u64 = 7_u64;
+    if (!((p).is_null())) && (ull != 0) {
+        assert!(true);
+    }
+    if ((x) > (y)) && (ull != 0) {
+        assert!(true);
+    }
+    let mut mask: i64 = (((1_i64) << (4)) | ((1_i64) << (5)));
+    let mut bits: i64 = ((1_i64) << (4));
+    if ((n) != (0)) && (((bits) & (mask)) != 0) {
+        assert!(true);
+    }
+    if ((n) != (0)) || (((bits) & (256_i64)) != 0) {
+        assert!(true);
+    }
+    let mut cp: *const u8 = b"hi\0".as_ptr();
+    let mut cnp: *const u8 = Default::default();
+    if ((x) > (y)) && (!(cp).is_null()) {
+        assert!(true);
+    }
+    if ((x) < (y)) || (!(cnp).is_null()) {
+        assert!(false);
+    }
+    if ((x) > (y)) && ((n != 0) && (!(cp).is_null())) {
+        assert!(true);
+    }
+    if ((x) > (y)) && ((unsafe { returns_one_1() }) != 0) {
+        assert!(true);
+    }
+    if ((x) > (y)) && (!((unsafe { returns_zero_2() }) != 0)) {
+        assert!(true);
+    }
+    if ((x) < (y)) || ((unsafe { returns_one_1() }) != 0) {
+        assert!(true);
+    }
+    if ((x) < (y)) || (!((unsafe { returns_one_1() }) != 0)) {
+        assert!(false);
+    }
+    if ((!((p).is_null())) && ((unsafe { returns_one_1() }) != 0)) && ((n) != (0)) {
         assert!(true);
     }
     return 0;

--- a/tests/unit/out/unsafe/bool_condition_logical_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical_c.rs
@@ -28,6 +28,12 @@ pub unsafe fn observe_0(mut v: i32) -> i32 {
     side_effect.prefix_inc();
     return v;
 }
+pub unsafe fn returns_one_1() -> i32 {
+    return 1;
+}
+pub unsafe fn returns_zero_2() -> i32 {
+    return 0;
+}
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
@@ -41,67 +47,123 @@ unsafe fn main_0() -> i32 {
     let mut np: *mut i32 = Default::default();
     let mut u: u32 = 4_u32;
     let mut code: Code = Code::from((Code::CODE_OK as i32));
-    if (n != 0) && (!(p).is_null()) {
+    if ((((n != 0) && (!(p).is_null())) as i32) != 0) {
         assert!((1 != 0));
     }
-    if (n != 0) && (!(np).is_null()) {
+    if ((((n != 0) && (!(np).is_null())) as i32) != 0) {
         assert!((0 != 0));
     }
-    if (zero != 0) || (!(p).is_null()) {
+    if ((((zero != 0) || (!(p).is_null())) as i32) != 0) {
         assert!((1 != 0));
     }
-    if (zero != 0) || (!(np).is_null()) {
+    if ((((zero != 0) || (!(np).is_null())) as i32) != 0) {
         assert!((0 != 0));
     }
-    if (((n != 0) && (u != 0)) && (!(p).is_null()))
-        && ((code as u32) == ((Code::CODE_OK as i32) as u32))
+    if ((((((((((n != 0) && (u != 0)) as i32) != 0) && (!(p).is_null())) as i32) != 0)
+        && ((((code as u32) == ((Code::CODE_OK as i32) as u32)) as i32) != 0)) as i32)
+        != 0)
     {
         assert!((1 != 0));
     }
     side_effect = 0;
-    if (zero != 0)
+    if ((((zero != 0)
         && ((unsafe {
             let _v: i32 = 1;
             observe_0(_v)
-        }) != 0)
+        }) != 0)) as i32)
+        != 0)
     {
         assert!((0 != 0));
     }
-    assert!(((side_effect) == (0)));
-    if (n != 0)
+    assert!(((((side_effect) == (0)) as i32) != 0));
+    if ((((n != 0)
         || ((unsafe {
             let _v: i32 = 1;
             observe_0(_v)
-        }) != 0)
+        }) != 0)) as i32)
+        != 0)
     {
         assert!((1 != 0));
     }
-    assert!(((side_effect) == (0)));
+    assert!(((((side_effect) == (0)) as i32) != 0));
     let mut x: i32 = 5;
     let mut y: i32 = 3;
     let mut flags: u32 = 2_u32;
-    if ((x) > (y)) || (((flags) & (1_u32)) != 0) {
+    if (((((((x) > (y)) as i32) != 0) || (((flags) & (1_u32)) != 0)) as i32) != 0) {
         assert!((1 != 0));
     }
-    if ((x) < (y)) || (((flags) & (1_u32)) != 0) {
+    if (((((((x) < (y)) as i32) != 0) || (((flags) & (1_u32)) != 0)) as i32) != 0) {
         assert!((0 != 0));
     }
     let mut a: u32 = 1_u32;
     let mut b: u32 = 2_u32;
     let mut c: u32 = 3_u32;
-    if ((a) != (c)) && ((b) != (c)) {
+    if (((((((a) != (c)) as i32) != 0) && ((((b) != (c)) as i32) != 0)) as i32) != 0) {
         assert!((1 != 0));
     }
     let mut s: i32 = -1_i32;
-    if ((p) != ((0 as *mut ::libc::c_void) as *mut i32)) && ((s) < (0)) {
+    if (((((((p) != ((0 as *mut ::libc::c_void) as *mut i32)) as i32) != 0)
+        && ((((s) < (0)) as i32) != 0)) as i32)
+        != 0)
+    {
         assert!((1 != 0));
     }
     let mut k: u32 = 2_u32;
     let mut done: bool = (0 != 0);
-    if ((k) > (1_u32)) || (!done) {
+    if (((((((k) > (1_u32)) as i32) != 0) || (!done)) as i32) != 0) {
         assert!((1 != 0));
     }
-    if ((x) > (y)) || (((flags) & (4_u32)) != 0) {
+    if (((((((x) > (y)) as i32) != 0) || (((flags) & (4_u32)) != 0)) as i32) != 0) {
+        assert!((1 != 0));
+    }
+    let mut ull: u64 = 7_u64;
+    if (((((((p) != ((0 as *mut ::libc::c_void) as *mut i32)) as i32) != 0) && (ull != 0)) as i32)
+        != 0)
+    {
+        assert!((1 != 0));
+    }
+    if (((((((x) > (y)) as i32) != 0) && (ull != 0)) as i32) != 0) {
+        assert!((1 != 0));
+    }
+    let mut mask: i64 = (((1_i64) << (4)) | ((1_i64) << (5)));
+    let mut bits: i64 = ((1_i64) << (4));
+    if (((((((n) != (0)) as i32) != 0) && (((bits) & (mask)) != 0)) as i32) != 0) {
+        assert!((1 != 0));
+    }
+    if (((((((n) != (0)) as i32) != 0) || (((bits) & (256_i64)) != 0)) as i32) != 0) {
+        assert!((1 != 0));
+    }
+    let mut cp: *const u8 = b"hi\0".as_ptr().cast_mut().cast_const();
+    let mut cnp: *const u8 = Default::default();
+    if (((((((x) > (y)) as i32) != 0) && (!(cp).is_null())) as i32) != 0) {
+        assert!((1 != 0));
+    }
+    if (((((((x) < (y)) as i32) != 0) || (!(cnp).is_null())) as i32) != 0) {
+        assert!((0 != 0));
+    }
+    if (((((((x) > (y)) as i32) != 0) && ((((n != 0) && (!(cp).is_null())) as i32) != 0)) as i32)
+        != 0)
+    {
+        assert!((1 != 0));
+    }
+    if (((((((x) > (y)) as i32) != 0) && ((unsafe { returns_one_1() }) != 0)) as i32) != 0) {
+        assert!((1 != 0));
+    }
+    if (((((((x) > (y)) as i32) != 0) && (!((unsafe { returns_zero_2() }) != 0))) as i32) != 0) {
+        assert!((1 != 0));
+    }
+    if (((((((x) < (y)) as i32) != 0) || ((unsafe { returns_one_1() }) != 0)) as i32) != 0) {
+        assert!((1 != 0));
+    }
+    if (((((((x) < (y)) as i32) != 0) || (!((unsafe { returns_one_1() }) != 0))) as i32) != 0) {
+        assert!((0 != 0));
+    }
+    if ((((((((((p) != ((0 as *mut ::libc::c_void) as *mut i32)) as i32) != 0)
+        && ((unsafe { returns_one_1() }) != 0)) as i32)
+        != 0)
+        && ((((n) != (0)) as i32) != 0)) as i32)
+        != 0)
+    {
         assert!((1 != 0));
     }
     return 0;

--- a/tests/unit/out/unsafe/bool_condition_ptr_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_ptr_c.rs
@@ -33,15 +33,15 @@ unsafe fn main_0() -> i32 {
         iters.prefix_inc();
         iter = Default::default();
     }
-    assert!(((iters) == (1)));
+    assert!(((((iters) == (1)) as i32) != 0));
     let mut t3: i32 = if !(p).is_null() { 1 } else { 0 };
-    assert!(((t3) == (1)));
+    assert!(((((t3) == (1)) as i32) != 0));
     let mut t4: i32 = if !(np).is_null() { 1 } else { 0 };
-    assert!(((t4) == (0)));
+    assert!(((((t4) == (0)) as i32) != 0));
     let mut t5: i32 = (!!(p).is_null() as i32);
-    assert!(((t5) == (0)));
+    assert!(((((t5) == (0)) as i32) != 0));
     let mut t6: i32 = (!!(np).is_null() as i32);
-    assert!(((t6) == (1)));
+    assert!(((((t6) == (1)) as i32) != 0));
     let mut b2: bool = !(p).is_null();
     let mut b3: bool = !(np).is_null();
     assert!(b2);

--- a/tests/unit/out/unsafe/bst.rs
+++ b/tests/unit/out/unsafe/bst.rs
@@ -14,13 +14,13 @@ pub struct node_t {
     pub value: i32,
 }
 pub unsafe fn find_0(mut node: *mut node_t, mut value: i32) -> *mut node_t {
-    if (((value) < ((*node).value)) && (!(((*node).left).is_null()))) {
+    if ((value) < ((*node).value)) && (!(((*node).left).is_null())) {
         return (unsafe {
             let _node: *mut node_t = (*node).left;
             let _value: i32 = value;
             find_0(_node, _value)
         });
-    } else if (((value) > ((*node).value)) && (!(((*node).right).is_null()))) {
+    } else if ((value) > ((*node).value)) && (!(((*node).right).is_null())) {
         return (unsafe {
             let _node: *mut node_t = (*node).right;
             let _value: i32 = value;

--- a/tests/unit/out/unsafe/builtin_types_compatible.rs
+++ b/tests/unit/out/unsafe/builtin_types_compatible.rs
@@ -12,16 +12,16 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    assert!(((1) == (1)));
-    assert!(((0) == (0)));
+    assert!(((((1) == (1)) as i32) != 0));
+    assert!(((((0) == (0)) as i32) != 0));
     let mut x: i32 = 0;
-    assert!(((1) == (1)));
-    assert!(((0) == (0)));
+    assert!(((((1) == (1)) as i32) != 0));
+    assert!(((((0) == (0)) as i32) != 0));
     let mut p: *mut i32 = Default::default();
-    assert!(((1) == (1)));
-    assert!(((0) == (0)));
+    assert!(((((1) == (1)) as i32) != 0));
+    assert!(((((0) == (0)) as i32) != 0));
     let mut ul: u64 = 0_u64;
-    assert!(((1) == (1)));
-    assert!(((0) == (0)));
+    assert!(((((1) == (1)) as i32) != 0));
+    assert!(((((0) == (0)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/c_struct.rs
+++ b/tests/unit/out/unsafe/c_struct.rs
@@ -61,14 +61,14 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut p: Point = Point { x: 10, y: 20 };
-    assert!(((p.x) == (10)));
-    assert!(((p.y) == (20)));
+    assert!(((((p.x) == (10)) as i32) != 0));
+    assert!(((((p.y) == (20)) as i32) != 0));
     let mut l: Line = Line {
         start: Point { x: 1, y: 2 },
         end: Point { x: 3, y: 4 },
     };
-    assert!(((l.start.x) == (1)));
-    assert!(((l.end.y) == (4)));
+    assert!(((((l.start.x) == (1)) as i32) != 0));
+    assert!(((((l.end.y) == (4)) as i32) != 0));
     let mut a: Node = Node {
         value: 1,
         next: Default::default(),
@@ -77,18 +77,18 @@ unsafe fn main_0() -> i32 {
         value: 2,
         next: (&mut a as *mut Node),
     };
-    assert!((((*b.next).value) == (1)));
+    assert!((((((*b.next).value) == (1)) as i32) != 0));
     let mut c: Container = Container {
         inner: Inner { a: 5, b: 6 },
         color: Color::from((Color::GREEN as i32)),
         count: 42,
     };
-    assert!(((c.inner.a) == (5)));
-    assert!(((c.inner.b) == (6)));
-    assert!(((c.color as u32) == ((Color::GREEN as i32) as u32)));
-    assert!(((c.count) == (42)));
+    assert!(((((c.inner.a) == (5)) as i32) != 0));
+    assert!(((((c.inner.b) == (6)) as i32) != 0));
+    assert!(((((c.color as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0));
+    assert!(((((c.count) == (42)) as i32) != 0));
     let mut c2: Container = <Container>::default();
     c2.color = Color::from((Color::BLUE as i32));
-    assert!(((c2.color as u32) == (2_u32)));
+    assert!(((((c2.color as u32) == (2_u32)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/enum_int_interop_c.rs
+++ b/tests/unit/out/unsafe/enum_int_interop_c.rs
@@ -95,10 +95,10 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut c: Color = Color::from((Color::RED as i32));
-    assert!(((c as u32) == ((Color::RED as i32) as u32)));
-    assert!(((c as u32) == (0_u32)));
-    assert!(((c as u32) != (1_u32)));
-    if ((c as u32) == ((Color::GREEN as i32) as u32)) {
+    assert!(((((c as u32) == ((Color::RED as i32) as u32)) as i32) != 0));
+    assert!(((((c as u32) == (0_u32)) as i32) != 0));
+    assert!(((((c as u32) != (1_u32)) as i32) != 0));
+    if ((((c as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0) {
         return 1;
     }
     'switch: {
@@ -119,48 +119,48 @@ unsafe fn main_0() -> i32 {
         }
     };
     let mut x: i32 = (c as i32);
-    assert!(((x) == (0)));
+    assert!(((((x) == (0)) as i32) != 0));
     let mut y: i32 = (((c as u32).wrapping_add(1_u32)) as i32);
-    assert!(((y) == (1)));
+    assert!(((((y) == (1)) as i32) != 0));
     c = Color::from(2);
-    assert!(((c as u32) == ((Color::BLUE as i32) as u32)));
-    assert!(((c as u32) == (2_u32)));
+    assert!(((((c as u32) == ((Color::BLUE as i32) as u32)) as i32) != 0));
+    assert!(((((c as u32) == (2_u32)) as i32) != 0));
     c = (unsafe {
         let _n: i32 = 1;
         make_color_2(_n)
     });
-    assert!(((c as u32) == ((Color::GREEN as i32) as u32)));
+    assert!(((((c as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0));
     let mut cmp: Color = Color::from(((c as u32).wrapping_add(1_u32)) as i32);
-    assert!(((cmp as u32) == ((Color::BLUE as i32) as u32)));
+    assert!(((((cmp as u32) == ((Color::BLUE as i32) as u32)) as i32) != 0));
     let mut o: Option = Option::from((Option::OPT_A as i32));
-    assert!(((o as u32) == ((Option::OPT_A as i32) as u32)));
-    assert!(((o as u32) == (10_u32)));
+    assert!(((((o as u32) == ((Option::OPT_A as i32) as u32)) as i32) != 0));
+    assert!(((((o as u32) == (10_u32)) as i32) != 0));
     let mut oi: i32 = (o as i32);
-    assert!(((oi) == (10)));
+    assert!(((((oi) == (10)) as i32) != 0));
     o = Option::from(20);
-    assert!(((o as u32) == ((Option::OPT_B as i32) as u32)));
+    assert!(((((o as u32) == ((Option::OPT_B as i32) as u32)) as i32) != 0));
     let mut rc: i32 = (unsafe {
         let _option: i32 = (o as i32);
         classify_option_1(_option)
     });
-    assert!(((rc) == (2)));
+    assert!(((((rc) == (2)) as i32) != 0));
     rc = (unsafe {
         let _option: i32 = 20;
         classify_option_1(_option)
     });
-    assert!(((rc) == (2)));
+    assert!(((((rc) == (2)) as i32) != 0));
     rc = (unsafe {
         let _option: i32 = (Option::OPT_C as i32);
         classify_option_1(_option)
     });
-    assert!(((rc) == (3)));
+    assert!(((((rc) == (3)) as i32) != 0));
     let mut t: Tag = Tag::from((Tag::TAG_ONE as i32));
-    assert!(((t as u32) == (1_u32)));
-    assert!(((t as u32) == ((Tag::TAG_ONE as i32) as u32)));
+    assert!(((((t as u32) == (1_u32)) as i32) != 0));
+    assert!(((((t as u32) == ((Tag::TAG_ONE as i32) as u32)) as i32) != 0));
     let mut ti: i32 = (t as i32);
-    assert!(((ti) == (1)));
+    assert!(((((ti) == (1)) as i32) != 0));
     t = Tag::from(2);
-    assert!(((t as u32) == ((Tag::TAG_TWO as i32) as u32)));
+    assert!(((((t as u32) == ((Tag::TAG_TWO as i32) as u32)) as i32) != 0));
     'switch: {
         let __match_cond = (t as u32);
         match __match_cond {
@@ -177,6 +177,6 @@ unsafe fn main_0() -> i32 {
         }
     };
     let mut extra: i32 = (((Color::RED as i32) + (Color::GREEN as i32)) + (Color::BLUE as i32));
-    assert!(((extra) == (((0) + (1)) + (2))));
+    assert!(((((extra) == (((0) + (1)) + (2))) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/expr_as_bool_c.rs
+++ b/tests/unit/out/unsafe/expr_as_bool_c.rs
@@ -6,6 +6,17 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
+pub unsafe fn cmp_eq_0(mut rc: i32) -> i32 {
+    return (((rc) == (-1_i32)) as i32);
+}
+pub unsafe fn cmp_or_ptr_1(mut p: *const u8, mut q: *const u8) -> i32 {
+    return (((!(p).is_null()) || (!(q).is_null())) as i32);
+}
+pub unsafe fn both_null_2(mut s1: *const u8, mut s2: *const u8) -> i32 {
+    return ((((((s1) == ((0 as *mut ::libc::c_void) as *const u8)) as i32) != 0)
+        && ((((s2) == ((0 as *mut ::libc::c_void) as *const u8)) as i32) != 0))
+        as i32);
+}
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
@@ -19,15 +30,16 @@ unsafe fn main_0() -> i32 {
         b
     } != 0)
     {}
-    'loop_: while (({
+    'loop_: while (((({
         b = a;
         b
-    }) != (0))
+    }) != (0)) as i32)
+        != 0)
     {}
     if (a != 0) {}
-    if ((a) == (b)) {}
-    if ((a) < (b)) {}
-    assert!(((a) == (b)));
+    if ((((a) == (b)) as i32) != 0) {}
+    if ((((a) < (b)) as i32) != 0) {}
+    assert!(((((a) == (b)) as i32) != 0));
     assert!(
         ((!(({
             a = b;
@@ -40,12 +52,73 @@ unsafe fn main_0() -> i32 {
         a = b;
         a
     } != 0);
-    c = (({
+    c = (((({
         b = a;
         b
-    }) != (0));
+    }) != (0)) as i32)
+        != 0);
     c = (a != 0);
-    c = ((a) == (b));
-    c = ((a) < (b));
+    c = ((((a) == (b)) as i32) != 0);
+    c = ((((a) < (b)) as i32) != 0);
+    let mut x: i32 = 5;
+    let mut y: i32 = 5;
+    let mut eq: i32 = (((x) == (y)) as i32);
+    let mut lt: i32 = (((x) < (y)) as i32);
+    let mut neq: i32 = (((x) != (y)) as i32);
+    assert!(((((eq) == (1)) as i32) != 0));
+    assert!(((((lt) == (0)) as i32) != 0));
+    assert!(((((neq) == (0)) as i32) != 0));
+    let mut p1: *const u8 = b"hi\0".as_ptr().cast_mut().cast_const();
+    let mut p2: *const u8 = Default::default();
+    let mut either: i32 = (((!(p1).is_null()) || (!(p2).is_null())) as i32);
+    let mut both: i32 = (((!(p1).is_null()) && (!(p2).is_null())) as i32);
+    assert!(((((either) == (1)) as i32) != 0));
+    assert!(((((both) == (0)) as i32) != 0));
+    assert!(
+        ((((unsafe {
+            let _rc: i32 = -1_i32;
+            cmp_eq_0(_rc)
+        }) == (1)) as i32)
+            != 0)
+    );
+    assert!(
+        ((((unsafe {
+            let _rc: i32 = 0;
+            cmp_eq_0(_rc)
+        }) == (0)) as i32)
+            != 0)
+    );
+    assert!(
+        ((((unsafe {
+            let _p: *const u8 = p1;
+            let _q: *const u8 = p2;
+            cmp_or_ptr_1(_p, _q)
+        }) == (1)) as i32)
+            != 0)
+    );
+    assert!(
+        ((((unsafe {
+            let _p: *const u8 = Default::default();
+            let _q: *const u8 = Default::default();
+            cmp_or_ptr_1(_p, _q)
+        }) == (0)) as i32)
+            != 0)
+    );
+    assert!(
+        ((((unsafe {
+            let _s1: *const u8 = Default::default();
+            let _s2: *const u8 = Default::default();
+            both_null_2(_s1, _s2)
+        }) == (1)) as i32)
+            != 0)
+    );
+    assert!(
+        ((((unsafe {
+            let _s1: *const u8 = p1;
+            let _s2: *const u8 = Default::default();
+            both_null_2(_s1, _s2)
+        }) == (0)) as i32)
+            != 0)
+    );
     return 0;
 }

--- a/tests/unit/out/unsafe/expr_as_bool_cpp.rs
+++ b/tests/unit/out/unsafe/expr_as_bool_cpp.rs
@@ -6,6 +6,15 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
+pub unsafe fn cmp_eq_0(mut rc: i32) -> i32 {
+    return (((rc) == (-1_i32)) as i32);
+}
+pub unsafe fn cmp_or_ptr_1(mut p: *const u8, mut q: *const u8) -> i32 {
+    return (((!(p).is_null()) || (!(q).is_null())) as i32);
+}
+pub unsafe fn both_null_2(mut s1: *const u8, mut s2: *const u8) -> i32 {
+    return ((((s1).is_null()) && ((s2).is_null())) as i32);
+}
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
@@ -46,5 +55,59 @@ unsafe fn main_0() -> i32 {
     c = (a != 0);
     c = ((a) == (b));
     c = ((a) < (b));
+    let mut x: i32 = 5;
+    let mut y: i32 = 5;
+    let mut eq: i32 = (((x) == (y)) as i32);
+    let mut lt: i32 = (((x) < (y)) as i32);
+    let mut neq: i32 = (((x) != (y)) as i32);
+    assert!(((eq) == (1)));
+    assert!(((lt) == (0)));
+    assert!(((neq) == (0)));
+    let mut p1: *const u8 = b"hi\0".as_ptr();
+    let mut p2: *const u8 = Default::default();
+    let mut either: i32 = (((!(p1).is_null()) || (!(p2).is_null())) as i32);
+    let mut both: i32 = (((!(p1).is_null()) && (!(p2).is_null())) as i32);
+    assert!(((either) == (1)));
+    assert!(((both) == (0)));
+    assert!(
+        ((unsafe {
+            let _rc: i32 = -1_i32;
+            cmp_eq_0(_rc)
+        }) == (1))
+    );
+    assert!(
+        ((unsafe {
+            let _rc: i32 = 0;
+            cmp_eq_0(_rc)
+        }) == (0))
+    );
+    assert!(
+        ((unsafe {
+            let _p: *const u8 = p1;
+            let _q: *const u8 = p2;
+            cmp_or_ptr_1(_p, _q)
+        }) == (1))
+    );
+    assert!(
+        ((unsafe {
+            let _p: *const u8 = Default::default();
+            let _q: *const u8 = Default::default();
+            cmp_or_ptr_1(_p, _q)
+        }) == (0))
+    );
+    assert!(
+        ((unsafe {
+            let _s1: *const u8 = Default::default();
+            let _s2: *const u8 = Default::default();
+            both_null_2(_s1, _s2)
+        }) == (1))
+    );
+    assert!(
+        ((unsafe {
+            let _s1: *const u8 = p1;
+            let _s2: *const u8 = Default::default();
+            both_null_2(_s1, _s2)
+        }) == (0))
+    );
     return 0;
 }

--- a/tests/unit/out/unsafe/huffman.rs
+++ b/tests/unit/out/unsafe/huffman.rs
@@ -16,7 +16,7 @@ pub struct MinHeapNode {
 }
 impl MinHeapNode {
     pub unsafe fn IsLeaf(&self) -> bool {
-        return (((self.left).is_null()) && ((self.right).is_null()));
+        return ((self.left).is_null()) && ((self.right).is_null());
     }
 }
 pub unsafe fn Swap_0(a: *mut MinHeapNode, b: *mut MinHeapNode) {
@@ -65,15 +65,15 @@ impl MinHeap {
         let mut smallest: i32 = idx;
         let mut left: i32 = (((2) * (idx)) + (1));
         let mut right: i32 = (((2) * (idx)) + (2));
-        if (((left) < (self.size))
+        if ((left) < (self.size))
             && (((*self.arr.as_mut().unwrap()[(left as u64) as usize]).freq)
-                < ((*self.arr.as_mut().unwrap()[(smallest as u64) as usize]).freq)))
+                < ((*self.arr.as_mut().unwrap()[(smallest as u64) as usize]).freq))
         {
             smallest = left;
         }
-        if (((right) < (self.size))
+        if ((right) < (self.size))
             && (((*self.arr.as_mut().unwrap()[(right as u64) as usize]).freq)
-                < ((*self.arr.as_mut().unwrap()[(smallest as u64) as usize]).freq)))
+                < ((*self.arr.as_mut().unwrap()[(smallest as u64) as usize]).freq))
         {
             smallest = right;
         }
@@ -106,9 +106,9 @@ impl MinHeap {
     pub unsafe fn Insert(&mut self, mut node: *mut MinHeapNode) {
         self.size.prefix_inc();
         let mut i: i32 = ((self.size) - (1));
-        'loop_: while (((i) != (0))
+        'loop_: while ((i) != (0))
             && (((*node).freq)
-                < ((*self.arr.as_mut().unwrap()[((((i) - (1)) / (2)) as u64) as usize]).freq)))
+                < ((*self.arr.as_mut().unwrap()[((((i) - (1)) / (2)) as u64) as usize]).freq))
         {
             self.arr.as_mut().unwrap()[(i as u64) as usize] =
                 self.arr.as_mut().unwrap()[((((i) - (1)) / (2)) as u64) as usize];

--- a/tests/unit/out/unsafe/kruskal.rs
+++ b/tests/unit/out/unsafe/kruskal.rs
@@ -41,7 +41,7 @@ pub unsafe fn partition_0(arr: *mut Option<Box<[Edge]>>, mut start: i32, mut end
     };
     let mut i: i32 = start;
     let mut j: i32 = end;
-    'loop_: while (((i) < (pidx)) && ((j) > (pidx))) {
+    'loop_: while ((i) < (pidx)) && ((j) > (pidx)) {
         'loop_: while (((*arr).as_mut().unwrap()[(i as u64) as usize].weight) <= ((*pivot).weight))
         {
             i.prefix_inc();
@@ -49,7 +49,7 @@ pub unsafe fn partition_0(arr: *mut Option<Box<[Edge]>>, mut start: i32, mut end
         'loop_: while (((*arr).as_mut().unwrap()[(j as u64) as usize].weight) > ((*pivot).weight)) {
             j.prefix_dec();
         }
-        if (((i) < (pidx)) && ((j) > (pidx))) {
+        if ((i) < (pidx)) && ((j) > (pidx)) {
             tmp = Edge {
                 u: (*arr).as_mut().unwrap()[(i as u64) as usize].u,
                 v: (*arr).as_mut().unwrap()[(i as u64) as usize].v,

--- a/tests/unit/out/unsafe/loop_with_postfix_inc.rs
+++ b/tests/unit/out/unsafe/loop_with_postfix_inc.rs
@@ -13,7 +13,7 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut x: i32 = 0;
-    'loop_: while (((x.postfix_inc()) < (100)) && ((x) != (50))) {
+    'loop_: while ((x.postfix_inc()) < (100)) && ((x) != (50)) {
         x.prefix_inc();
     }
     return x;

--- a/tests/unit/out/unsafe/map-reallocation.rs
+++ b/tests/unit/out/unsafe/map-reallocation.rs
@@ -20,12 +20,12 @@ unsafe fn main_0() -> i32 {
         UnsafeMapIterator::find_key(&m as *const BTreeMap<i32, Box<i32>>, &sentinel);
     let mut p: *mut i32 = (&mut *it.second() as *mut i32);
     assert!(
-        (((*it.second()) == (sentinel))
-            && (!(b"iterator does not have correct value before insert\0".as_ptr()).is_null()))
+        ((*it.second()) == (sentinel))
+            && (!(b"iterator does not have correct value before insert\0".as_ptr()).is_null())
     );
     assert!(
-        (((*p) == (sentinel))
-            && (!(b"pointer does not have correct value before insert\0".as_ptr()).is_null()))
+        ((*p) == (sentinel))
+            && (!(b"pointer does not have correct value before insert\0".as_ptr()).is_null())
     );
     let mut i: i32 = 0;
     'loop_: while ((i) < (sentinel)) {
@@ -38,17 +38,17 @@ unsafe fn main_0() -> i32 {
         i.prefix_inc();
     }
     assert!(
-        (((*it.second()) != (0))
+        ((*it.second()) != (0))
             && (!(b"in refcount, iterator points to index 0 instead of sentinel\0".as_ptr())
-                .is_null()))
+                .is_null())
     );
     assert!(
-        (((*it.second()) == (sentinel))
-            && (!(b"iterator does not have correct value after insert\0".as_ptr()).is_null()))
+        ((*it.second()) == (sentinel))
+            && (!(b"iterator does not have correct value after insert\0".as_ptr()).is_null())
     );
     assert!(
-        (((*p) == (sentinel))
-            && (!(b"pointer does not have correct value after insert\0".as_ptr()).is_null()))
+        ((*p) == (sentinel))
+            && (!(b"pointer does not have correct value after insert\0".as_ptr()).is_null())
     );
     *it.second() = 57005;
     assert!(((*m.entry(sentinel).or_default().as_mut()) == (57005)));

--- a/tests/unit/out/unsafe/new_bst.rs
+++ b/tests/unit/out/unsafe/new_bst.rs
@@ -14,13 +14,13 @@ pub struct node_t {
     pub value: i32,
 }
 pub unsafe fn find_0(mut node: *mut node_t, mut value: i32) -> *mut node_t {
-    if (((value) < ((*node).value)) && (!(((*node).left).is_null()))) {
+    if ((value) < ((*node).value)) && (!(((*node).left).is_null())) {
         return (unsafe {
             let _node: *mut node_t = (*node).left;
             let _value: i32 = value;
             find_0(_node, _value)
         });
-    } else if (((value) > ((*node).value)) && (!(((*node).right).is_null()))) {
+    } else if ((value) > ((*node).value)) && (!(((*node).right).is_null())) {
         return (unsafe {
             let _node: *mut node_t = (*node).right;
             let _value: i32 = value;
@@ -100,7 +100,7 @@ unsafe fn main_0() -> i32 {
         let _value: i32 = 4;
         insert_1(_node, _value)
     });
-    let mut out: bool = ((((((((*(unsafe {
+    let mut out: bool = (((((((*(unsafe {
         let _node: *mut node_t = root;
         let _value: i32 = 0;
         find_0(_node, _value)
@@ -140,7 +140,7 @@ unsafe fn main_0() -> i32 {
             let _value: i32 = 5;
             find_0(_node, _value)
         })
-        .is_null()));
+        .is_null());
     (unsafe {
         let _node: *mut node_t = root;
         del_2(_node)

--- a/tests/unit/out/unsafe/operator_less_than.rs
+++ b/tests/unit/out/unsafe/operator_less_than.rs
@@ -14,8 +14,8 @@ pub struct Pair {
 }
 impl Pair {
     pub unsafe fn lt(&self, other: *const Pair) -> bool {
-        return (((self.x) < ((*other).x))
-            || (((self.x) == ((*other).x)) && ((self.y) < ((*other).y))));
+        return ((self.x) < ((*other).x))
+            || (((self.x) == ((*other).x)) && ((self.y) < ((*other).y)));
     }
 }
 impl Ord for Pair {

--- a/tests/unit/out/unsafe/pointer_arithmetic.rs
+++ b/tests/unit/out/unsafe/pointer_arithmetic.rs
@@ -19,10 +19,10 @@ unsafe fn main_0() -> i32 {
         let mut a: [i32; 2] = [1, 2];
         p = (&mut a[(1) as usize] as *mut i32);
         (*p) += 1;
-        if (((a[(0) as usize]) == (1)) && ((a[(1) as usize]) == (3))) {
+        if ((a[(0) as usize]) == (1)) && ((a[(1) as usize]) == (3)) {
             p.prefix_dec();
             (*p) += 1;
-            if (((a[(0) as usize]) == (2)) && ((a[(1) as usize]) == (3))) {
+            if ((a[(0) as usize]) == (2)) && ((a[(1) as usize]) == (3)) {
                 p = (&mut x as *mut i32);
                 (*p) += 1;
                 if ((x) == (3)) {

--- a/tests/unit/out/unsafe/reinterpret_cast_double.rs
+++ b/tests/unit/out/unsafe/reinterpret_cast_double.rs
@@ -16,6 +16,6 @@ unsafe fn main_0() -> i32 {
     let mut bits: *mut u64 = ((&mut d as *mut f64) as *mut u64);
     assert!(((*bits) == (4607182418800017408_u64)));
     (*bits) = 4614256656552045848_u64;
-    assert!((((d) > (3.14E+0)) && ((d) < (3.15E+0))));
+    assert!(((d) > (3.14E+0)) && ((d) < (3.15E+0)));
     return 0;
 }

--- a/tests/unit/out/unsafe/string.rs
+++ b/tests/unit/out/unsafe/string.rs
@@ -45,8 +45,8 @@ unsafe fn main_0() -> i32 {
     let mut i: u32 = 0_u32;
     'loop_: while ((i as u64) < ((s2.len() - 1) as u64)) {
         assert!(
-            ((((*p2.offset((i) as isize)) as i32) == (('a' as u8) as i32))
-                && ((s2[(i as u64) as usize] as i32) == (('a' as u8) as i32)))
+            (((*p2.offset((i) as isize)) as i32) == (('a' as u8) as i32))
+                && ((s2[(i as u64) as usize] as i32) == (('a' as u8) as i32))
         );
         i.prefix_inc();
     }
@@ -59,8 +59,8 @@ unsafe fn main_0() -> i32 {
     let mut i: u32 = 2_u32;
     'loop_: while ((i as u64) < ((s2.len() - 1) as u64)) {
         assert!(
-            ((((*p2.offset((i) as isize)) as i32) == (('a' as u8) as i32))
-                && ((s2[(i as u64) as usize] as i32) == (('a' as u8) as i32)))
+            (((*p2.offset((i) as isize)) as i32) == (('a' as u8) as i32))
+                && ((s2[(i as u64) as usize] as i32) == (('a' as u8) as i32))
         );
         i.prefix_inc();
     }

--- a/tests/unit/out/unsafe/string_literals_concat_c.rs
+++ b/tests/unit/out/unsafe/string_literals_concat_c.rs
@@ -13,15 +13,15 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut arr: [u8; 7] = *b"foobar\0";
-    assert!(((arr[(0) as usize] as i32) == ('f' as i32)));
-    assert!(((arr[(3) as usize] as i32) == ('b' as i32)));
-    assert!(((arr[(5) as usize] as i32) == ('r' as i32)));
-    assert!(((arr[(6) as usize] as i32) == ('\0' as i32)));
+    assert!(((((arr[(0) as usize] as i32) == ('f' as i32)) as i32) != 0));
+    assert!(((((arr[(3) as usize] as i32) == ('b' as i32)) as i32) != 0));
+    assert!(((((arr[(5) as usize] as i32) == ('r' as i32)) as i32) != 0));
+    assert!(((((arr[(6) as usize] as i32) == ('\0' as i32)) as i32) != 0));
     let mut split_pieces: *const u8 = b"abcdefghi\0".as_ptr().cast_mut().cast_const();
-    assert!((((*split_pieces.offset((0) as isize)) as i32) == ('a' as i32)));
-    assert!((((*split_pieces.offset((3) as isize)) as i32) == ('d' as i32)));
-    assert!((((*split_pieces.offset((6) as isize)) as i32) == ('g' as i32)));
-    assert!((((*split_pieces.offset((8) as isize)) as i32) == ('i' as i32)));
-    assert!((((*split_pieces.offset((9) as isize)) as i32) == ('\0' as i32)));
+    assert!((((((*split_pieces.offset((0) as isize)) as i32) == ('a' as i32)) as i32) != 0));
+    assert!((((((*split_pieces.offset((3) as isize)) as i32) == ('d' as i32)) as i32) != 0));
+    assert!((((((*split_pieces.offset((6) as isize)) as i32) == ('g' as i32)) as i32) != 0));
+    assert!((((((*split_pieces.offset((8) as isize)) as i32) == ('i' as i32)) as i32) != 0));
+    assert!((((((*split_pieces.offset((9) as isize)) as i32) == ('\0' as i32)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/string_literals_return_c.rs
+++ b/tests/unit/out/unsafe/string_literals_return_c.rs
@@ -13,7 +13,7 @@ pub unsafe fn get_empty_1() -> *const u8 {
     return b"\0".as_ptr().cast_mut().cast_const();
 }
 pub unsafe fn get_branch_2(mut x: i32) -> *const u8 {
-    if ((x) > (0)) {
+    if ((((x) > (0)) as i32) != 0) {
         return b"positive\0".as_ptr().cast_mut().cast_const();
     }
     return b"non-positive\0".as_ptr().cast_mut().cast_const();
@@ -25,24 +25,24 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut a: *const u8 = (unsafe { get_greeting_0() });
-    assert!((((*a.offset((0) as isize)) as i32) == ('h' as i32)));
-    assert!((((*a.offset((4) as isize)) as i32) == ('o' as i32)));
-    assert!((((*a.offset((5) as isize)) as i32) == ('\0' as i32)));
+    assert!((((((*a.offset((0) as isize)) as i32) == ('h' as i32)) as i32) != 0));
+    assert!((((((*a.offset((4) as isize)) as i32) == ('o' as i32)) as i32) != 0));
+    assert!((((((*a.offset((5) as isize)) as i32) == ('\0' as i32)) as i32) != 0));
     let mut b: *const u8 = (unsafe { get_empty_1() });
-    assert!((((*b.offset((0) as isize)) as i32) == ('\0' as i32)));
+    assert!((((((*b.offset((0) as isize)) as i32) == ('\0' as i32)) as i32) != 0));
     let mut c: *const u8 = (unsafe {
         let _x: i32 = 1;
         get_branch_2(_x)
     });
-    assert!((((*c.offset((0) as isize)) as i32) == ('p' as i32)));
-    assert!((((*c.offset((7) as isize)) as i32) == ('e' as i32)));
-    assert!((((*c.offset((8) as isize)) as i32) == ('\0' as i32)));
+    assert!((((((*c.offset((0) as isize)) as i32) == ('p' as i32)) as i32) != 0));
+    assert!((((((*c.offset((7) as isize)) as i32) == ('e' as i32)) as i32) != 0));
+    assert!((((((*c.offset((8) as isize)) as i32) == ('\0' as i32)) as i32) != 0));
     let mut d: *const u8 = (unsafe {
         let _x: i32 = -1_i32;
         get_branch_2(_x)
     });
-    assert!((((*d.offset((0) as isize)) as i32) == ('n' as i32)));
-    assert!((((*d.offset((11) as isize)) as i32) == ('e' as i32)));
-    assert!((((*d.offset((12) as isize)) as i32) == ('\0' as i32)));
+    assert!((((((*d.offset((0) as isize)) as i32) == ('n' as i32)) as i32) != 0));
+    assert!((((((*d.offset((11) as isize)) as i32) == ('e' as i32)) as i32) != 0));
+    assert!((((((*d.offset((12) as isize)) as i32) == ('\0' as i32)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/string_literals_sized_c.rs
+++ b/tests/unit/out/unsafe/string_literals_sized_c.rs
@@ -13,25 +13,33 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut empty_buf: [u8; 256] = [0u8; 256];
-    assert!(((empty_buf[(0) as usize] as i32) == ('\0' as i32)));
-    assert!(((empty_buf[(255) as usize] as i32) == ('\0' as i32)));
+    assert!(((((empty_buf[(0) as usize] as i32) == ('\0' as i32)) as i32) != 0));
+    assert!(((((empty_buf[(255) as usize] as i32) == ('\0' as i32)) as i32) != 0));
     let mut prefix_buf: [u8; 32] =
         *b"%\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
-    assert!(((prefix_buf[(0) as usize] as i32) == ('%' as i32)));
-    assert!(((prefix_buf[(1) as usize] as i32) == ('\0' as i32)));
-    assert!(((prefix_buf[(31) as usize] as i32) == ('\0' as i32)));
+    assert!(((((prefix_buf[(0) as usize] as i32) == ('%' as i32)) as i32) != 0));
+    assert!(((((prefix_buf[(1) as usize] as i32) == ('\0' as i32)) as i32) != 0));
+    assert!(((((prefix_buf[(31) as usize] as i32) == ('\0' as i32)) as i32) != 0));
     let mut short_buf: [u8; 16] = *b"hi\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
-    assert!(((short_buf[(0) as usize] as i32) == ('h' as i32)));
-    assert!(((short_buf[(1) as usize] as i32) == ('i' as i32)));
-    assert!(((short_buf[(2) as usize] as i32) == ('\0' as i32)));
-    assert!(((short_buf[(15) as usize] as i32) == ('\0' as i32)));
+    assert!(((((short_buf[(0) as usize] as i32) == ('h' as i32)) as i32) != 0));
+    assert!(((((short_buf[(1) as usize] as i32) == ('i' as i32)) as i32) != 0));
+    assert!(((((short_buf[(2) as usize] as i32) == ('\0' as i32)) as i32) != 0));
+    assert!(((((short_buf[(15) as usize] as i32) == ('\0' as i32)) as i32) != 0));
     let mut exact_buf: [u8; 6] = *b"hello\0";
-    assert!(((exact_buf[(0) as usize] as i32) == ('h' as i32)));
-    assert!(((exact_buf[(4) as usize] as i32) == ('o' as i32)));
-    assert!(((exact_buf[(5) as usize] as i32) == ('\0' as i32)));
-    assert!(((::std::mem::size_of::<[u8; 6]>() as u64) == (6_u64)));
-    assert!((((::std::mem::size_of::<[u8; 6]>() as u64 as u64).wrapping_sub(1_u64)) == (5_u64)));
-    assert!(((::std::mem::size_of::<[u8; 1]>() as u64) == (1_u64)));
-    assert!((((::std::mem::size_of::<[u8; 16]>() as u64 as u64).wrapping_sub(1_u64)) == (15_u64)));
+    assert!(((((exact_buf[(0) as usize] as i32) == ('h' as i32)) as i32) != 0));
+    assert!(((((exact_buf[(4) as usize] as i32) == ('o' as i32)) as i32) != 0));
+    assert!(((((exact_buf[(5) as usize] as i32) == ('\0' as i32)) as i32) != 0));
+    assert!(((((::std::mem::size_of::<[u8; 6]>() as u64) == (6_u64)) as i32) != 0));
+    assert!(
+        (((((::std::mem::size_of::<[u8; 6]>() as u64 as u64).wrapping_sub(1_u64)) == (5_u64))
+            as i32)
+            != 0)
+    );
+    assert!(((((::std::mem::size_of::<[u8; 1]>() as u64) == (1_u64)) as i32) != 0));
+    assert!(
+        (((((::std::mem::size_of::<[u8; 16]>() as u64 as u64).wrapping_sub(1_u64)) == (15_u64))
+            as i32)
+            != 0)
+    );
     return 0;
 }

--- a/tests/unit/out/unsafe/union_addrof_external.rs
+++ b/tests/unit/out/unsafe/union_addrof_external.rs
@@ -53,7 +53,7 @@ pub unsafe fn fill_0(mut out: *mut ::libc::c_void, mut cap: u64) {
     src[(5) as usize] = 0_u8;
     src[(6) as usize] = 0_u8;
     src[(7) as usize] = 1_u8;
-    let mut n: u64 = if ((::std::mem::size_of::<[u8; 16]>() as u64) < (cap)) {
+    let mut n: u64 = if ((((::std::mem::size_of::<[u8; 16]>() as u64) < (cap)) as i32) != 0) {
         ::std::mem::size_of::<[u8; 16]>() as u64
     } else {
         cap
@@ -90,10 +90,18 @@ unsafe fn main_0() -> i32 {
         let _cap: u64 = ::std::mem::size_of::<Container_anon_0>() as u64;
         fill_0(_out, _cap)
     });
-    assert!(((c.view.h.code as i32) == (2)));
-    assert!((((*((&mut c.view.h.lo as *mut u16) as *mut u8).offset((0) as isize)) as i32) == (0)));
-    assert!((((*((&mut c.view.h.lo as *mut u16) as *mut u8).offset((1) as isize)) as i32) == (80)));
-    assert!(((c.view.raw_[(0) as usize] as i32) == (2)));
-    assert!((((c.view.raw_[(3) as usize] as u8) as i32) == (80)));
+    assert!(((((c.view.h.code as i32) == (2)) as i32) != 0));
+    assert!(
+        (((((*((&mut c.view.h.lo as *mut u16) as *mut u8).offset((0) as isize)) as i32) == (0))
+            as i32)
+            != 0)
+    );
+    assert!(
+        (((((*((&mut c.view.h.lo as *mut u16) as *mut u8).offset((1) as isize)) as i32) == (80))
+            as i32)
+            != 0)
+    );
+    assert!(((((c.view.raw_[(0) as usize] as i32) == (2)) as i32) != 0));
+    assert!((((((c.view.raw_[(3) as usize] as u8) as i32) == (80)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/union_basic.rs
+++ b/tests/unit/out/unsafe/union_basic.rs
@@ -25,8 +25,8 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut u: basic = <basic>::default();
     u.i = 42;
-    assert!(((u.i) == (42)));
+    assert!(((((u.i) == (42)) as i32) != 0));
     u.f = 3.140000105E+0;
-    assert!(((u.f) == (3.140000105E+0)));
+    assert!(((((u.f) == (3.140000105E+0)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/union_cross_arm_cast.rs
+++ b/tests/unit/out/unsafe/union_cross_arm_cast.rs
@@ -77,14 +77,18 @@ unsafe fn main_0() -> i32 {
     c.len = (::std::mem::size_of::<shape_b>() as u64 as u32);
     (*(((&mut c.u.a as *mut shape_a) as *mut ::libc::c_void) as *mut shape_b)).tail =
         3735928559_u32;
-    assert!(((c.u.b.tail) == (3735928559_u32)));
-    assert!(((c.u.b.code as i32) == (10)));
+    assert!(((((c.u.b.tail) == (3735928559_u32)) as i32) != 0));
+    assert!(((((c.u.b.code as i32) == (10)) as i32) != 0));
     c.u.b.lo = 8080_u16;
     assert!(
-        (((*((&mut c.u.raw_ as *mut [u8; 64]) as *mut u8).offset((2) as isize)) as i32) == (144))
+        (((((*((&mut c.u.raw_ as *mut [u8; 64]) as *mut u8).offset((2) as isize)) as i32) == (144))
+            as i32)
+            != 0)
     );
     assert!(
-        (((*((&mut c.u.raw_ as *mut [u8; 64]) as *mut u8).offset((3) as isize)) as i32) == (31))
+        (((((*((&mut c.u.raw_ as *mut [u8; 64]) as *mut u8).offset((3) as isize)) as i32) == (31))
+            as i32)
+            != 0)
     );
     return 0;
 }

--- a/tests/unit/out/unsafe/union_field_alignment.rs
+++ b/tests/unit/out/unsafe/union_field_alignment.rs
@@ -32,6 +32,6 @@ unsafe fn main_0() -> i32 {
     let mut n: node = <node>::default();
     n.next = Default::default();
     n.x.bytes[(0) as usize] = 171_u8;
-    assert!(((n.x.bytes[(0) as usize] as i32) == (171)));
+    assert!(((((n.x.bytes[(0) as usize] as i32) == (171)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/union_memset_memcpy.rs
+++ b/tests/unit/out/unsafe/union_memset_memcpy.rs
@@ -70,10 +70,10 @@ unsafe fn main_0() -> i32 {
         }
         ((&mut c as *mut Container) as *mut Container as *mut ::libc::c_void)
     };
-    assert!(((c.view.a.code as i32) == (0)));
-    assert!(((c.view.b.lo as i32) == (0)));
-    assert!(((c.view.raw_[(0) as usize] as i32) == (0)));
-    assert!(((c.view.raw_[(255) as usize] as i32) == (0)));
+    assert!(((((c.view.a.code as i32) == (0)) as i32) != 0));
+    assert!(((((c.view.b.lo as i32) == (0)) as i32) != 0));
+    assert!(((((c.view.raw_[(0) as usize] as i32) == (0)) as i32) != 0));
+    assert!(((((c.view.raw_[(255) as usize] as i32) == (0)) as i32) != 0));
     let mut src: [u8; 16] = [
         0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8,
         0_u8,
@@ -86,7 +86,7 @@ unsafe fn main_0() -> i32 {
     src[(6) as usize] = 0_u8;
     src[(7) as usize] = 1_u8;
     let mut len: u64 = 16_u64;
-    assert!(((len) <= (::std::mem::size_of::<[u8; 256]>() as u64)));
+    assert!(((((len) <= (::std::mem::size_of::<[u8; 256]>() as u64)) as i32) != 0));
     {
         if len != 0 {
             ::std::ptr::copy_nonoverlapping(
@@ -97,8 +97,12 @@ unsafe fn main_0() -> i32 {
         }
         ((&mut c.view.raw_ as *mut [u8; 256]) as *mut [u8; 256] as *mut ::libc::c_void)
     };
-    assert!(((c.view.b.code as i32) == (2)));
-    assert!((((*((&mut c.view.b.lo as *mut u16) as *mut u8).offset((0) as isize)) as i32) == (80)));
+    assert!(((((c.view.b.code as i32) == (2)) as i32) != 0));
+    assert!(
+        (((((*((&mut c.view.b.lo as *mut u16) as *mut u8).offset((0) as isize)) as i32) == (80))
+            as i32)
+            != 0)
+    );
     {
         let byte_0 =
             ((&mut c as *mut Container) as *mut Container as *mut ::libc::c_void) as *mut u8;
@@ -107,6 +111,6 @@ unsafe fn main_0() -> i32 {
         }
         ((&mut c as *mut Container) as *mut Container as *mut ::libc::c_void)
     };
-    assert!(((c.view.b.code as i32) == (0)));
+    assert!(((((c.view.b.code as i32) == (0)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/union_nested.rs
+++ b/tests/unit/out/unsafe/union_nested.rs
@@ -76,8 +76,8 @@ unsafe fn main_0() -> i32 {
     ex.len = (::std::mem::size_of::<record>() as u64 as u32);
     ex.body.h.code = 2_u16;
     ex.body.h.pad[(0) as usize] = (('X' as i32) as u8);
-    assert!(((ex.body.h.code as i32) == (2)));
-    assert!(((ex.body.h.pad[(0) as usize] as i32) == ('X' as i32)));
-    assert!(((ex.body.nested.view.h.code as i32) == (2)));
+    assert!(((((ex.body.h.code as i32) == (2)) as i32) != 0));
+    assert!(((((ex.body.h.pad[(0) as usize] as i32) == ('X' as i32)) as i32) != 0));
+    assert!(((((ex.body.nested.view.h.code as i32) == (2)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/union_pointer_pun_address.rs
+++ b/tests/unit/out/unsafe/union_pointer_pun_address.rs
@@ -38,6 +38,10 @@ unsafe fn main_0() -> i32 {
     let mut ptr: anon_0 = <anon_0>::default();
     ptr.to_a = (&mut a as *mut node_a);
     let mut out: *mut node_b = ptr.to_b;
-    assert!(((out as *mut ::libc::c_void) == ((&mut a as *mut node_a) as *mut ::libc::c_void)));
+    assert!(
+        ((((out as *mut ::libc::c_void) == ((&mut a as *mut node_a) as *mut ::libc::c_void))
+            as i32)
+            != 0)
+    );
     return 0;
 }

--- a/tests/unit/out/unsafe/union_pointer_pun_writethrough.rs
+++ b/tests/unit/out/unsafe/union_pointer_pun_writethrough.rs
@@ -27,6 +27,6 @@ unsafe fn main_0() -> i32 {
     let mut pp: anon_0 = <anon_0>::default();
     pp.as_signed = (&mut x as *mut i64);
     (*pp.as_unsigned) = 42_u64;
-    assert!(((x) == (42_i64)));
+    assert!(((((x) == (42_i64)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/union_struct_dual_use.rs
+++ b/tests/unit/out/unsafe/union_struct_dual_use.rs
@@ -41,10 +41,11 @@ unsafe fn main_0() -> i32 {
     standalone.a = 3;
     standalone.b = 4;
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _i: *mut Inner = (&mut standalone as *mut Inner);
             sum_inner_0(_i)
-        }) == (7))
+        }) == (7)) as i32)
+            != 0)
     );
     let mut outer: Outer = <Outer>::default();
     {
@@ -57,12 +58,13 @@ unsafe fn main_0() -> i32 {
     outer.u.inner.a = 3;
     outer.u.inner.b = 4;
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _i: *mut Inner = (&mut outer.u.inner as *mut Inner);
             sum_inner_0(_i)
-        }) == (7))
+        }) == (7)) as i32)
+            != 0)
     );
-    assert!((((outer.u.raw_[(0) as usize] as u8) as i32) == (3)));
-    assert!((((outer.u.raw_[(4) as usize] as u8) as i32) == (4)));
+    assert!((((((outer.u.raw_[(0) as usize] as u8) as i32) == (3)) as i32) != 0));
+    assert!((((((outer.u.raw_[(4) as usize] as u8) as i32) == (4)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/union_tagged_many_arms.rs
+++ b/tests/unit/out/unsafe/union_tagged_many_arms.rs
@@ -56,23 +56,27 @@ unsafe fn main_0() -> i32 {
     let mut a: Slot = <Slot>::default();
     a.tag = Tag::from((Tag::T_NUM_S as i32));
     a.payload.signed_n = (-7_i32 as i64);
-    assert!(((a.payload.signed_n) == (-7_i32 as i64)));
+    assert!(((((a.payload.signed_n) == (-7_i32 as i64)) as i32) != 0));
     let mut b: Slot = <Slot>::default();
     b.tag = Tag::from((Tag::T_NUM_U as i32));
     b.payload.unsigned_n = 3735928559_u64;
-    assert!(((b.payload.unsigned_n) == (3735928559_u64)));
+    assert!(((((b.payload.unsigned_n) == (3735928559_u64)) as i32) != 0));
     let mut c: Slot = <Slot>::default();
     c.tag = Tag::from((Tag::T_TEXT as i32));
     c.payload.text = b"hello\0".as_ptr().cast_mut().cast_const();
-    assert!((((*c.payload.text.offset((0) as isize)) as i32) == ('h' as i32)));
+    assert!((((((*c.payload.text.offset((0) as isize)) as i32) == ('h' as i32)) as i32) != 0));
     let mut d: Slot = <Slot>::default();
     d.tag = Tag::from((Tag::T_FLOAT as i32));
     d.payload.f = 1.5E+0;
-    assert!(((d.payload.f) == (1.5E+0)));
+    assert!(((((d.payload.f) == (1.5E+0)) as i32) != 0));
     let mut x: i32 = 0;
     let mut e: Slot = <Slot>::default();
     e.tag = Tag::from((Tag::T_REF as i32));
     e.payload.handle = ((&mut x as *mut i32) as *mut i32 as *mut ::libc::c_void);
-    assert!(((e.payload.handle) == ((&mut x as *mut i32) as *mut i32 as *mut ::libc::c_void)));
+    assert!(
+        ((((e.payload.handle) == ((&mut x as *mut i32) as *mut i32 as *mut ::libc::c_void))
+            as i32)
+            != 0)
+    );
     return 0;
 }

--- a/tests/unit/out/unsafe/union_tagged_simple.rs
+++ b/tests/unit/out/unsafe/union_tagged_simple.rs
@@ -50,12 +50,16 @@ unsafe fn main_0() -> i32 {
     m1.kind = Kind::from((Kind::KIND_DONE as i32));
     m1.handle = ((&mut dummy as *mut i32) as *mut i32 as *mut ::libc::c_void);
     m1.payload.code = 42;
-    assert!(((m1.kind as u32) == ((Kind::KIND_DONE as i32) as u32)));
-    assert!(((m1.payload.code) == (42)));
+    assert!(((((m1.kind as u32) == ((Kind::KIND_DONE as i32) as u32)) as i32) != 0));
+    assert!(((((m1.payload.code) == (42)) as i32) != 0));
     let mut m2: Event = <Event>::default();
     m2.kind = Kind::from((Kind::KIND_NONE as i32));
     m2.handle = ((&mut dummy as *mut i32) as *mut i32 as *mut ::libc::c_void);
     m2.payload.obj = ((&mut dummy as *mut i32) as *mut i32 as *mut ::libc::c_void);
-    assert!(((m2.payload.obj) == ((&mut dummy as *mut i32) as *mut i32 as *mut ::libc::c_void)));
+    assert!(
+        ((((m2.payload.obj) == ((&mut dummy as *mut i32) as *mut i32 as *mut ::libc::c_void))
+            as i32)
+            != 0)
+    );
     return 0;
 }

--- a/tests/unit/out/unsafe/union_tagged_struct_arms.rs
+++ b/tests/unit/out/unsafe/union_tagged_struct_arms.rs
@@ -83,10 +83,11 @@ unsafe fn main_0() -> i32 {
     p_list.v.list.items = items.as_mut_ptr();
     p_list.v.list.count = 3_i64;
     p_list.v.list.cursor = 1_i64;
-    assert!(((p_list.v.list.count) == (3_i64)));
+    assert!(((((p_list.v.list.count) == (3_i64)) as i32) != 0));
     assert!(
-        (((*(*p_list.v.list.items.offset((1) as isize)).offset((0) as isize)) as i32)
-            == ('b' as i32))
+        (((((*(*p_list.v.list.items.offset((1) as isize)).offset((0) as isize)) as i32)
+            == ('b' as i32)) as i32)
+            != 0)
     );
     let mut p_letters: Branch = <Branch>::default();
     p_letters.choice = Choice::from((Choice::C_LETTERS as i32));
@@ -95,7 +96,7 @@ unsafe fn main_0() -> i32 {
     p_letters.v.letters.hi = ('z' as i32);
     p_letters.v.letters.curr = ('m' as i32);
     p_letters.v.letters.step = 1_u8;
-    assert!((((p_letters.v.letters.hi) - (p_letters.v.letters.lo)) == (25)));
+    assert!((((((p_letters.v.letters.hi) - (p_letters.v.letters.lo)) == (25)) as i32) != 0));
     let mut p_integers: Branch = <Branch>::default();
     p_integers.choice = Choice::from((Choice::C_INTEGERS as i32));
     p_integers.index = 2;
@@ -104,7 +105,7 @@ unsafe fn main_0() -> i32 {
     p_integers.v.integers.curr = 1_i64;
     p_integers.v.integers.step = 1_i64;
     p_integers.v.integers.width = 3;
-    assert!(((p_integers.v.integers.hi) == (100_i64)));
-    assert!(((p_integers.v.integers.width) == (3)));
+    assert!(((((p_integers.v.integers.hi) == (100_i64)) as i32) != 0));
+    assert!(((((p_integers.v.integers.width) == (3)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/union_void_ptr_sized_deref.rs
+++ b/tests/unit/out/unsafe/union_void_ptr_sized_deref.rs
@@ -79,7 +79,7 @@ unsafe fn main_0() -> i32 {
         let _count: i64 = 1234605616436508552_i64;
         write_count_0(_s, _count)
     });
-    assert!(((buf64) == (1234605616436508552_i64)));
+    assert!(((((buf64) == (1234605616436508552_i64)) as i32) != 0));
     s.width = Width::from((Width::W_32 as i32));
     s.out.handle = ((&mut buf32 as *mut i32) as *mut i32 as *mut ::libc::c_void);
     (unsafe {
@@ -87,7 +87,7 @@ unsafe fn main_0() -> i32 {
         let _count: i64 = 305419896_i64;
         write_count_0(_s, _count)
     });
-    assert!(((buf32) == (305419896)));
+    assert!(((((buf32) == (305419896)) as i32) != 0));
     s.width = Width::from((Width::W_16 as i32));
     s.out.handle = ((&mut buf16 as *mut i16) as *mut i16 as *mut ::libc::c_void);
     (unsafe {
@@ -95,6 +95,6 @@ unsafe fn main_0() -> i32 {
         let _count: i64 = 4660_i64;
         write_count_0(_s, _count)
     });
-    assert!(((buf16 as i32) == (4660)));
+    assert!(((((buf16 as i32) == (4660)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/va_arg_chain.rs
+++ b/tests/unit/out/unsafe/va_arg_chain.rs
@@ -8,7 +8,7 @@ use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn extract_nth_0(mut n: i32, mut ap: VaList) -> i32 {
     let mut i: i32 = 0;
-    'loop_: while ((i) < (n)) {
+    'loop_: while ((((i) < (n)) as i32) != 0) {
         ap.arg::<i32>();
         i.postfix_inc();
     }
@@ -38,22 +38,25 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _n: i32 = 2;
             top_level_2(_n, &[100.into(), 200.into(), 300.into(), 400.into()])
-        }) == (300))
+        }) == (300)) as i32)
+            != 0)
     );
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _n: i32 = 0;
             top_level_2(_n, &[42.into(), 99.into()])
-        }) == (42))
+        }) == (42)) as i32)
+            != 0)
     );
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _n: i32 = 3;
             top_level_2(_n, &[1.into(), 2.into(), 3.into(), 4.into()])
-        }) == (4))
+        }) == (4)) as i32)
+            != 0)
     );
     return 0;
 }

--- a/tests/unit/out/unsafe/va_arg_concat.rs
+++ b/tests/unit/out/unsafe/va_arg_concat.rs
@@ -11,10 +11,11 @@ pub unsafe fn sum_ints_0(mut first: i32, args: &[VaArg]) -> i32 {
     let mut total: i32 = first;
     ap = VaList::new(args);
     let mut val: i32 = 0_i32;
-    'loop_: while (({
+    'loop_: while (((({
         val = ap.arg::<i32>();
         val
-    }) != (0))
+    }) != (0)) as i32)
+        != 0)
     {
         total += val;
     }
@@ -27,22 +28,25 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _first: i32 = 1;
             sum_ints_0(_first, &[2.into(), 3.into(), 4.into(), 0.into()])
-        }) == (10))
+        }) == (10)) as i32)
+            != 0)
     );
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _first: i32 = 100;
             sum_ints_0(_first, &[0.into()])
-        }) == (100))
+        }) == (100)) as i32)
+            != 0)
     );
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _first: i32 = 5;
             sum_ints_0(_first, &[5.into(), 5.into(), 5.into(), 5.into(), 0.into()])
-        }) == (25))
+        }) == (25)) as i32)
+            != 0)
     );
     return 0;
 }

--- a/tests/unit/out/unsafe/va_arg_conditional.rs
+++ b/tests/unit/out/unsafe/va_arg_conditional.rs
@@ -22,18 +22,20 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _verbose: i32 = 1;
             let _fmt: *const u8 = b"%d\0".as_ptr().cast_mut().cast_const();
             conditional_log_0(_verbose, _fmt, &[42.into()])
-        }) == (42))
+        }) == (42)) as i32)
+            != 0)
     );
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _verbose: i32 = 0;
             let _fmt: *const u8 = b"%d\0".as_ptr().cast_mut().cast_const();
             conditional_log_0(_verbose, _fmt, &[99.into()])
-        }) == (-1_i32))
+        }) == (-1_i32)) as i32)
+            != 0)
     );
     return 0;
 }

--- a/tests/unit/out/unsafe/va_arg_copy.rs
+++ b/tests/unit/out/unsafe/va_arg_copy.rs
@@ -13,17 +13,17 @@ pub unsafe fn sum_with_copy_0(mut count: i32, args: &[VaArg]) -> i32 {
     aq = ap.clone();
     let mut sum1: i32 = 0;
     let mut i: i32 = 0;
-    'loop_: while ((i) < (count)) {
+    'loop_: while ((((i) < (count)) as i32) != 0) {
         sum1 += ap.arg::<i32>();
         i.postfix_inc();
     }
     let mut sum2: i32 = 0;
     let mut i: i32 = 0;
-    'loop_: while ((i) < (count)) {
+    'loop_: while ((((i) < (count)) as i32) != 0) {
         sum2 += aq.arg::<i32>();
         i.postfix_inc();
     }
-    assert!(((sum1) == (sum2)));
+    assert!(((((sum1) == (sum2)) as i32) != 0));
     return ((sum1) + (sum2));
 }
 pub fn main() {
@@ -33,10 +33,11 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _count: i32 = 3;
             sum_with_copy_0(_count, &[10.into(), 20.into(), 30.into()])
-        }) == (120))
+        }) == (120)) as i32)
+            != 0)
     );
     return 0;
 }

--- a/tests/unit/out/unsafe/va_arg_forward.rs
+++ b/tests/unit/out/unsafe/va_arg_forward.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 pub unsafe fn inner_0(mut count: i32, mut ap: VaList) -> i32 {
     let mut total: i32 = 0;
     let mut i: i32 = 0;
-    'loop_: while ((i) < (count)) {
+    'loop_: while ((((i) < (count)) as i32) != 0) {
         total += ap.arg::<i32>();
         i.postfix_inc();
     }
@@ -32,22 +32,25 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _count: i32 = 3;
             outer_1(_count, &[10.into(), 20.into(), 30.into()])
-        }) == (60))
+        }) == (60)) as i32)
+            != 0)
     );
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _count: i32 = 1;
             outer_1(_count, &[42.into()])
-        }) == (42))
+        }) == (42)) as i32)
+            != 0)
     );
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _count: i32 = 0;
             outer_1(_count, &[])
-        }) == (0))
+        }) == (0)) as i32)
+            != 0)
     );
     return 0;
 }

--- a/tests/unit/out/unsafe/va_arg_mixed_int_ptr.rs
+++ b/tests/unit/out/unsafe/va_arg_mixed_int_ptr.rs
@@ -11,9 +11,9 @@ pub unsafe fn mixed_args_0(mut count: i32, args: &[VaArg]) -> i32 {
     ap = VaList::new(args);
     let mut total: i32 = 0;
     let mut i: i32 = 0;
-    'loop_: while ((i) < (count)) {
+    'loop_: while ((((i) < (count)) as i32) != 0) {
         let mut tag: i32 = ap.arg::<i32>();
-        if ((tag) == (0)) {
+        if ((((tag) == (0)) as i32) != 0) {
             total += ap.arg::<i32>();
         } else {
             let mut ptr: *mut i32 = ap.arg::<*mut i32>();
@@ -31,7 +31,7 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut x: i32 = 100;
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _count: i32 = 3;
             mixed_args_0(
                 _count,
@@ -44,20 +44,23 @@ unsafe fn main_0() -> i32 {
                     20.into(),
                 ],
             )
-        }) == (130))
+        }) == (130)) as i32)
+            != 0)
     );
     let mut y: i32 = 50;
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _count: i32 = 1;
             mixed_args_0(_count, &[1.into(), (&mut y as *mut i32).into()])
-        }) == (50))
+        }) == (50)) as i32)
+            != 0)
     );
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _count: i32 = 2;
             mixed_args_0(_count, &[0.into(), 5.into(), 0.into(), 3.into()])
-        }) == (8))
+        }) == (8)) as i32)
+            != 0)
     );
     return 0;
 }

--- a/tests/unit/out/unsafe/va_arg_mixed_types.rs
+++ b/tests/unit/out/unsafe/va_arg_mixed_types.rs
@@ -11,11 +11,11 @@ pub unsafe fn sum_mixed_0(mut count: i32, args: &[VaArg]) -> i32 {
     ap = VaList::new(args);
     let mut total: i32 = 0;
     let mut i: i32 = 0;
-    'loop_: while ((i) < (count)) {
+    'loop_: while ((((i) < (count)) as i32) != 0) {
         let mut tag: i32 = ap.arg::<i32>();
-        if ((tag) == (0)) {
+        if ((((tag) == (0)) as i32) != 0) {
             total += ap.arg::<i32>();
-        } else if ((tag) == (1)) {
+        } else if ((((tag) == (1)) as i32) != 0) {
             total += (ap.arg::<f64>() as i32);
         } else {
             let mut val: i64 = ap.arg::<i64>();
@@ -32,7 +32,7 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _count: i32 = 3;
             sum_mixed_0(
                 _count,
@@ -45,19 +45,22 @@ unsafe fn main_0() -> i32 {
                     30_i64.into(),
                 ],
             )
-        }) == (60))
+        }) == (60)) as i32)
+            != 0)
     );
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _count: i32 = 1;
             sum_mixed_0(_count, &[0.into(), 42.into()])
-        }) == (42))
+        }) == (42)) as i32)
+            != 0)
     );
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _count: i32 = 2;
             sum_mixed_0(_count, &[1.into(), 3.7E+0.into(), 2.into(), 100_i64.into()])
-        }) == (103))
+        }) == (103)) as i32)
+            != 0)
     );
     return 0;
 }

--- a/tests/unit/out/unsafe/va_arg_printf.rs
+++ b/tests/unit/out/unsafe/va_arg_printf.rs
@@ -27,16 +27,18 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _fmt: *const u8 = b"hello %d %d\0".as_ptr().cast_mut().cast_const();
             logf_1(_fmt, &[10.into(), 32.into()])
-        }) == (42))
+        }) == (42)) as i32)
+            != 0)
     );
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _fmt: *const u8 = b"x %d %d\0".as_ptr().cast_mut().cast_const();
             logf_1(_fmt, &[1.into(), 2.into()])
-        }) == (3))
+        }) == (3)) as i32)
+            != 0)
     );
     return 0;
 }

--- a/tests/unit/out/unsafe/va_arg_promotion.rs
+++ b/tests/unit/out/unsafe/va_arg_promotion.rs
@@ -12,9 +12,9 @@ pub unsafe fn test_promotions_0(mut count: i32, args: &[VaArg]) -> i32 {
     let mut a: i32 = ap.arg::<i32>();
     let mut b: i32 = ap.arg::<i32>();
     let mut c: f64 = ap.arg::<f64>();
-    assert!(((a) == (65)));
-    assert!(((b) == (10)));
-    assert!(((c) == (3.0E+0)));
+    assert!(((((a) == (65)) as i32) != 0));
+    assert!(((((b) == (10)) as i32) != 0));
+    assert!(((((c) == (3.0E+0)) as i32) != 0));
     return (((a) + (b)) + (c as i32));
 }
 pub fn main() {
@@ -27,13 +27,14 @@ unsafe fn main_0() -> i32 {
     let mut y: i16 = 10_i16;
     let mut z: f32 = 3.0E+0;
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _count: i32 = 3;
             test_promotions_0(
                 _count,
                 &[(x as i32).into(), (y as i32).into(), (z as f64).into()],
             )
-        }) == (78))
+        }) == (78)) as i32)
+            != 0)
     );
     return 0;
 }

--- a/tests/unit/out/unsafe/va_arg_snprintf.rs
+++ b/tests/unit/out/unsafe/va_arg_snprintf.rs
@@ -26,22 +26,24 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut buf: [u8; 64] = [0_u8; 64];
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _buf: *mut u8 = buf.as_mut_ptr();
             let _size: i32 = 1;
             let _fmt: *const u8 = b"%d\0".as_ptr().cast_mut().cast_const();
             extract_first_0(_buf, _size, _fmt, &[42.into()])
-        }) == (42))
+        }) == (42)) as i32)
+            != 0)
     );
-    assert!(((buf[(0) as usize] as i32) == (42)));
+    assert!(((((buf[(0) as usize] as i32) == (42)) as i32) != 0));
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _buf: *mut u8 = buf.as_mut_ptr();
             let _size: i32 = 1;
             let _fmt: *const u8 = b"%d\0".as_ptr().cast_mut().cast_const();
             extract_first_0(_buf, _size, _fmt, &[65.into()])
-        }) == (65))
+        }) == (65)) as i32)
+            != 0)
     );
-    assert!(((buf[(0) as usize] as i32) == ('A' as i32)));
+    assert!(((((buf[(0) as usize] as i32) == ('A' as i32)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/va_arg_struct_ctx.rs
+++ b/tests/unit/out/unsafe/va_arg_struct_ctx.rs
@@ -33,13 +33,13 @@ unsafe fn main_0() -> i32 {
         let _fmt: *const u8 = b"error %d\0".as_ptr().cast_mut().cast_const();
         set_error_0(_ctx, _fmt, &[42.into()])
     });
-    assert!(((ctx.last_error) == (42)));
+    assert!(((((ctx.last_error) == (42)) as i32) != 0));
     ctx.verbose = 0;
     (unsafe {
         let _ctx: *mut context = (&mut ctx as *mut context);
         let _fmt: *const u8 = b"error %d\0".as_ptr().cast_mut().cast_const();
         set_error_0(_ctx, _fmt, &[99.into()])
     });
-    assert!(((ctx.last_error) == (42)));
+    assert!(((((ctx.last_error) == (42)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/va_arg_two_passes.rs
+++ b/tests/unit/out/unsafe/va_arg_two_passes.rs
@@ -12,18 +12,20 @@ pub unsafe fn sum_then_product_0(mut first: i32, args: &[VaArg]) -> i32 {
     let mut product: i32 = first;
     ap = VaList::new(args);
     let mut val: i32 = 0_i32;
-    'loop_: while (({
+    'loop_: while (((({
         val = ap.arg::<i32>();
         val
-    }) != (0))
+    }) != (0)) as i32)
+        != 0)
     {
         sum += val;
     }
     ap = VaList::new(args);
-    'loop_: while (({
+    'loop_: while (((({
         val = ap.arg::<i32>();
         val
-    }) != (0))
+    }) != (0)) as i32)
+        != 0)
     {
         product *= val;
     }
@@ -36,10 +38,11 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     assert!(
-        ((unsafe {
+        ((((unsafe {
             let _first: i32 = 2;
             sum_then_product_0(_first, &[3.into(), 4.into(), 0.into()])
-        }) == (33))
+        }) == (33)) as i32)
+            != 0)
     );
     return 0;
 }

--- a/tests/unit/out/unsafe/vector.rs
+++ b/tests/unit/out/unsafe/vector.rs
@@ -96,7 +96,7 @@ unsafe fn main_0() -> i32 {
     assert!(((v7.len() as u64) == (200_u64)));
     let mut i: u32 = 0_u32;
     'loop_: while ((i) < (200_u32)) {
-        assert!((((v7[(i as u64) as usize].0).is_null()) && ((v7[(i as u64) as usize].1) == (0))));
+        assert!(((v7[(i as u64) as usize].0).is_null()) && ((v7[(i as u64) as usize].1) == (0)));
         i.prefix_inc();
     }
     let mut p1: *const f64 = v6.as_mut_ptr().cast_const();


### PR DESCRIPTION
In C, comparison and logical binary operations always produce an int where a bool is expected.

For this reason, wrap binary operators in `(... as i32)` if the type of BinaryOperator is int. ConvertIntegralToBooleanCast will later take care to convert the integer back to boolean.