### PR TITLE
Translate default pointers in globals

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -1849,7 +1849,9 @@ bool Converter::VisitImplicitCastExpr(clang::ImplicitCastExpr *expr) {
     if (type->isFunctionPointerType()) {
       StrCat("None");
     } else {
-      StrCat(keyword_default_);
+      StrCat(type->getPointeeType().isConstQualified()
+                 ? "std::ptr::null()"
+                 : "std::ptr::null_mut()");
     }
     computed_expr_type_ = ComputedExprType::FreshPointer;
     break;
@@ -2953,12 +2955,13 @@ std::string Converter::GetDefaultAsString(clang::QualType qual_type) {
   }
 
   if (qual_type->isPointerType()) {
-    if (qual_type->getPointeeType()->isFunctionType()) {
+    auto pointee = qual_type->getPointeeType();
+    if (pointee->isFunctionType()) {
       return "None";
-    } else {
-      computed_expr_type_ = ComputedExprType::FreshPointer;
-      return keyword_default_;
     }
+    computed_expr_type_ = ComputedExprType::FreshPointer;
+    return pointee.isConstQualified() ? "std::ptr::null()"
+                                      : "std::ptr::null_mut()";
   }
 
   computed_expr_type_ = ComputedExprType::FreshValue;

--- a/tests/benchmarks/out/unsafe/bfs.rs
+++ b/tests/benchmarks/out/unsafe/bfs.rs
@@ -134,14 +134,14 @@ unsafe fn main_0() -> i32 {
         V: (V as u32),
         adj: Box::leak(
             (0..V)
-                .map(|_| Default::default())
+                .map(|_| std::ptr::null_mut())
                 .collect::<Box<[*mut GraphNode]>>(),
         )
         .as_mut_ptr(),
     };
     let mut i: u32 = 0_u32;
     'loop_: while ((i as u64) < (V)) {
-        (*graph.adj.offset((i) as isize)) = Default::default();
+        (*graph.adj.offset((i) as isize)) = std::ptr::null_mut();
         i.prefix_inc();
     }
     let mut i: u32 = 0_u32;

--- a/tests/benchmarks/out/unsafe/bst.rs
+++ b/tests/benchmarks/out/unsafe/bst.rs
@@ -29,7 +29,7 @@ pub unsafe fn find_0(mut node: *mut node_t, mut value: i32) -> *mut node_t {
     } else if ((value) == ((*node).value)) {
         return node;
     }
-    return Default::default();
+    return std::ptr::null_mut();
 }
 pub unsafe fn insert_1(mut node: *mut node_t, mut new_node: *mut node_t) -> *mut node_t {
     if (node).is_null() {
@@ -58,8 +58,8 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let N: i32 = 25000;
     let mut tree: *mut node_t = (Box::leak(Box::new(node_t {
-        left: Default::default(),
-        right: Default::default(),
+        left: std::ptr::null_mut(),
+        right: std::ptr::null_mut(),
         value: 0,
     })) as *mut node_t);
     let mut i: i32 = 0;
@@ -67,8 +67,8 @@ unsafe fn main_0() -> i32 {
         (unsafe {
             let _node: *mut node_t = tree;
             let _new_node: *mut node_t = (Box::leak(Box::new(node_t {
-                left: Default::default(),
-                right: Default::default(),
+                left: std::ptr::null_mut(),
+                right: std::ptr::null_mut(),
                 value: i,
             })) as *mut node_t);
             insert_1(_node, _new_node)

--- a/tests/ub/out/unsafe/ub2.rs
+++ b/tests/ub/out/unsafe/ub2.rs
@@ -7,7 +7,7 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn null_0() -> *mut i32 {
-    let mut p: *mut i32 = Default::default();
+    let mut p: *mut i32 = std::ptr::null_mut();
     return p;
 }
 pub fn main() {

--- a/tests/ub/out/unsafe/ub4.rs
+++ b/tests/ub/out/unsafe/ub4.rs
@@ -15,7 +15,7 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut out: *mut i32 = Default::default();
+    let mut out: *mut i32 = std::ptr::null_mut();
     let mut x1: i32 = 1;
     if (x1 != 0) {
         let mut x2: i32 = -1_i32;

--- a/tests/ub/out/unsafe/ub5.rs
+++ b/tests/ub/out/unsafe/ub5.rs
@@ -7,7 +7,7 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn null_0(mut p: *mut *mut i32) {
-    (*p) = Default::default();
+    (*p) = std::ptr::null_mut();
 }
 pub fn main() {
     unsafe {

--- a/tests/unit/null_in_statics.cpp
+++ b/tests/unit/null_in_statics.cpp
@@ -1,0 +1,27 @@
+#include <cassert>
+#include <cstddef>
+
+static int *p_mut;
+static const int *p_const;
+static const char *cp;
+static int *arr_of_ptr[4];
+static int **pp;
+static const int *const_arr_of_ptr[3];
+static const char *cp_explicit_null = nullptr;
+static int *p_zero = 0;
+
+int main() {
+  assert(p_mut == nullptr);
+  assert(p_const == nullptr);
+  assert(cp == nullptr);
+  for (int i = 0; i < 4; ++i) {
+    assert(arr_of_ptr[i] == nullptr);
+  }
+  assert(pp == nullptr);
+  for (int i = 0; i < 3; ++i) {
+    assert(const_arr_of_ptr[i] == nullptr);
+  }
+  assert(cp_explicit_null == nullptr);
+  assert(p_zero == nullptr);
+  return 0;
+}

--- a/tests/unit/out/refcount/null_in_statics.rs
+++ b/tests/unit/out/refcount/null_in_statics.rs
@@ -1,0 +1,64 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+thread_local!(
+    pub static p_mut: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
+);
+thread_local!(
+    pub static p_const: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
+);
+thread_local!(
+    pub static cp: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::<u8>::null()));
+);
+thread_local!(
+    pub static arr_of_ptr: Value<Box<[Ptr<i32>]>> = Rc::new(RefCell::new(
+        (0..4)
+            .map(|_| Ptr::<i32>::null())
+            .collect::<Box<[Ptr<i32>]>>(),
+    ));
+);
+thread_local!(
+    pub static pp: Value<Ptr<Ptr<i32>>> = Rc::new(RefCell::new(Ptr::<Ptr<i32>>::null()));
+);
+thread_local!(
+    pub static const_arr_of_ptr: Value<Box<[Ptr<i32>]>> = Rc::new(RefCell::new(
+        (0..3)
+            .map(|_| Ptr::<i32>::null())
+            .collect::<Box<[Ptr<i32>]>>(),
+    ));
+);
+thread_local!(
+    pub static cp_explicit_null: Value<Ptr<u8>> = Rc::new(RefCell::new(Default::default()));
+);
+thread_local!(
+    pub static p_zero: Value<Ptr<i32>> = Rc::new(RefCell::new(Default::default()));
+);
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!((*p_mut.with(Value::clone).borrow()).is_null());
+    assert!((*p_const.with(Value::clone).borrow()).is_null());
+    assert!((*cp.with(Value::clone).borrow()).is_null());
+    let i: Value<i32> = Rc::new(RefCell::new(0));
+    'loop_: while ((*i.borrow()) < 4) {
+        assert!(((*arr_of_ptr.with(Value::clone).borrow())[(*i.borrow()) as usize]).is_null());
+        (*i.borrow_mut()).prefix_inc();
+    }
+    assert!((*pp.with(Value::clone).borrow()).is_null());
+    let i: Value<i32> = Rc::new(RefCell::new(0));
+    'loop_: while ((*i.borrow()) < 3) {
+        assert!(
+            ((*const_arr_of_ptr.with(Value::clone).borrow())[(*i.borrow()) as usize]).is_null()
+        );
+        (*i.borrow_mut()).prefix_inc();
+    }
+    assert!((*cp_explicit_null.with(Value::clone).borrow()).is_null());
+    assert!((*p_zero.with(Value::clone).borrow()).is_null());
+    return 0;
+}

--- a/tests/unit/out/unsafe/10_struct.rs
+++ b/tests/unit/out/unsafe/10_struct.rs
@@ -38,7 +38,7 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut g: Graph = Graph {
         V: 5_u32,
-        adj: Default::default(),
+        adj: std::ptr::null_mut(),
     };
     return 0;
 }

--- a/tests/unit/out/unsafe/bool_condition_logical.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical.rs
@@ -44,7 +44,7 @@ unsafe fn main_0() -> i32 {
     let mut zero: i32 = 0;
     let mut storage: i32 = 7;
     let mut p: *mut i32 = (&mut storage as *mut i32);
-    let mut np: *mut i32 = Default::default();
+    let mut np: *mut i32 = std::ptr::null_mut();
     let mut u: u32 = 4_u32;
     let mut code: Code = Code::CODE_OK;
     if (n != 0) && (!(p).is_null()) {
@@ -124,7 +124,7 @@ unsafe fn main_0() -> i32 {
         assert!(true);
     }
     let mut cp: *const u8 = b"hi\0".as_ptr();
-    let mut cnp: *const u8 = Default::default();
+    let mut cnp: *const u8 = std::ptr::null();
     if ((x) > (y)) && (!(cp).is_null()) {
         assert!(true);
     }

--- a/tests/unit/out/unsafe/bool_condition_logical_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical_c.rs
@@ -44,7 +44,7 @@ unsafe fn main_0() -> i32 {
     let mut zero: i32 = 0;
     let mut storage: i32 = 7;
     let mut p: *mut i32 = (&mut storage as *mut i32);
-    let mut np: *mut i32 = Default::default();
+    let mut np: *mut i32 = std::ptr::null_mut();
     let mut u: u32 = 4_u32;
     let mut code: Code = Code::from((Code::CODE_OK as i32));
     if ((((n != 0) && (!(p).is_null())) as i32) != 0) {
@@ -134,7 +134,7 @@ unsafe fn main_0() -> i32 {
         assert!((1 != 0));
     }
     let mut cp: *const u8 = b"hi\0".as_ptr().cast_mut().cast_const();
-    let mut cnp: *const u8 = Default::default();
+    let mut cnp: *const u8 = std::ptr::null();
     if (((((((x) > (y)) as i32) != 0) && (!(cp).is_null())) as i32) != 0) {
         assert!((1 != 0));
     }

--- a/tests/unit/out/unsafe/bool_condition_ptr.rs
+++ b/tests/unit/out/unsafe/bool_condition_ptr.rs
@@ -14,7 +14,7 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut storage: i32 = 7;
     let mut p: *mut i32 = (&mut storage as *mut i32);
-    let mut np: *mut i32 = Default::default();
+    let mut np: *mut i32 = std::ptr::null_mut();
     if !(p).is_null() {
         assert!(true);
     }
@@ -31,7 +31,7 @@ unsafe fn main_0() -> i32 {
     let mut iters: i32 = 0;
     'loop_: while !(iter).is_null() {
         iters.prefix_inc();
-        iter = Default::default();
+        iter = std::ptr::null_mut();
     }
     assert!(((iters) == (1)));
     let mut t3: i32 = if !(p).is_null() { 1 } else { 0 };

--- a/tests/unit/out/unsafe/bool_condition_ptr_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_ptr_c.rs
@@ -14,7 +14,7 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut storage: i32 = 7;
     let mut p: *mut i32 = (&mut storage as *mut i32);
-    let mut np: *mut i32 = Default::default();
+    let mut np: *mut i32 = std::ptr::null_mut();
     if !(p).is_null() {
         assert!((1 != 0));
     }
@@ -31,7 +31,7 @@ unsafe fn main_0() -> i32 {
     let mut iters: i32 = 0;
     'loop_: while !(iter).is_null() {
         iters.prefix_inc();
-        iter = Default::default();
+        iter = std::ptr::null_mut();
     }
     assert!(((((iters) == (1)) as i32) != 0));
     let mut t3: i32 = if !(p).is_null() { 1 } else { 0 };

--- a/tests/unit/out/unsafe/bst.rs
+++ b/tests/unit/out/unsafe/bst.rs
@@ -29,7 +29,7 @@ pub unsafe fn find_0(mut node: *mut node_t, mut value: i32) -> *mut node_t {
     } else if ((value) == ((*node).value)) {
         return node;
     }
-    return Default::default();
+    return std::ptr::null_mut();
 }
 pub unsafe fn insert_1(mut node: *mut node_t, mut new_node: *mut node_t) -> *mut node_t {
     if (node).is_null() {
@@ -57,28 +57,28 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut tree: Option<Box<node_t>> = Some(Box::new(node_t {
-        left: Default::default(),
-        right: Default::default(),
+        left: std::ptr::null_mut(),
+        right: std::ptr::null_mut(),
         value: 0,
     }));
     let mut n1: Option<Box<node_t>> = Some(Box::new(node_t {
-        left: Default::default(),
-        right: Default::default(),
+        left: std::ptr::null_mut(),
+        right: std::ptr::null_mut(),
         value: 1,
     }));
     let mut n2: Option<Box<node_t>> = Some(Box::new(node_t {
-        left: Default::default(),
-        right: Default::default(),
+        left: std::ptr::null_mut(),
+        right: std::ptr::null_mut(),
         value: 2,
     }));
     let mut n3: Option<Box<node_t>> = Some(Box::new(node_t {
-        left: Default::default(),
-        right: Default::default(),
+        left: std::ptr::null_mut(),
+        right: std::ptr::null_mut(),
         value: 3,
     }));
     let mut n4: Option<Box<node_t>> = Some(Box::new(node_t {
-        left: Default::default(),
-        right: Default::default(),
+        left: std::ptr::null_mut(),
+        right: std::ptr::null_mut(),
         value: 4,
     }));
     let mut ptr1: *mut node_t = (&mut (*tree.as_deref_mut().unwrap()) as *mut node_t);

--- a/tests/unit/out/unsafe/builtin_types_compatible.rs
+++ b/tests/unit/out/unsafe/builtin_types_compatible.rs
@@ -17,7 +17,7 @@ unsafe fn main_0() -> i32 {
     let mut x: i32 = 0;
     assert!(((((1) == (1)) as i32) != 0));
     assert!(((((0) == (0)) as i32) != 0));
-    let mut p: *mut i32 = Default::default();
+    let mut p: *mut i32 = std::ptr::null_mut();
     assert!(((((1) == (1)) as i32) != 0));
     assert!(((((0) == (0)) as i32) != 0));
     let mut ul: u64 = 0_u64;

--- a/tests/unit/out/unsafe/c_struct.rs
+++ b/tests/unit/out/unsafe/c_struct.rs
@@ -71,7 +71,7 @@ unsafe fn main_0() -> i32 {
     assert!(((((l.end.y) == (4)) as i32) != 0));
     let mut a: Node = Node {
         value: 1,
-        next: Default::default(),
+        next: std::ptr::null_mut(),
     };
     let mut b: Node = Node {
         value: 2,

--- a/tests/unit/out/unsafe/clone_vs_move.rs
+++ b/tests/unit/out/unsafe/clone_vs_move.rs
@@ -25,7 +25,7 @@ impl Default for Foo {
         Foo {
             x: 0_i32,
             y: <*mut i32>::default(),
-            z: Default::default(),
+            z: std::ptr::null_mut(),
             a: [0_i32; 3],
             bar: <Bar>::default(),
         }

--- a/tests/unit/out/unsafe/default.rs
+++ b/tests/unit/out/unsafe/default.rs
@@ -18,10 +18,10 @@ pub struct Pointers {
 impl Default for Pointers {
     fn default() -> Self {
         Pointers {
-            x1: Default::default(),
-            x2: Default::default(),
-            x3: [Default::default(); 5],
-            x4: [Default::default(); 10],
+            x1: std::ptr::null_mut(),
+            x2: std::ptr::null(),
+            x3: [std::ptr::null_mut(); 5],
+            x4: [std::ptr::null(); 10],
             x5: 0_i32,
         }
     }

--- a/tests/unit/out/unsafe/expr_as_bool_c.rs
+++ b/tests/unit/out/unsafe/expr_as_bool_c.rs
@@ -69,7 +69,7 @@ unsafe fn main_0() -> i32 {
     assert!(((((lt) == (0)) as i32) != 0));
     assert!(((((neq) == (0)) as i32) != 0));
     let mut p1: *const u8 = b"hi\0".as_ptr().cast_mut().cast_const();
-    let mut p2: *const u8 = Default::default();
+    let mut p2: *const u8 = std::ptr::null();
     let mut either: i32 = (((!(p1).is_null()) || (!(p2).is_null())) as i32);
     let mut both: i32 = (((!(p1).is_null()) && (!(p2).is_null())) as i32);
     assert!(((((either) == (1)) as i32) != 0));
@@ -98,16 +98,16 @@ unsafe fn main_0() -> i32 {
     );
     assert!(
         ((((unsafe {
-            let _p: *const u8 = Default::default();
-            let _q: *const u8 = Default::default();
+            let _p: *const u8 = std::ptr::null();
+            let _q: *const u8 = std::ptr::null();
             cmp_or_ptr_1(_p, _q)
         }) == (0)) as i32)
             != 0)
     );
     assert!(
         ((((unsafe {
-            let _s1: *const u8 = Default::default();
-            let _s2: *const u8 = Default::default();
+            let _s1: *const u8 = std::ptr::null();
+            let _s2: *const u8 = std::ptr::null();
             both_null_2(_s1, _s2)
         }) == (1)) as i32)
             != 0)
@@ -115,7 +115,7 @@ unsafe fn main_0() -> i32 {
     assert!(
         ((((unsafe {
             let _s1: *const u8 = p1;
-            let _s2: *const u8 = Default::default();
+            let _s2: *const u8 = std::ptr::null();
             both_null_2(_s1, _s2)
         }) == (0)) as i32)
             != 0)

--- a/tests/unit/out/unsafe/expr_as_bool_cpp.rs
+++ b/tests/unit/out/unsafe/expr_as_bool_cpp.rs
@@ -64,7 +64,7 @@ unsafe fn main_0() -> i32 {
     assert!(((lt) == (0)));
     assert!(((neq) == (0)));
     let mut p1: *const u8 = b"hi\0".as_ptr();
-    let mut p2: *const u8 = Default::default();
+    let mut p2: *const u8 = std::ptr::null();
     let mut either: i32 = (((!(p1).is_null()) || (!(p2).is_null())) as i32);
     let mut both: i32 = (((!(p1).is_null()) && (!(p2).is_null())) as i32);
     assert!(((either) == (1)));
@@ -90,22 +90,22 @@ unsafe fn main_0() -> i32 {
     );
     assert!(
         ((unsafe {
-            let _p: *const u8 = Default::default();
-            let _q: *const u8 = Default::default();
+            let _p: *const u8 = std::ptr::null();
+            let _q: *const u8 = std::ptr::null();
             cmp_or_ptr_1(_p, _q)
         }) == (0))
     );
     assert!(
         ((unsafe {
-            let _s1: *const u8 = Default::default();
-            let _s2: *const u8 = Default::default();
+            let _s1: *const u8 = std::ptr::null();
+            let _s2: *const u8 = std::ptr::null();
             both_null_2(_s1, _s2)
         }) == (1))
     );
     assert!(
         ((unsafe {
             let _s1: *const u8 = p1;
-            let _s2: *const u8 = Default::default();
+            let _s2: *const u8 = std::ptr::null();
             both_null_2(_s1, _s2)
         }) == (0))
     );

--- a/tests/unit/out/unsafe/fflush_null.rs
+++ b/tests/unit/out/unsafe/fflush_null.rs
@@ -12,7 +12,7 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut file_ptr: *mut ::std::fs::File = Default::default();
+    let mut file_ptr: *mut ::std::fs::File = std::ptr::null_mut();
     return if !(file_ptr).is_null() {
         match (*file_ptr).sync_all() {
             Ok(_) => 0,

--- a/tests/unit/out/unsafe/fn_ptr_stdlib_compare.rs
+++ b/tests/unit/out/unsafe/fn_ptr_stdlib_compare.rs
@@ -43,10 +43,10 @@ unsafe fn main_0() -> i32 {
         >(Some(my_alternative_fread_0));
     assert!(
         ((unsafe {
-            let _arg0: *mut ::libc::c_void = Default::default();
+            let _arg0: *mut ::libc::c_void = std::ptr::null_mut();
             let _arg1: u64 = 0_u64;
             let _arg2: u64 = 0_u64;
-            let _arg3: *mut ::std::fs::File = Default::default();
+            let _arg3: *mut ::std::fs::File = std::ptr::null_mut();
             (f3).unwrap()(_arg0, _arg1, _arg2, _arg3)
         }) == (22_u64))
     );

--- a/tests/unit/out/unsafe/huffman.rs
+++ b/tests/unit/out/unsafe/huffman.rs
@@ -55,8 +55,8 @@ impl MinHeap {
         self.alloc.as_mut().unwrap()[(self.next as u64) as usize] = MinHeapNode {
             data: data,
             freq: freq,
-            left: Default::default(),
-            right: Default::default(),
+            left: std::ptr::null_mut(),
+            right: std::ptr::null_mut(),
         };
         return (&mut self.alloc.as_mut().unwrap()[(self.next.postfix_inc() as u64) as usize]
             as *mut MinHeapNode);

--- a/tests/unit/out/unsafe/init.rs
+++ b/tests/unit/out/unsafe/init.rs
@@ -21,7 +21,7 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut x: i32 = 0_i32;
-    let mut p: *mut i32 = Default::default();
+    let mut p: *mut i32 = std::ptr::null_mut();
     let g: *mut i32 = &mut x as *mut i32;
     let mut q: *mut i32 = (&mut x as *mut i32);
     let mut z: *mut i32 = p;

--- a/tests/unit/out/unsafe/linked_list.rs
+++ b/tests/unit/out/unsafe/linked_list.rs
@@ -38,7 +38,7 @@ pub unsafe fn Append_1(head: *mut Node, new_node: *mut Node) {
 }
 pub unsafe fn Delete_2(mut head: *mut Node, mut val: i32) -> *mut Node {
     let mut curr: *mut Node = head;
-    let mut prev: *mut Node = Default::default();
+    let mut prev: *mut Node = std::ptr::null_mut();
     'loop_: while !((curr).is_null()) {
         if (((*curr).val) == (val)) {
             if !((prev).is_null()) {
@@ -61,36 +61,36 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut n0: Node = Node {
         val: 5,
-        next: Default::default(),
+        next: std::ptr::null_mut(),
     };
     let mut head: *mut Node = (&mut n0 as *mut Node);
     let mut n1: Node = Node {
         val: 4,
-        next: Default::default(),
+        next: std::ptr::null_mut(),
     };
     let mut n2: Node = Node {
         val: 3,
-        next: Default::default(),
+        next: std::ptr::null_mut(),
     };
     let mut n3: Node = Node {
         val: 2,
-        next: Default::default(),
+        next: std::ptr::null_mut(),
     };
     let mut n4: Node = Node {
         val: 1,
-        next: Default::default(),
+        next: std::ptr::null_mut(),
     };
     let mut n5: Node = Node {
         val: 0,
-        next: Default::default(),
+        next: std::ptr::null_mut(),
     };
     let mut n6: Node = Node {
         val: -1_i32,
-        next: Default::default(),
+        next: std::ptr::null_mut(),
     };
     let mut n7: Node = Node {
         val: -2_i32,
-        next: Default::default(),
+        next: std::ptr::null_mut(),
     };
     (unsafe {
         let _head: *mut Node = &mut (*head) as *mut Node;

--- a/tests/unit/out/unsafe/new_bst.rs
+++ b/tests/unit/out/unsafe/new_bst.rs
@@ -29,13 +29,13 @@ pub unsafe fn find_0(mut node: *mut node_t, mut value: i32) -> *mut node_t {
     } else if ((value) == ((*node).value)) {
         return node;
     }
-    return Default::default();
+    return std::ptr::null_mut();
 }
 pub unsafe fn insert_1(mut node: *mut node_t, mut value: i32) -> *mut node_t {
     if (node).is_null() {
         return (Box::leak(Box::new(node_t {
-            left: Default::default(),
-            right: Default::default(),
+            left: std::ptr::null_mut(),
+            right: std::ptr::null_mut(),
             value: value,
         })) as *mut node_t);
     }
@@ -76,8 +76,8 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut root: *mut node_t = (Box::leak(Box::new(node_t {
-        left: Default::default(),
-        right: Default::default(),
+        left: std::ptr::null_mut(),
+        right: std::ptr::null_mut(),
         value: 0,
     })) as *mut node_t);
     root = (unsafe {

--- a/tests/unit/out/unsafe/null_in_statics.rs
+++ b/tests/unit/out/unsafe/null_in_statics.rs
@@ -1,0 +1,40 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub static mut p_mut: *mut i32 = std::ptr::null_mut();
+pub static mut p_const: *const i32 = std::ptr::null();
+pub static mut cp: *const u8 = std::ptr::null();
+pub static mut arr_of_ptr: [*mut i32; 4] = [std::ptr::null_mut(); 4];
+pub static mut pp: *mut *mut i32 = std::ptr::null_mut();
+pub static mut const_arr_of_ptr: [*const i32; 3] = [std::ptr::null(); 3];
+pub static mut cp_explicit_null: *const u8 = std::ptr::null();
+pub static mut p_zero: *mut i32 = std::ptr::null_mut();
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!((p_mut).is_null());
+    assert!((p_const).is_null());
+    assert!((cp).is_null());
+    let mut i: i32 = 0;
+    'loop_: while ((i) < (4)) {
+        assert!((arr_of_ptr[(i) as usize]).is_null());
+        i.prefix_inc();
+    }
+    assert!((pp).is_null());
+    let mut i: i32 = 0;
+    'loop_: while ((i) < (3)) {
+        assert!((const_arr_of_ptr[(i) as usize]).is_null());
+        i.prefix_inc();
+    }
+    assert!((cp_explicit_null).is_null());
+    assert!((p_zero).is_null());
+    return 0;
+}

--- a/tests/unit/out/unsafe/pointer_array.rs
+++ b/tests/unit/out/unsafe/pointer_array.rs
@@ -14,7 +14,7 @@ pub struct StackArray {
 impl Default for StackArray {
     fn default() -> Self {
         StackArray {
-            arr: [Default::default(); 3],
+            arr: [std::ptr::null_mut(); 3],
         }
     }
 }

--- a/tests/unit/out/unsafe/pointer_to_boolean.rs
+++ b/tests/unit/out/unsafe/pointer_to_boolean.rs
@@ -12,7 +12,7 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut x: *mut i32 = Default::default();
+    let mut x: *mut i32 = std::ptr::null_mut();
     if !(x).is_null() {
         return 1;
     }

--- a/tests/unit/out/unsafe/pointers.rs
+++ b/tests/unit/out/unsafe/pointers.rs
@@ -54,7 +54,7 @@ unsafe fn main_0() -> i32 {
         let _t: *mut Test = (&mut t1 as *mut Test);
         Update_0(_t)
     });
-    let mut t3: *mut Test = Default::default();
+    let mut t3: *mut Test = std::ptr::null_mut();
     t3 = t2;
     (*t3).x = 15;
     (*(unsafe { (*t3).as_ptr() })) += 10;

--- a/tests/unit/out/unsafe/push_emplace_back.rs
+++ b/tests/unit/out/unsafe/push_emplace_back.rs
@@ -28,7 +28,7 @@ pub unsafe fn push_param_0(mut dest: *mut Vec<Vec<u8>>) {
 }
 pub unsafe fn push_local_from_field_1(mut jpg: *mut JPEGData, mut cond: bool) {
     let mut head: [u8; 3] = [1_u8, 2_u8, 3_u8];
-    let mut dest: *mut Vec<Vec<u8>> = Default::default();
+    let mut dest: *mut Vec<Vec<u8>> = std::ptr::null_mut();
     if cond {
         dest = (&mut (*jpg).com_data as *mut Vec<Vec<u8>>);
     } else {
@@ -50,7 +50,7 @@ pub unsafe fn nested_push_move_3(mut bw: *mut Writer) {
 }
 pub unsafe fn emplace_local_from_field_4(mut jpg: *mut JPEGData, mut cond: bool) {
     let mut head: [u8; 3] = [1_u8, 2_u8, 3_u8];
-    let mut dest: *mut Vec<Vec<u8>> = Default::default();
+    let mut dest: *mut Vec<Vec<u8>> = std::ptr::null_mut();
     if cond {
         dest = (&mut (*jpg).com_data as *mut Vec<Vec<u8>>);
     } else {

--- a/tests/unit/out/unsafe/random.rs
+++ b/tests/unit/out/unsafe/random.rs
@@ -23,9 +23,9 @@ impl Pair {
         self.y.prefix_inc();
         self.a[(4) as usize] = 1;
         (*self.r) = 1;
-        self.p = Default::default();
-        self.pair = Default::default();
-        self.ap[(0) as usize] = Default::default();
+        self.p = std::ptr::null_mut();
+        self.pair = std::ptr::null_mut();
+        self.ap[(0) as usize] = std::ptr::null_mut();
     }
     pub unsafe fn as_val(&mut self) -> i32 {
         return self.x;
@@ -44,9 +44,9 @@ impl Default for Pair {
             y: 0_i32,
             a: [0_i32; 5],
             r: <*mut i32>::default(),
-            p: Default::default(),
-            pair: Default::default(),
-            ap: [Default::default(); 2],
+            p: std::ptr::null_mut(),
+            pair: std::ptr::null_mut(),
+            ap: [std::ptr::null_mut(); 2],
         }
     }
 }
@@ -81,9 +81,9 @@ unsafe fn main_0() -> i32 {
         y: 2,
         a: [1, 2, 3, 4, 5],
         r: &mut x1 as *mut i32,
-        p: Default::default(),
-        pair: Default::default(),
-        ap: [Default::default(), Default::default()],
+        p: std::ptr::null_mut(),
+        pair: std::ptr::null_mut(),
+        ap: [std::ptr::null_mut(), std::ptr::null_mut()],
     };
     let mut y4: Pair = Pair {
         x: y1.x,
@@ -136,7 +136,7 @@ unsafe fn main_0() -> i32 {
     };
     let ry3: *mut Pair = &mut (*py1) as *mut Pair;
     let mut py3: *mut Pair = py1;
-    py3 = Default::default();
+    py3 = std::ptr::null_mut();
     let mut ptr2pair: *mut Pair = py3;
     (unsafe {
         let _x1: i32 = x1;
@@ -197,9 +197,9 @@ unsafe fn main_0() -> i32 {
         y: 2,
         a: [1, 2, 3, 4, 5],
         r: &mut j as *mut i32,
-        p: Default::default(),
-        pair: Default::default(),
-        ap: [Default::default(), Default::default()],
+        p: std::ptr::null_mut(),
+        pair: std::ptr::null_mut(),
+        ap: [std::ptr::null_mut(), std::ptr::null_mut()],
     };
     y1.x = new_y.x;
     let mut i: u32 = 1_u32;

--- a/tests/unit/out/unsafe/templates.rs
+++ b/tests/unit/out/unsafe/templates.rs
@@ -13,10 +13,10 @@ pub unsafe fn foo_1(mut x: f64) -> f64 {
     return x;
 }
 pub unsafe fn bar_2(mut p: *mut i32, mut flag: bool) -> *mut i32 {
-    return if flag { p } else { Default::default() };
+    return if flag { p } else { std::ptr::null_mut() };
 }
 pub unsafe fn bar_3(mut p: *mut f64, mut flag: bool) -> *mut f64 {
-    return if flag { p } else { Default::default() };
+    return if flag { p } else { std::ptr::null_mut() };
 }
 pub unsafe fn func_4(mut x1: i32, mut x2: i32, mut x3: i32) -> i32 {
     return (((x1) + (x2)) + (x3));

--- a/tests/unit/out/unsafe/union_field_alignment.rs
+++ b/tests/unit/out/unsafe/union_field_alignment.rs
@@ -30,7 +30,7 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut n: node = <node>::default();
-    n.next = Default::default();
+    n.next = std::ptr::null_mut();
     n.x.bytes[(0) as usize] = 171_u8;
     assert!(((((n.x.bytes[(0) as usize] as i32) == (171)) as i32) != 0));
     return 0;


### PR DESCRIPTION
Previously, we used `Default::default()` for initializing pointers to null. This is not compatible with initializing global variables because they are declared in static context. In static context, only const functions can be used. `Default::default()` is not const, `std::ptr::null()/null_mut()` are const.