### PR TITLE
Allow initialization of enums in global context

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -1733,6 +1733,19 @@ bool Converter::VisitCXXBoolLiteralExpr(clang::CXXBoolLiteralExpr *expr) {
 
 void Converter::ConvertIntegerToEnumeralCast(clang::Expr *to,
                                              clang::Expr *from) {
+  // Short circuit `Enum::from(X as i32)` to `X`
+  if (auto ref =
+          clang::dyn_cast<clang::DeclRefExpr>(from->IgnoreParenImpCasts())) {
+    if (auto ec = clang::dyn_cast<clang::EnumConstantDecl>(ref->getDecl())) {
+      auto src_enum = clang::dyn_cast<clang::EnumDecl>(ec->getDeclContext());
+      auto dst_enum = to->getType()->getAs<clang::EnumType>();
+      if (src_enum && dst_enum && dst_enum->getDecl() == src_enum) {
+        StrCat(std::format("{}::{}", GetRecordName(src_enum),
+                           std::string_view(ec->getName())));
+        return;
+      }
+    }
+  }
   StrCat(GetUnsafeTypeAsString(to->getType()), "::from");
   PushParen paren(*this);
   Convert(from);

--- a/tests/unit/enum_int_interop.cpp
+++ b/tests/unit/enum_int_interop.cpp
@@ -15,6 +15,22 @@ typedef enum {
   TAG_TWO = 2,
 } Tag;
 
+struct Entry {
+  const char *name;
+  Color color;
+  Option opt;
+};
+
+static Color global_color = GREEN;
+static Option global_opt = OPT_B;
+static Tag global_tag = TAG_TWO;
+
+static Entry entries[3] = {
+    {"first", RED, OPT_NONE},
+    {"second", GREEN, OPT_A},
+    {"third", BLUE, OPT_C},
+};
+
 int as_int(Color c) { return c; }
 
 int classify_option(int option) {
@@ -112,6 +128,17 @@ int main() {
 
   int extra = (int)RED + (int)GREEN + (int)BLUE;
   assert(extra == 0 + 1 + 2);
+
+  assert(global_color == GREEN);
+  assert(global_opt == OPT_B);
+  assert(global_tag == TAG_TWO);
+
+  assert(entries[0].color == RED);
+  assert(entries[0].opt == OPT_NONE);
+  assert(entries[1].color == GREEN);
+  assert(entries[1].opt == OPT_A);
+  assert(entries[2].color == BLUE);
+  assert(entries[2].opt == OPT_C);
 
   return 0;
 }

--- a/tests/unit/enum_int_interop_c.c
+++ b/tests/unit/enum_int_interop_c.c
@@ -15,6 +15,22 @@ typedef enum {
   TAG_TWO = 2,
 } Tag;
 
+struct Entry {
+  const char *name;
+  enum Color color;
+  enum Option opt;
+};
+
+static enum Color global_color = GREEN;
+static enum Option global_opt = OPT_B;
+static Tag global_tag = TAG_TWO;
+
+static struct Entry entries[3] = {
+    {"first", RED, OPT_NONE},
+    {"second", GREEN, OPT_A},
+    {"third", BLUE, OPT_C},
+};
+
 int as_int(enum Color c) { return c; }
 
 int classify_option(int option) {
@@ -112,6 +128,17 @@ int main() {
 
   int extra = (int)RED + (int)GREEN + (int)BLUE;
   assert(extra == 0 + 1 + 2);
+
+  assert(global_color == GREEN);
+  assert(global_opt == OPT_B);
+  assert(global_tag == TAG_TWO);
+
+  assert(entries[0].color == RED);
+  assert(entries[0].opt == OPT_NONE);
+  assert(entries[1].color == GREEN);
+  assert(entries[1].opt == OPT_A);
+  assert(entries[2].color == BLUE);
+  assert(entries[2].opt == OPT_C);
 
   return 0;
 }

--- a/tests/unit/out/refcount/anonymous_enum_c.rs
+++ b/tests/unit/out/refcount/anonymous_enum_c.rs
@@ -99,18 +99,18 @@ fn main_0() -> i32 {
     assert!(((((anon_enum_3::FIRST_A as i32) != (anon_enum_3::FIRST_B as i32)) as i32) != 0));
     assert!(((((anon_enum_11::SECOND_A as i32) != (anon_enum_11::SECOND_B as i32)) as i32) != 0));
     assert!(((((anon_enum_31::THIRD_A as i32) != (anon_enum_31::THIRD_B as i32)) as i32) != 0));
-    let td: Value<TdEnum> = Rc::new(RefCell::new(TdEnum::from((TdEnum::TD_A as i32))));
+    let td: Value<TdEnum> = Rc::new(RefCell::new(TdEnum::TD_A));
     assert!((((((*td.borrow()) as u32) == ((TdEnum::TD_A as i32) as u32)) as i32) != 0));
-    (*td.borrow_mut()) = TdEnum::from((TdEnum::TD_B as i32));
+    (*td.borrow_mut()) = TdEnum::TD_B;
     assert!((((((*td.borrow()) as u32) == ((TdEnum::TD_B as i32) as u32)) as i32) != 0));
     let w: Value<WithAnonField> = <Value<WithAnonField>>::default();
-    (*(*w.borrow()).field.borrow_mut()) = anon_enum_24::from((anon_enum_24::FIELD_A as i32));
+    (*(*w.borrow()).field.borrow_mut()) = anon_enum_24::FIELD_A;
     assert!(
         (((((*(*w.borrow()).field.borrow()) as u32) == ((anon_enum_24::FIELD_A as i32) as u32))
             as i32)
             != 0)
     );
-    (*(*w.borrow()).field.borrow_mut()) = anon_enum_24::from((anon_enum_24::FIELD_B as i32));
+    (*(*w.borrow()).field.borrow_mut()) = anon_enum_24::FIELD_B;
     assert!(
         (((((*(*w.borrow()).field.borrow()) as u32) == ((anon_enum_24::FIELD_B as i32) as u32))
             as i32)

--- a/tests/unit/out/refcount/bool_condition_enum_c.rs
+++ b/tests/unit/out/refcount/bool_condition_enum_c.rs
@@ -27,8 +27,8 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    let code: Value<Code> = Rc::new(RefCell::new(Code::from((Code::CODE_OK as i32))));
-    let err: Value<Code> = Rc::new(RefCell::new(Code::from((Code::CODE_ERR as i32))));
+    let code: Value<Code> = Rc::new(RefCell::new(Code::CODE_OK));
+    let err: Value<Code> = Rc::new(RefCell::new(Code::CODE_ERR));
     if ((*code.borrow()) != Code::from(0)) {
         assert!((0 != 0));
     }

--- a/tests/unit/out/refcount/bool_condition_logical_c.rs
+++ b/tests/unit/out/refcount/bool_condition_logical_c.rs
@@ -47,7 +47,7 @@ fn main_0() -> i32 {
     let p: Value<Ptr<i32>> = Rc::new(RefCell::new((storage.as_pointer())));
     let np: Value<Ptr<i32>> = Rc::new(RefCell::new(Default::default()));
     let u: Value<u32> = Rc::new(RefCell::new(4_u32));
-    let code: Value<Code> = Rc::new(RefCell::new(Code::from((Code::CODE_OK as i32))));
+    let code: Value<Code> = Rc::new(RefCell::new(Code::CODE_OK));
     if (((((*n.borrow()) != 0) && (!(*p.borrow()).is_null())) as i32) != 0) {
         assert!((1 != 0));
     }

--- a/tests/unit/out/refcount/c_struct.rs
+++ b/tests/unit/out/refcount/c_struct.rs
@@ -96,7 +96,7 @@ fn main_0() -> i32 {
             a: Rc::new(RefCell::new(5)),
             b: Rc::new(RefCell::new(6)),
         })),
-        color: Rc::new(RefCell::new(Color::from((Color::GREEN as i32)))),
+        color: Rc::new(RefCell::new(Color::GREEN)),
         count: Rc::new(RefCell::new(42)),
     }));
     assert!(((((*(*(*c.borrow()).inner.borrow()).a.borrow()) == 5) as i32) != 0));
@@ -107,7 +107,7 @@ fn main_0() -> i32 {
     );
     assert!(((((*(*c.borrow()).count.borrow()) == 42) as i32) != 0));
     let c2: Value<Container> = <Value<Container>>::default();
-    (*(*c2.borrow()).color.borrow_mut()) = Color::from((Color::BLUE as i32));
+    (*(*c2.borrow()).color.borrow_mut()) = Color::BLUE;
     assert!((((((*(*c2.borrow()).color.borrow()) as u32) == 2_u32) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/refcount/enum_int_interop.rs
+++ b/tests/unit/out/refcount/enum_int_interop.rs
@@ -59,6 +59,51 @@ impl From<i32> for Tag {
         }
     }
 }
+#[derive(Default)]
+pub struct Entry {
+    pub name: Value<Ptr<u8>>,
+    pub color: Value<Color>,
+    pub opt: Value<Option>,
+}
+impl Clone for Entry {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            name: Rc::new(RefCell::new((*self.name.borrow()).clone())),
+            color: Rc::new(RefCell::new((*self.color.borrow()).clone())),
+            opt: Rc::new(RefCell::new((*self.opt.borrow()).clone())),
+        };
+        this
+    }
+}
+impl ByteRepr for Entry {}
+thread_local!(
+    pub static global_color: Value<Color> = Rc::new(RefCell::new(Color::GREEN));
+);
+thread_local!(
+    pub static global_opt: Value<Option> = Rc::new(RefCell::new(Option::OPT_B));
+);
+thread_local!(
+    pub static global_tag: Value<Tag> = Rc::new(RefCell::new(Tag::TAG_TWO));
+);
+thread_local!(
+    pub static entries: Value<Box<[Entry]>> = Rc::new(RefCell::new(Box::new([
+        Entry {
+            name: Rc::new(RefCell::new(Ptr::from_string_literal("first"))),
+            color: Rc::new(RefCell::new(Color::RED)),
+            opt: Rc::new(RefCell::new(Option::OPT_NONE)),
+        },
+        Entry {
+            name: Rc::new(RefCell::new(Ptr::from_string_literal("second"))),
+            color: Rc::new(RefCell::new(Color::GREEN)),
+            opt: Rc::new(RefCell::new(Option::OPT_A)),
+        },
+        Entry {
+            name: Rc::new(RefCell::new(Ptr::from_string_literal("third"))),
+            color: Rc::new(RefCell::new(Color::BLUE)),
+            opt: Rc::new(RefCell::new(Option::OPT_C)),
+        },
+    ])));
+);
 pub fn as_int_0(c: Color) -> i32 {
     let c: Value<Color> = Rc::new(RefCell::new(c));
     return ((*c.borrow()) as i32).clone();
@@ -183,5 +228,44 @@ fn main_0() -> i32 {
         (((Color::RED as i32) + (Color::GREEN as i32)) + (Color::BLUE as i32)),
     ));
     assert!(((*extra.borrow()) == ((0 + 1) + 2)));
+    assert!((((*global_color.with(Value::clone).borrow()) as i32) == (Color::GREEN as i32)));
+    assert!((((*global_opt.with(Value::clone).borrow()) as i32) == (Option::OPT_B as i32)));
+    assert!((((*global_tag.with(Value::clone).borrow()) as i32) == (Tag::TAG_TWO as i32)));
+    assert!(
+        (((*(*entries.with(Value::clone).borrow())[(0) as usize]
+            .color
+            .borrow()) as i32)
+            == (Color::RED as i32))
+    );
+    assert!(
+        (((*(*entries.with(Value::clone).borrow())[(0) as usize]
+            .opt
+            .borrow()) as i32)
+            == (Option::OPT_NONE as i32))
+    );
+    assert!(
+        (((*(*entries.with(Value::clone).borrow())[(1) as usize]
+            .color
+            .borrow()) as i32)
+            == (Color::GREEN as i32))
+    );
+    assert!(
+        (((*(*entries.with(Value::clone).borrow())[(1) as usize]
+            .opt
+            .borrow()) as i32)
+            == (Option::OPT_A as i32))
+    );
+    assert!(
+        (((*(*entries.with(Value::clone).borrow())[(2) as usize]
+            .color
+            .borrow()) as i32)
+            == (Color::BLUE as i32))
+    );
+    assert!(
+        (((*(*entries.with(Value::clone).borrow())[(2) as usize]
+            .opt
+            .borrow()) as i32)
+            == (Option::OPT_C as i32))
+    );
     return 0;
 }

--- a/tests/unit/out/refcount/enum_int_interop_c.rs
+++ b/tests/unit/out/refcount/enum_int_interop_c.rs
@@ -59,6 +59,41 @@ impl From<i32> for Tag {
         }
     }
 }
+#[derive(Default)]
+pub struct Entry {
+    pub name: Value<Ptr<u8>>,
+    pub color: Value<Color>,
+    pub opt: Value<Option>,
+}
+impl ByteRepr for Entry {}
+thread_local!(
+    pub static global_color: Value<Color> = Rc::new(RefCell::new(Color::GREEN));
+);
+thread_local!(
+    pub static global_opt: Value<Option> = Rc::new(RefCell::new(Option::OPT_B));
+);
+thread_local!(
+    pub static global_tag: Value<Tag> = Rc::new(RefCell::new(Tag::TAG_TWO));
+);
+thread_local!(
+    pub static entries: Value<Box<[Entry]>> = Rc::new(RefCell::new(Box::new([
+        Entry {
+            name: Rc::new(RefCell::new(Ptr::from_string_literal("first"))),
+            color: Rc::new(RefCell::new(Color::RED)),
+            opt: Rc::new(RefCell::new(Option::OPT_NONE)),
+        },
+        Entry {
+            name: Rc::new(RefCell::new(Ptr::from_string_literal("second"))),
+            color: Rc::new(RefCell::new(Color::GREEN)),
+            opt: Rc::new(RefCell::new(Option::OPT_A)),
+        },
+        Entry {
+            name: Rc::new(RefCell::new(Ptr::from_string_literal("third"))),
+            color: Rc::new(RefCell::new(Color::BLUE)),
+            opt: Rc::new(RefCell::new(Option::OPT_C)),
+        },
+    ])));
+);
 pub fn as_int_0(c: Color) -> i32 {
     let c: Value<Color> = Rc::new(RefCell::new(c));
     return ((*c.borrow()) as i32).clone();
@@ -95,7 +130,7 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    let c: Value<Color> = Rc::new(RefCell::new(Color::from((Color::RED as i32))));
+    let c: Value<Color> = Rc::new(RefCell::new(Color::RED));
     assert!((((((*c.borrow()) as u32) == ((Color::RED as i32) as u32)) as i32) != 0));
     assert!((((((*c.borrow()) as u32) == 0_u32) as i32) != 0));
     assert!((((((*c.borrow()) as u32) != 1_u32) as i32) != 0));
@@ -137,7 +172,7 @@ fn main_0() -> i32 {
         (((*c.borrow()) as u32).wrapping_add(1_u32)) as i32,
     )));
     assert!((((((*cmp.borrow()) as u32) == ((Color::BLUE as i32) as u32)) as i32) != 0));
-    let o: Value<Option> = Rc::new(RefCell::new(Option::from((Option::OPT_A as i32))));
+    let o: Value<Option> = Rc::new(RefCell::new(Option::OPT_A));
     assert!((((((*o.borrow()) as u32) == ((Option::OPT_A as i32) as u32)) as i32) != 0));
     assert!((((((*o.borrow()) as u32) == 10_u32) as i32) != 0));
     let oi: Value<i32> = Rc::new(RefCell::new(((*o.borrow()) as i32).clone()));
@@ -161,7 +196,7 @@ fn main_0() -> i32 {
         classify_option_1(_option)
     });
     assert!(((((*rc.borrow()) == 3) as i32) != 0));
-    let t: Value<Tag> = Rc::new(RefCell::new(Tag::from((Tag::TAG_ONE as i32))));
+    let t: Value<Tag> = Rc::new(RefCell::new(Tag::TAG_ONE));
     assert!((((((*t.borrow()) as u32) == 1_u32) as i32) != 0));
     assert!((((((*t.borrow()) as u32) == ((Tag::TAG_ONE as i32) as u32)) as i32) != 0));
     let ti: Value<i32> = Rc::new(RefCell::new(((*t.borrow()) as i32).clone()));
@@ -187,5 +222,62 @@ fn main_0() -> i32 {
         (((Color::RED as i32) + (Color::GREEN as i32)) + (Color::BLUE as i32)),
     ));
     assert!(((((*extra.borrow()) == ((0 + 1) + 2)) as i32) != 0));
+    assert!(
+        (((((*global_color.with(Value::clone).borrow()) as u32) == ((Color::GREEN as i32) as u32))
+            as i32)
+            != 0)
+    );
+    assert!(
+        (((((*global_opt.with(Value::clone).borrow()) as u32) == ((Option::OPT_B as i32) as u32))
+            as i32)
+            != 0)
+    );
+    assert!(
+        (((((*global_tag.with(Value::clone).borrow()) as u32) == ((Tag::TAG_TWO as i32) as u32))
+            as i32)
+            != 0)
+    );
+    assert!(
+        (((((*(*entries.with(Value::clone).borrow())[(0) as usize]
+            .color
+            .borrow()) as u32)
+            == ((Color::RED as i32) as u32)) as i32)
+            != 0)
+    );
+    assert!(
+        (((((*(*entries.with(Value::clone).borrow())[(0) as usize]
+            .opt
+            .borrow()) as u32)
+            == ((Option::OPT_NONE as i32) as u32)) as i32)
+            != 0)
+    );
+    assert!(
+        (((((*(*entries.with(Value::clone).borrow())[(1) as usize]
+            .color
+            .borrow()) as u32)
+            == ((Color::GREEN as i32) as u32)) as i32)
+            != 0)
+    );
+    assert!(
+        (((((*(*entries.with(Value::clone).borrow())[(1) as usize]
+            .opt
+            .borrow()) as u32)
+            == ((Option::OPT_A as i32) as u32)) as i32)
+            != 0)
+    );
+    assert!(
+        (((((*(*entries.with(Value::clone).borrow())[(2) as usize]
+            .color
+            .borrow()) as u32)
+            == ((Color::BLUE as i32) as u32)) as i32)
+            != 0)
+    );
+    assert!(
+        (((((*(*entries.with(Value::clone).borrow())[(2) as usize]
+            .opt
+            .borrow()) as u32)
+            == ((Option::OPT_C as i32) as u32)) as i32)
+            != 0)
+    );
     return 0;
 }

--- a/tests/unit/out/unsafe/anonymous_enum_c.rs
+++ b/tests/unit/out/unsafe/anonymous_enum_c.rs
@@ -101,14 +101,14 @@ unsafe fn main_0() -> i32 {
     assert!(((((anon_enum_3::FIRST_A as i32) != (anon_enum_3::FIRST_B as i32)) as i32) != 0));
     assert!(((((anon_enum_11::SECOND_A as i32) != (anon_enum_11::SECOND_B as i32)) as i32) != 0));
     assert!(((((anon_enum_31::THIRD_A as i32) != (anon_enum_31::THIRD_B as i32)) as i32) != 0));
-    let mut td: TdEnum = TdEnum::from((TdEnum::TD_A as i32));
+    let mut td: TdEnum = TdEnum::TD_A;
     assert!(((((td as u32) == ((TdEnum::TD_A as i32) as u32)) as i32) != 0));
-    td = (TdEnum::from((TdEnum::TD_B as i32))).clone();
+    td = (TdEnum::TD_B).clone();
     assert!(((((td as u32) == ((TdEnum::TD_B as i32) as u32)) as i32) != 0));
     let mut w: WithAnonField = <WithAnonField>::default();
-    w.field = anon_enum_24::from((anon_enum_24::FIELD_A as i32));
+    w.field = anon_enum_24::FIELD_A;
     assert!(((((w.field as u32) == ((anon_enum_24::FIELD_A as i32) as u32)) as i32) != 0));
-    w.field = (anon_enum_24::from((anon_enum_24::FIELD_B as i32))).clone();
+    w.field = (anon_enum_24::FIELD_B).clone();
     assert!(((((w.field as u32) == ((anon_enum_24::FIELD_B as i32) as u32)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/bool_condition_enum_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_enum_c.rs
@@ -29,8 +29,8 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut code: Code = Code::from((Code::CODE_OK as i32));
-    let mut err: Code = Code::from((Code::CODE_ERR as i32));
+    let mut code: Code = Code::CODE_OK;
+    let mut err: Code = Code::CODE_ERR;
     if (code != Code::from(0)) {
         assert!((0 != 0));
     }

--- a/tests/unit/out/unsafe/bool_condition_logical_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical_c.rs
@@ -46,7 +46,7 @@ unsafe fn main_0() -> i32 {
     let mut p: *mut i32 = (&mut storage as *mut i32);
     let mut np: *mut i32 = Default::default();
     let mut u: u32 = 4_u32;
-    let mut code: Code = Code::from((Code::CODE_OK as i32));
+    let mut code: Code = Code::CODE_OK;
     if ((((n != 0) && (!(p).is_null())) as i32) != 0) {
         assert!((1 != 0));
     }

--- a/tests/unit/out/unsafe/c_struct.rs
+++ b/tests/unit/out/unsafe/c_struct.rs
@@ -80,7 +80,7 @@ unsafe fn main_0() -> i32 {
     assert!((((((*b.next).value) == (1)) as i32) != 0));
     let mut c: Container = Container {
         inner: Inner { a: 5, b: 6 },
-        color: Color::from((Color::GREEN as i32)),
+        color: Color::GREEN,
         count: 42,
     };
     assert!(((((c.inner.a) == (5)) as i32) != 0));
@@ -88,7 +88,7 @@ unsafe fn main_0() -> i32 {
     assert!(((((c.color as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0));
     assert!(((((c.count) == (42)) as i32) != 0));
     let mut c2: Container = <Container>::default();
-    c2.color = Color::from((Color::BLUE as i32));
+    c2.color = Color::BLUE;
     assert!(((((c2.color as u32) == (2_u32)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/enum_int_interop.rs
+++ b/tests/unit/out/unsafe/enum_int_interop.rs
@@ -59,6 +59,33 @@ impl From<i32> for Tag {
         }
     }
 }
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct Entry {
+    pub name: *const u8,
+    pub color: Color,
+    pub opt: Option,
+}
+pub static mut global_color: Color = Color::GREEN;
+pub static mut global_opt: Option = Option::OPT_B;
+pub static mut global_tag: Tag = Tag::TAG_TWO;
+pub static mut entries: [Entry; 3] = [
+    Entry {
+        name: b"first\0".as_ptr(),
+        color: Color::RED,
+        opt: Option::OPT_NONE,
+    },
+    Entry {
+        name: b"second\0".as_ptr(),
+        color: Color::GREEN,
+        opt: Option::OPT_A,
+    },
+    Entry {
+        name: b"third\0".as_ptr(),
+        color: Color::BLUE,
+        opt: Option::OPT_C,
+    },
+];
 pub unsafe fn as_int_0(mut c: Color) -> i32 {
     return (c as i32);
 }
@@ -178,5 +205,14 @@ unsafe fn main_0() -> i32 {
     };
     let mut extra: i32 = (((Color::RED as i32) + (Color::GREEN as i32)) + (Color::BLUE as i32));
     assert!(((extra) == (((0) + (1)) + (2))));
+    assert!(((global_color as i32) == (Color::GREEN as i32)));
+    assert!(((global_opt as i32) == (Option::OPT_B as i32)));
+    assert!(((global_tag as i32) == (Tag::TAG_TWO as i32)));
+    assert!(((entries[(0) as usize].color as i32) == (Color::RED as i32)));
+    assert!(((entries[(0) as usize].opt as i32) == (Option::OPT_NONE as i32)));
+    assert!(((entries[(1) as usize].color as i32) == (Color::GREEN as i32)));
+    assert!(((entries[(1) as usize].opt as i32) == (Option::OPT_A as i32)));
+    assert!(((entries[(2) as usize].color as i32) == (Color::BLUE as i32)));
+    assert!(((entries[(2) as usize].opt as i32) == (Option::OPT_C as i32)));
     return 0;
 }

--- a/tests/unit/out/unsafe/enum_int_interop_c.rs
+++ b/tests/unit/out/unsafe/enum_int_interop_c.rs
@@ -59,6 +59,33 @@ impl From<i32> for Tag {
         }
     }
 }
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct Entry {
+    pub name: *const u8,
+    pub color: Color,
+    pub opt: Option,
+}
+pub static mut global_color: Color = Color::GREEN;
+pub static mut global_opt: Option = Option::OPT_B;
+pub static mut global_tag: Tag = Tag::TAG_TWO;
+pub static mut entries: [Entry; 3] = [
+    Entry {
+        name: b"first\0".as_ptr().cast_mut().cast_const(),
+        color: Color::RED,
+        opt: Option::OPT_NONE,
+    },
+    Entry {
+        name: b"second\0".as_ptr().cast_mut().cast_const(),
+        color: Color::GREEN,
+        opt: Option::OPT_A,
+    },
+    Entry {
+        name: b"third\0".as_ptr().cast_mut().cast_const(),
+        color: Color::BLUE,
+        opt: Option::OPT_C,
+    },
+];
 pub unsafe fn as_int_0(mut c: Color) -> i32 {
     return (c as i32);
 }
@@ -94,7 +121,7 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut c: Color = Color::from((Color::RED as i32));
+    let mut c: Color = Color::RED;
     assert!(((((c as u32) == ((Color::RED as i32) as u32)) as i32) != 0));
     assert!(((((c as u32) == (0_u32)) as i32) != 0));
     assert!(((((c as u32) != (1_u32)) as i32) != 0));
@@ -132,7 +159,7 @@ unsafe fn main_0() -> i32 {
     assert!(((((c as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0));
     let mut cmp: Color = Color::from(((c as u32).wrapping_add(1_u32)) as i32);
     assert!(((((cmp as u32) == ((Color::BLUE as i32) as u32)) as i32) != 0));
-    let mut o: Option = Option::from((Option::OPT_A as i32));
+    let mut o: Option = Option::OPT_A;
     assert!(((((o as u32) == ((Option::OPT_A as i32) as u32)) as i32) != 0));
     assert!(((((o as u32) == (10_u32)) as i32) != 0));
     let mut oi: i32 = (o as i32);
@@ -154,7 +181,7 @@ unsafe fn main_0() -> i32 {
         classify_option_1(_option)
     });
     assert!(((((rc) == (3)) as i32) != 0));
-    let mut t: Tag = Tag::from((Tag::TAG_ONE as i32));
+    let mut t: Tag = Tag::TAG_ONE;
     assert!(((((t as u32) == (1_u32)) as i32) != 0));
     assert!(((((t as u32) == ((Tag::TAG_ONE as i32) as u32)) as i32) != 0));
     let mut ti: i32 = (t as i32);
@@ -178,5 +205,24 @@ unsafe fn main_0() -> i32 {
     };
     let mut extra: i32 = (((Color::RED as i32) + (Color::GREEN as i32)) + (Color::BLUE as i32));
     assert!(((((extra) == (((0) + (1)) + (2))) as i32) != 0));
+    assert!(((((global_color as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0));
+    assert!(((((global_opt as u32) == ((Option::OPT_B as i32) as u32)) as i32) != 0));
+    assert!(((((global_tag as u32) == ((Tag::TAG_TWO as i32) as u32)) as i32) != 0));
+    assert!(((((entries[(0) as usize].color as u32) == ((Color::RED as i32) as u32)) as i32) != 0));
+    assert!(
+        ((((entries[(0) as usize].opt as u32) == ((Option::OPT_NONE as i32) as u32)) as i32) != 0)
+    );
+    assert!(
+        ((((entries[(1) as usize].color as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0)
+    );
+    assert!(
+        ((((entries[(1) as usize].opt as u32) == ((Option::OPT_A as i32) as u32)) as i32) != 0)
+    );
+    assert!(
+        ((((entries[(2) as usize].color as u32) == ((Color::BLUE as i32) as u32)) as i32) != 0)
+    );
+    assert!(
+        ((((entries[(2) as usize].opt as u32) == ((Option::OPT_C as i32) as u32)) as i32) != 0)
+    );
     return 0;
 }

--- a/tests/unit/out/unsafe/union_tagged_many_arms.rs
+++ b/tests/unit/out/unsafe/union_tagged_many_arms.rs
@@ -54,24 +54,24 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut a: Slot = <Slot>::default();
-    a.tag = Tag::from((Tag::T_NUM_S as i32));
+    a.tag = Tag::T_NUM_S;
     a.payload.signed_n = (-7_i32 as i64);
     assert!(((((a.payload.signed_n) == (-7_i32 as i64)) as i32) != 0));
     let mut b: Slot = <Slot>::default();
-    b.tag = Tag::from((Tag::T_NUM_U as i32));
+    b.tag = Tag::T_NUM_U;
     b.payload.unsigned_n = 3735928559_u64;
     assert!(((((b.payload.unsigned_n) == (3735928559_u64)) as i32) != 0));
     let mut c: Slot = <Slot>::default();
-    c.tag = Tag::from((Tag::T_TEXT as i32));
+    c.tag = Tag::T_TEXT;
     c.payload.text = b"hello\0".as_ptr().cast_mut().cast_const();
     assert!((((((*c.payload.text.offset((0) as isize)) as i32) == ('h' as i32)) as i32) != 0));
     let mut d: Slot = <Slot>::default();
-    d.tag = Tag::from((Tag::T_FLOAT as i32));
+    d.tag = Tag::T_FLOAT;
     d.payload.f = 1.5E+0;
     assert!(((((d.payload.f) == (1.5E+0)) as i32) != 0));
     let mut x: i32 = 0;
     let mut e: Slot = <Slot>::default();
-    e.tag = Tag::from((Tag::T_REF as i32));
+    e.tag = Tag::T_REF;
     e.payload.handle = ((&mut x as *mut i32) as *mut i32 as *mut ::libc::c_void);
     assert!(
         ((((e.payload.handle) == ((&mut x as *mut i32) as *mut i32 as *mut ::libc::c_void))

--- a/tests/unit/out/unsafe/union_tagged_simple.rs
+++ b/tests/unit/out/unsafe/union_tagged_simple.rs
@@ -47,13 +47,13 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut dummy: i32 = 0;
     let mut m1: Event = <Event>::default();
-    m1.kind = Kind::from((Kind::KIND_DONE as i32));
+    m1.kind = Kind::KIND_DONE;
     m1.handle = ((&mut dummy as *mut i32) as *mut i32 as *mut ::libc::c_void);
     m1.payload.code = 42;
     assert!(((((m1.kind as u32) == ((Kind::KIND_DONE as i32) as u32)) as i32) != 0));
     assert!(((((m1.payload.code) == (42)) as i32) != 0));
     let mut m2: Event = <Event>::default();
-    m2.kind = Kind::from((Kind::KIND_NONE as i32));
+    m2.kind = Kind::KIND_NONE;
     m2.handle = ((&mut dummy as *mut i32) as *mut i32 as *mut ::libc::c_void);
     m2.payload.obj = ((&mut dummy as *mut i32) as *mut i32 as *mut ::libc::c_void);
     assert!(

--- a/tests/unit/out/unsafe/union_tagged_struct_arms.rs
+++ b/tests/unit/out/unsafe/union_tagged_struct_arms.rs
@@ -78,7 +78,7 @@ unsafe fn main_0() -> i32 {
         b"c\0".as_ptr().cast_mut(),
     ];;
     let mut p_list: Branch = <Branch>::default();
-    p_list.choice = Choice::from((Choice::C_LIST as i32));
+    p_list.choice = Choice::C_LIST;
     p_list.index = 0;
     p_list.v.list.items = items.as_mut_ptr();
     p_list.v.list.count = 3_i64;
@@ -90,7 +90,7 @@ unsafe fn main_0() -> i32 {
             != 0)
     );
     let mut p_letters: Branch = <Branch>::default();
-    p_letters.choice = Choice::from((Choice::C_LETTERS as i32));
+    p_letters.choice = Choice::C_LETTERS;
     p_letters.index = 1;
     p_letters.v.letters.lo = ('a' as i32);
     p_letters.v.letters.hi = ('z' as i32);
@@ -98,7 +98,7 @@ unsafe fn main_0() -> i32 {
     p_letters.v.letters.step = 1_u8;
     assert!((((((p_letters.v.letters.hi) - (p_letters.v.letters.lo)) == (25)) as i32) != 0));
     let mut p_integers: Branch = <Branch>::default();
-    p_integers.choice = Choice::from((Choice::C_INTEGERS as i32));
+    p_integers.choice = Choice::C_INTEGERS;
     p_integers.index = 2;
     p_integers.v.integers.lo = 1_i64;
     p_integers.v.integers.hi = 100_i64;

--- a/tests/unit/out/unsafe/union_void_ptr_sized_deref.rs
+++ b/tests/unit/out/unsafe/union_void_ptr_sized_deref.rs
@@ -72,7 +72,7 @@ unsafe fn main_0() -> i32 {
     let mut buf32: i32 = 0;
     let mut buf16: i16 = 0_i16;
     let mut s: Sink = <Sink>::default();
-    s.width = Width::from((Width::W_64 as i32));
+    s.width = Width::W_64;
     s.out.handle = ((&mut buf64 as *mut i64) as *mut i64 as *mut ::libc::c_void);
     (unsafe {
         let _s: *mut Sink = (&mut s as *mut Sink);
@@ -80,7 +80,7 @@ unsafe fn main_0() -> i32 {
         write_count_0(_s, _count)
     });
     assert!(((((buf64) == (1234605616436508552_i64)) as i32) != 0));
-    s.width = Width::from((Width::W_32 as i32));
+    s.width = Width::W_32;
     s.out.handle = ((&mut buf32 as *mut i32) as *mut i32 as *mut ::libc::c_void);
     (unsafe {
         let _s: *mut Sink = (&mut s as *mut Sink);
@@ -88,7 +88,7 @@ unsafe fn main_0() -> i32 {
         write_count_0(_s, _count)
     });
     assert!(((((buf32) == (305419896)) as i32) != 0));
-    s.width = Width::from((Width::W_16 as i32));
+    s.width = Width::W_16;
     s.out.handle = ((&mut buf16 as *mut i16) as *mut i16 as *mut ::libc::c_void);
     (unsafe {
         let _s: *mut Sink = (&mut s as *mut Sink);


### PR DESCRIPTION
Previously, in C, enums were initialized with the `Enum::from(X as i32)` pattern because enum variants are represented as int and the type of variable is represented as enum.

The From trait is not allowed in global context because it's non-const. This PR fixes this by short-circuiting `ConvertIntegerToEnumeralCast` to emit `X` instead of `Enum::from(X as i32)`