### PR TITLE
Add Sync trait on structs used in globals

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -3485,8 +3485,8 @@ void Converter::AddSyncTrait(const clang::RecordDecl *decl) {
     return;
   }
 
-  StrCat("\n// SAFETY: preserves unsafe C semantics; thread-safety is the "
-         "programmer's responsibility\n");
+  StrCat("\n// SAFETY: preserves unsafe C semantics; thread-safety is not "
+         "enforced\n");
   StrCat("unsafe impl Sync for", GetRecordName(decl));
   PushBrace brace(*this);
 }

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -688,6 +688,7 @@ void Converter::EmitRustStructOrUnion(clang::RecordDecl *decl) {
   }
   AddDefaultTrait(decl);
   AddByteReprTrait(decl);
+  AddSyncTrait(decl);
 }
 
 bool Converter::VisitCXXRecordDecl(clang::CXXRecordDecl *decl) {
@@ -3469,6 +3470,26 @@ void Converter::AddDefaultTrait(const clang::RecordDecl *decl) {
 }
 
 void Converter::AddByteReprTrait(const clang::RecordDecl *decl) {}
+
+static bool recordImplementsSync(const clang::RecordDecl *decl) {
+  for (auto field : decl->fields()) {
+    if (field->getType()->isPointerType()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void Converter::AddSyncTrait(const clang::RecordDecl *decl) {
+  if (!recordImplementsSync(decl)) {
+    return;
+  }
+
+  StrCat("\n// SAFETY: preserves unsafe C semantics; thread-safety is the "
+         "programmer's responsibility\n");
+  StrCat("unsafe impl Sync for", GetRecordName(decl));
+  PushBrace brace(*this);
+}
 
 void Converter::ConvertUnsignedArithBinaryOperator(clang::BinaryOperator *op,
                                                    clang::Expr *expr) {

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -466,6 +466,8 @@ protected:
 
   virtual void AddByteReprTrait(const clang::RecordDecl *decl);
 
+  virtual void AddSyncTrait(const clang::RecordDecl *decl);
+
   virtual void
   ConvertUnsignedArithBinaryOperator(clang::BinaryOperator *binary_operator,
                                      clang::Expr *expr);

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -503,6 +503,8 @@ void ConverterRefCount::AddByteReprTrait(const clang::RecordDecl *decl) {
   PushBrace brace(*this);
 }
 
+void ConverterRefCount::AddSyncTrait(const clang::RecordDecl *decl) {}
+
 std::string
 ConverterRefCount::GetSelfMaybeWithMut(const clang::CXXMethodDecl *decl) {
   return "&self";

--- a/cpp2rust/converter/models/converter_refcount.h
+++ b/cpp2rust/converter/models/converter_refcount.h
@@ -39,6 +39,8 @@ public:
 
   void AddByteReprTrait(const clang::RecordDecl *decl) override;
 
+  void AddSyncTrait(const clang::RecordDecl *decl) override;
+
   void AddDefaultTrait(const clang::RecordDecl *decl) override;
 
   void AddDefaultTraitForUnion(const clang::RecordDecl *decl) override;

--- a/tests/benchmarks/out/unsafe/bfs.rs
+++ b/tests/benchmarks/out/unsafe/bfs.rs
@@ -36,12 +36,16 @@ impl Queue {
         return ((self.back) == (0_u64));
     }
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for Queue {}
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct GraphNode {
     pub vertex: u32,
     pub next: *mut GraphNode,
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for GraphNode {}
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Graph {
@@ -60,6 +64,8 @@ impl Graph {
         })) as *mut GraphNode);
     }
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for Graph {}
 pub unsafe fn BFS_0(graph: *const Graph, mut start_vertex: u32) -> *mut u32 {
     let mut Q: Queue = Queue {
         elems: Box::leak(

--- a/tests/benchmarks/out/unsafe/bst.rs
+++ b/tests/benchmarks/out/unsafe/bst.rs
@@ -13,6 +13,8 @@ pub struct node_t {
     pub right: *mut node_t,
     pub value: i32,
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for node_t {}
 pub unsafe fn find_0(mut node: *mut node_t, mut value: i32) -> *mut node_t {
     if ((value) < ((*node).value)) && (!(((*node).left).is_null())) {
         return (unsafe {

--- a/tests/unit/out/refcount/send_sync_in_statics.rs
+++ b/tests/unit/out/refcount/send_sync_in_statics.rs
@@ -1,0 +1,58 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+#[derive(Default)]
+pub struct Entry {
+    pub name: Value<Ptr<u8>>,
+    pub p: Value<Ptr<i32>>,
+}
+impl Clone for Entry {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            name: Rc::new(RefCell::new((*self.name.borrow()).clone())),
+            p: Rc::new(RefCell::new((*self.p.borrow()).clone())),
+        };
+        this
+    }
+}
+impl ByteRepr for Entry {}
+thread_local!(
+    pub static single_entry: Value<Entry> = Rc::new(RefCell::new(Entry {
+        name: Rc::new(RefCell::new(Ptr::from_string_literal("alone"))),
+        p: Rc::new(RefCell::new(Default::default())),
+    }));
+);
+thread_local!(
+    pub static entries: Value<Box<[Entry]>> = Rc::new(RefCell::new(Box::new([
+        Entry {
+            name: Rc::new(RefCell::new(Ptr::from_string_literal("first"))),
+            p: Rc::new(RefCell::new(Default::default())),
+        },
+        Entry {
+            name: Rc::new(RefCell::new(Ptr::from_string_literal("second"))),
+            p: Rc::new(RefCell::new(Default::default())),
+        },
+    ])));
+);
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!((*(*single_entry.with(Value::clone).borrow()).p.borrow()).is_null());
+    let i: Value<i32> = Rc::new(RefCell::new(0));
+    'loop_: while ((*i.borrow()) < 2) {
+        assert!(
+            (*(*entries.with(Value::clone).borrow())[(*i.borrow()) as usize]
+                .p
+                .borrow())
+            .is_null()
+        );
+        (*i.borrow_mut()).prefix_inc();
+    }
+    return 0;
+}

--- a/tests/unit/out/unsafe/10_struct.rs
+++ b/tests/unit/out/unsafe/10_struct.rs
@@ -12,6 +12,8 @@ pub struct GraphNode {
     pub dst: u32,
     pub next: *mut GraphNode,
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for GraphNode {}
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Graph {
@@ -30,6 +32,8 @@ impl Graph {
         })) as *mut GraphNode);
     }
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for Graph {}
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);

--- a/tests/unit/out/unsafe/bool_condition_logical_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical_c.rs
@@ -46,7 +46,7 @@ unsafe fn main_0() -> i32 {
     let mut p: *mut i32 = (&mut storage as *mut i32);
     let mut np: *mut i32 = std::ptr::null_mut();
     let mut u: u32 = 4_u32;
-    let mut code: Code = Code::CODE_OK;
+    let mut code: Code = Code::from((Code::CODE_OK as i32));
     if ((((n != 0) && (!(p).is_null())) as i32) != 0) {
         assert!((1 != 0));
     }

--- a/tests/unit/out/unsafe/bool_condition_logical_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical_c.rs
@@ -46,7 +46,7 @@ unsafe fn main_0() -> i32 {
     let mut p: *mut i32 = (&mut storage as *mut i32);
     let mut np: *mut i32 = std::ptr::null_mut();
     let mut u: u32 = 4_u32;
-    let mut code: Code = Code::from((Code::CODE_OK as i32));
+    let mut code: Code = Code::CODE_OK;
     if ((((n != 0) && (!(p).is_null())) as i32) != 0) {
         assert!((1 != 0));
     }

--- a/tests/unit/out/unsafe/bst.rs
+++ b/tests/unit/out/unsafe/bst.rs
@@ -13,6 +13,8 @@ pub struct node_t {
     pub right: *mut node_t,
     pub value: i32,
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for node_t {}
 pub unsafe fn find_0(mut node: *mut node_t, mut value: i32) -> *mut node_t {
     if ((value) < ((*node).value)) && (!(((*node).left).is_null())) {
         return (unsafe {

--- a/tests/unit/out/unsafe/c_struct.rs
+++ b/tests/unit/out/unsafe/c_struct.rs
@@ -82,7 +82,7 @@ unsafe fn main_0() -> i32 {
     assert!((((((*b.next).value) == (1)) as i32) != 0));
     let mut c: Container = Container {
         inner: Inner { a: 5, b: 6 },
-        color: Color::from((Color::GREEN as i32)),
+        color: Color::GREEN,
         count: 42,
     };
     assert!(((((c.inner.a) == (5)) as i32) != 0));
@@ -90,7 +90,7 @@ unsafe fn main_0() -> i32 {
     assert!(((((c.color as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0));
     assert!(((((c.count) == (42)) as i32) != 0));
     let mut c2: Container = <Container>::default();
-    c2.color = Color::from((Color::BLUE as i32));
+    c2.color = Color::BLUE;
     assert!(((((c2.color as u32) == (2_u32)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/c_struct.rs
+++ b/tests/unit/out/unsafe/c_struct.rs
@@ -24,6 +24,8 @@ pub struct Node {
     pub value: i32,
     pub next: *mut Node,
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for Node {}
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Color {
     #[default]

--- a/tests/unit/out/unsafe/c_struct.rs
+++ b/tests/unit/out/unsafe/c_struct.rs
@@ -80,7 +80,7 @@ unsafe fn main_0() -> i32 {
     assert!((((((*b.next).value) == (1)) as i32) != 0));
     let mut c: Container = Container {
         inner: Inner { a: 5, b: 6 },
-        color: Color::GREEN,
+        color: Color::from((Color::GREEN as i32)),
         count: 42,
     };
     assert!(((((c.inner.a) == (5)) as i32) != 0));
@@ -88,7 +88,7 @@ unsafe fn main_0() -> i32 {
     assert!(((((c.color as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0));
     assert!(((((c.count) == (42)) as i32) != 0));
     let mut c2: Container = <Container>::default();
-    c2.color = Color::BLUE;
+    c2.color = Color::from((Color::BLUE as i32));
     assert!(((((c2.color as u32) == (2_u32)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/clone_vs_move.rs
+++ b/tests/unit/out/unsafe/clone_vs_move.rs
@@ -31,6 +31,8 @@ impl Default for Foo {
         }
     }
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for Foo {}
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);

--- a/tests/unit/out/unsafe/complex_function.rs
+++ b/tests/unit/out/unsafe/complex_function.rs
@@ -40,6 +40,8 @@ impl X3 {
         return self.v;
     }
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for X3 {}
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct X4 {

--- a/tests/unit/out/unsafe/default.rs
+++ b/tests/unit/out/unsafe/default.rs
@@ -26,6 +26,8 @@ impl Default for Pointers {
         }
     }
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for Pointers {}
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);

--- a/tests/unit/out/unsafe/enum_int_interop.rs
+++ b/tests/unit/out/unsafe/enum_int_interop.rs
@@ -66,6 +66,8 @@ pub struct Entry {
     pub color: Color,
     pub opt: Option,
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for Entry {}
 pub static mut global_color: Color = Color::GREEN;
 pub static mut global_opt: Option = Option::OPT_B;
 pub static mut global_tag: Tag = Tag::TAG_TWO;

--- a/tests/unit/out/unsafe/enum_int_interop_c.rs
+++ b/tests/unit/out/unsafe/enum_int_interop_c.rs
@@ -66,6 +66,8 @@ pub struct Entry {
     pub color: Color,
     pub opt: Option,
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for Entry {}
 pub static mut global_color: Color = Color::GREEN;
 pub static mut global_opt: Option = Option::OPT_B;
 pub static mut global_tag: Tag = Tag::TAG_TWO;

--- a/tests/unit/out/unsafe/exprs.rs
+++ b/tests/unit/out/unsafe/exprs.rs
@@ -25,6 +25,8 @@ impl Y {
         return (&mut self.x as *mut X);
     }
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for Y {}
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);

--- a/tests/unit/out/unsafe/fn_ptr_cast.rs
+++ b/tests/unit/out/unsafe/fn_ptr_cast.rs
@@ -49,6 +49,8 @@ pub unsafe fn test_double_cast_2() {
 pub struct Command {
     pub data: *mut ::libc::c_void,
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for Command {}
 pub unsafe fn test_void_ptr_to_fn_3() {
     let mut cmd: Command = <Command>::default();
     cmd.data = std::mem::transmute::<Option<unsafe fn(i32) -> i32>, *mut ::libc::c_void>(Some(

--- a/tests/unit/out/unsafe/fn_ptr_struct.rs
+++ b/tests/unit/out/unsafe/fn_ptr_struct.rs
@@ -20,6 +20,8 @@ impl Default for Handler {
         }
     }
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for Handler {}
 pub unsafe fn double_it_0(mut x: i32) -> i32 {
     return ((x) * (2));
 }

--- a/tests/unit/out/unsafe/fn_ptr_vtable.rs
+++ b/tests/unit/out/unsafe/fn_ptr_vtable.rs
@@ -22,6 +22,8 @@ impl Default for Vtable {
         }
     }
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for Vtable {}
 pub static mut storage: i32 = 0_i32;
 pub unsafe fn int_create_0(mut val: i32) -> *mut ::libc::c_void {
     storage = val;

--- a/tests/unit/out/unsafe/huffman.rs
+++ b/tests/unit/out/unsafe/huffman.rs
@@ -19,6 +19,8 @@ impl MinHeapNode {
         return ((self.left).is_null()) && ((self.right).is_null());
     }
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for MinHeapNode {}
 pub unsafe fn Swap_0(a: *mut MinHeapNode, b: *mut MinHeapNode) {
     let mut t: MinHeapNode = MinHeapNode {
         data: (*a).data,

--- a/tests/unit/out/unsafe/linked_list.rs
+++ b/tests/unit/out/unsafe/linked_list.rs
@@ -17,6 +17,8 @@ impl Node {
         self.next = next;
     }
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for Node {}
 pub unsafe fn Find_0(mut head: *mut Node, mut idx: i32) -> *mut Node {
     let mut curr: *mut Node = head;
     let mut i: i32 = 0;

--- a/tests/unit/out/unsafe/new_bst.rs
+++ b/tests/unit/out/unsafe/new_bst.rs
@@ -13,6 +13,8 @@ pub struct node_t {
     pub right: *mut node_t,
     pub value: i32,
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for node_t {}
 pub unsafe fn find_0(mut node: *mut node_t, mut value: i32) -> *mut node_t {
     if ((value) < ((*node).value)) && (!(((*node).left).is_null())) {
         return (unsafe {

--- a/tests/unit/out/unsafe/push_emplace_back.rs
+++ b/tests/unit/out/unsafe/push_emplace_back.rs
@@ -17,6 +17,8 @@ pub struct Writer {
     pub output: *mut Vec<Chunk>,
     pub chunk: Chunk,
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for Writer {}
 #[repr(C)]
 #[derive(Clone, Default)]
 pub struct JPEGData {

--- a/tests/unit/out/unsafe/random.rs
+++ b/tests/unit/out/unsafe/random.rs
@@ -50,6 +50,8 @@ impl Default for Pair {
         }
     }
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for Pair {}
 pub unsafe fn zero_0() -> i32 {
     return 0;
 }

--- a/tests/unit/out/unsafe/send_sync_in_statics.rs
+++ b/tests/unit/out/unsafe/send_sync_in_statics.rs
@@ -12,7 +12,7 @@ pub struct Entry {
     pub name: *const u8,
     pub p: *mut i32,
 }
-// SAFETY: preserves unsafe C semantics; thread-safety is the programmer's responsibility
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
 unsafe impl Sync for Entry {}
 pub static single_entry: Entry = Entry {
     name: b"alone\0".as_ptr(),

--- a/tests/unit/out/unsafe/send_sync_in_statics.rs
+++ b/tests/unit/out/unsafe/send_sync_in_statics.rs
@@ -1,0 +1,44 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct Entry {
+    pub name: *const u8,
+    pub p: *mut i32,
+}
+// SAFETY: preserves unsafe C semantics; thread-safety is the programmer's responsibility
+unsafe impl Sync for Entry {}
+pub static single_entry: Entry = Entry {
+    name: b"alone\0".as_ptr(),
+    p: std::ptr::null_mut(),
+};
+pub static entries: [Entry; 2] = [
+    Entry {
+        name: b"first\0".as_ptr(),
+        p: std::ptr::null_mut(),
+    },
+    Entry {
+        name: b"second\0".as_ptr(),
+        p: std::ptr::null_mut(),
+    },
+];
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!((single_entry.p).is_null());
+    let mut i: i32 = 0;
+    'loop_: while ((i) < (2)) {
+        assert!((entries[(i) as usize].p).is_null());
+        i.prefix_inc();
+    }
+    return 0;
+}

--- a/tests/unit/out/unsafe/union_field_alignment.rs
+++ b/tests/unit/out/unsafe/union_field_alignment.rs
@@ -17,12 +17,16 @@ impl Default for node_anon_0 {
         unsafe { std::mem::zeroed() }
     }
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for node_anon_0 {}
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct node {
     pub next: *mut node,
     pub x: node_anon_0,
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for node {}
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);

--- a/tests/unit/out/unsafe/union_pointer_pun_address.rs
+++ b/tests/unit/out/unsafe/union_pointer_pun_address.rs
@@ -17,6 +17,8 @@ pub struct node_b {
     pub data: *mut ::libc::c_void,
     pub next: *mut node_b,
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for node_b {}
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
@@ -34,7 +36,9 @@ unsafe fn main_0() -> i32 {
         fn default() -> Self {
             unsafe { std::mem::zeroed() }
         }
-    };
+    }
+    // SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+    unsafe impl Sync for anon_0 {};
     let mut ptr: anon_0 = <anon_0>::default();
     ptr.to_a = (&mut a as *mut node_a);
     let mut out: *mut node_b = ptr.to_b;

--- a/tests/unit/out/unsafe/union_pointer_pun_writethrough.rs
+++ b/tests/unit/out/unsafe/union_pointer_pun_writethrough.rs
@@ -23,7 +23,9 @@ unsafe fn main_0() -> i32 {
         fn default() -> Self {
             unsafe { std::mem::zeroed() }
         }
-    };
+    }
+    // SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+    unsafe impl Sync for anon_0 {};
     let mut pp: anon_0 = <anon_0>::default();
     pp.as_signed = (&mut x as *mut i64);
     (*pp.as_unsigned) = 42_u64;

--- a/tests/unit/out/unsafe/union_tagged_many_arms.rs
+++ b/tests/unit/out/unsafe/union_tagged_many_arms.rs
@@ -41,6 +41,8 @@ impl Default for Slot_anon_0 {
         unsafe { std::mem::zeroed() }
     }
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for Slot_anon_0 {}
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Slot {
@@ -54,24 +56,24 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut a: Slot = <Slot>::default();
-    a.tag = Tag::T_NUM_S;
+    a.tag = Tag::from((Tag::T_NUM_S as i32));
     a.payload.signed_n = (-7_i32 as i64);
     assert!(((((a.payload.signed_n) == (-7_i32 as i64)) as i32) != 0));
     let mut b: Slot = <Slot>::default();
-    b.tag = Tag::T_NUM_U;
+    b.tag = Tag::from((Tag::T_NUM_U as i32));
     b.payload.unsigned_n = 3735928559_u64;
     assert!(((((b.payload.unsigned_n) == (3735928559_u64)) as i32) != 0));
     let mut c: Slot = <Slot>::default();
-    c.tag = Tag::T_TEXT;
+    c.tag = Tag::from((Tag::T_TEXT as i32));
     c.payload.text = b"hello\0".as_ptr().cast_mut().cast_const();
     assert!((((((*c.payload.text.offset((0) as isize)) as i32) == ('h' as i32)) as i32) != 0));
     let mut d: Slot = <Slot>::default();
-    d.tag = Tag::T_FLOAT;
+    d.tag = Tag::from((Tag::T_FLOAT as i32));
     d.payload.f = 1.5E+0;
     assert!(((((d.payload.f) == (1.5E+0)) as i32) != 0));
     let mut x: i32 = 0;
     let mut e: Slot = <Slot>::default();
-    e.tag = Tag::T_REF;
+    e.tag = Tag::from((Tag::T_REF as i32));
     e.payload.handle = ((&mut x as *mut i32) as *mut i32 as *mut ::libc::c_void);
     assert!(
         ((((e.payload.handle) == ((&mut x as *mut i32) as *mut i32 as *mut ::libc::c_void))

--- a/tests/unit/out/unsafe/union_tagged_many_arms.rs
+++ b/tests/unit/out/unsafe/union_tagged_many_arms.rs
@@ -56,24 +56,24 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut a: Slot = <Slot>::default();
-    a.tag = Tag::from((Tag::T_NUM_S as i32));
+    a.tag = Tag::T_NUM_S;
     a.payload.signed_n = (-7_i32 as i64);
     assert!(((((a.payload.signed_n) == (-7_i32 as i64)) as i32) != 0));
     let mut b: Slot = <Slot>::default();
-    b.tag = Tag::from((Tag::T_NUM_U as i32));
+    b.tag = Tag::T_NUM_U;
     b.payload.unsigned_n = 3735928559_u64;
     assert!(((((b.payload.unsigned_n) == (3735928559_u64)) as i32) != 0));
     let mut c: Slot = <Slot>::default();
-    c.tag = Tag::from((Tag::T_TEXT as i32));
+    c.tag = Tag::T_TEXT;
     c.payload.text = b"hello\0".as_ptr().cast_mut().cast_const();
     assert!((((((*c.payload.text.offset((0) as isize)) as i32) == ('h' as i32)) as i32) != 0));
     let mut d: Slot = <Slot>::default();
-    d.tag = Tag::from((Tag::T_FLOAT as i32));
+    d.tag = Tag::T_FLOAT;
     d.payload.f = 1.5E+0;
     assert!(((((d.payload.f) == (1.5E+0)) as i32) != 0));
     let mut x: i32 = 0;
     let mut e: Slot = <Slot>::default();
-    e.tag = Tag::from((Tag::T_REF as i32));
+    e.tag = Tag::T_REF;
     e.payload.handle = ((&mut x as *mut i32) as *mut i32 as *mut ::libc::c_void);
     assert!(
         ((((e.payload.handle) == ((&mut x as *mut i32) as *mut i32 as *mut ::libc::c_void))

--- a/tests/unit/out/unsafe/union_tagged_simple.rs
+++ b/tests/unit/out/unsafe/union_tagged_simple.rs
@@ -32,6 +32,8 @@ impl Default for Event_anon_0 {
         unsafe { std::mem::zeroed() }
     }
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for Event_anon_0 {}
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Event {
@@ -39,6 +41,8 @@ pub struct Event {
     pub handle: *mut ::libc::c_void,
     pub payload: Event_anon_0,
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for Event {}
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
@@ -47,13 +51,13 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut dummy: i32 = 0;
     let mut m1: Event = <Event>::default();
-    m1.kind = Kind::KIND_DONE;
+    m1.kind = Kind::from((Kind::KIND_DONE as i32));
     m1.handle = ((&mut dummy as *mut i32) as *mut i32 as *mut ::libc::c_void);
     m1.payload.code = 42;
     assert!(((((m1.kind as u32) == ((Kind::KIND_DONE as i32) as u32)) as i32) != 0));
     assert!(((((m1.payload.code) == (42)) as i32) != 0));
     let mut m2: Event = <Event>::default();
-    m2.kind = Kind::KIND_NONE;
+    m2.kind = Kind::from((Kind::KIND_NONE as i32));
     m2.handle = ((&mut dummy as *mut i32) as *mut i32 as *mut ::libc::c_void);
     m2.payload.obj = ((&mut dummy as *mut i32) as *mut i32 as *mut ::libc::c_void);
     assert!(

--- a/tests/unit/out/unsafe/union_tagged_simple.rs
+++ b/tests/unit/out/unsafe/union_tagged_simple.rs
@@ -51,13 +51,13 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut dummy: i32 = 0;
     let mut m1: Event = <Event>::default();
-    m1.kind = Kind::from((Kind::KIND_DONE as i32));
+    m1.kind = Kind::KIND_DONE;
     m1.handle = ((&mut dummy as *mut i32) as *mut i32 as *mut ::libc::c_void);
     m1.payload.code = 42;
     assert!(((((m1.kind as u32) == ((Kind::KIND_DONE as i32) as u32)) as i32) != 0));
     assert!(((((m1.payload.code) == (42)) as i32) != 0));
     let mut m2: Event = <Event>::default();
-    m2.kind = Kind::from((Kind::KIND_NONE as i32));
+    m2.kind = Kind::KIND_NONE;
     m2.handle = ((&mut dummy as *mut i32) as *mut i32 as *mut ::libc::c_void);
     m2.payload.obj = ((&mut dummy as *mut i32) as *mut i32 as *mut ::libc::c_void);
     assert!(

--- a/tests/unit/out/unsafe/union_tagged_struct_arms.rs
+++ b/tests/unit/out/unsafe/union_tagged_struct_arms.rs
@@ -30,6 +30,8 @@ pub struct Branch_anon_0_anon_0 {
     pub count: i64,
     pub cursor: i64,
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for Branch_anon_0_anon_0 {}
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Branch_anon_0_anon_1 {
@@ -78,7 +80,7 @@ unsafe fn main_0() -> i32 {
         b"c\0".as_ptr().cast_mut(),
     ];;
     let mut p_list: Branch = <Branch>::default();
-    p_list.choice = Choice::C_LIST;
+    p_list.choice = Choice::from((Choice::C_LIST as i32));
     p_list.index = 0;
     p_list.v.list.items = items.as_mut_ptr();
     p_list.v.list.count = 3_i64;
@@ -90,7 +92,7 @@ unsafe fn main_0() -> i32 {
             != 0)
     );
     let mut p_letters: Branch = <Branch>::default();
-    p_letters.choice = Choice::C_LETTERS;
+    p_letters.choice = Choice::from((Choice::C_LETTERS as i32));
     p_letters.index = 1;
     p_letters.v.letters.lo = ('a' as i32);
     p_letters.v.letters.hi = ('z' as i32);
@@ -98,7 +100,7 @@ unsafe fn main_0() -> i32 {
     p_letters.v.letters.step = 1_u8;
     assert!((((((p_letters.v.letters.hi) - (p_letters.v.letters.lo)) == (25)) as i32) != 0));
     let mut p_integers: Branch = <Branch>::default();
-    p_integers.choice = Choice::C_INTEGERS;
+    p_integers.choice = Choice::from((Choice::C_INTEGERS as i32));
     p_integers.index = 2;
     p_integers.v.integers.lo = 1_i64;
     p_integers.v.integers.hi = 100_i64;

--- a/tests/unit/out/unsafe/union_tagged_struct_arms.rs
+++ b/tests/unit/out/unsafe/union_tagged_struct_arms.rs
@@ -80,7 +80,7 @@ unsafe fn main_0() -> i32 {
         b"c\0".as_ptr().cast_mut(),
     ];;
     let mut p_list: Branch = <Branch>::default();
-    p_list.choice = Choice::from((Choice::C_LIST as i32));
+    p_list.choice = Choice::C_LIST;
     p_list.index = 0;
     p_list.v.list.items = items.as_mut_ptr();
     p_list.v.list.count = 3_i64;
@@ -92,7 +92,7 @@ unsafe fn main_0() -> i32 {
             != 0)
     );
     let mut p_letters: Branch = <Branch>::default();
-    p_letters.choice = Choice::from((Choice::C_LETTERS as i32));
+    p_letters.choice = Choice::C_LETTERS;
     p_letters.index = 1;
     p_letters.v.letters.lo = ('a' as i32);
     p_letters.v.letters.hi = ('z' as i32);
@@ -100,7 +100,7 @@ unsafe fn main_0() -> i32 {
     p_letters.v.letters.step = 1_u8;
     assert!((((((p_letters.v.letters.hi) - (p_letters.v.letters.lo)) == (25)) as i32) != 0));
     let mut p_integers: Branch = <Branch>::default();
-    p_integers.choice = Choice::from((Choice::C_INTEGERS as i32));
+    p_integers.choice = Choice::C_INTEGERS;
     p_integers.index = 2;
     p_integers.v.integers.lo = 1_i64;
     p_integers.v.integers.hi = 100_i64;

--- a/tests/unit/out/unsafe/union_void_ptr_sized_deref.rs
+++ b/tests/unit/out/unsafe/union_void_ptr_sized_deref.rs
@@ -74,7 +74,7 @@ unsafe fn main_0() -> i32 {
     let mut buf32: i32 = 0;
     let mut buf16: i16 = 0_i16;
     let mut s: Sink = <Sink>::default();
-    s.width = Width::from((Width::W_64 as i32));
+    s.width = Width::W_64;
     s.out.handle = ((&mut buf64 as *mut i64) as *mut i64 as *mut ::libc::c_void);
     (unsafe {
         let _s: *mut Sink = (&mut s as *mut Sink);
@@ -82,7 +82,7 @@ unsafe fn main_0() -> i32 {
         write_count_0(_s, _count)
     });
     assert!(((((buf64) == (1234605616436508552_i64)) as i32) != 0));
-    s.width = Width::from((Width::W_32 as i32));
+    s.width = Width::W_32;
     s.out.handle = ((&mut buf32 as *mut i32) as *mut i32 as *mut ::libc::c_void);
     (unsafe {
         let _s: *mut Sink = (&mut s as *mut Sink);
@@ -90,7 +90,7 @@ unsafe fn main_0() -> i32 {
         write_count_0(_s, _count)
     });
     assert!(((((buf32) == (305419896)) as i32) != 0));
-    s.width = Width::from((Width::W_16 as i32));
+    s.width = Width::W_16;
     s.out.handle = ((&mut buf16 as *mut i16) as *mut i16 as *mut ::libc::c_void);
     (unsafe {
         let _s: *mut Sink = (&mut s as *mut Sink);

--- a/tests/unit/out/unsafe/union_void_ptr_sized_deref.rs
+++ b/tests/unit/out/unsafe/union_void_ptr_sized_deref.rs
@@ -36,6 +36,8 @@ impl Default for Sink_anon_0 {
         unsafe { std::mem::zeroed() }
     }
 }
+// SAFETY: preserves unsafe C semantics; thread-safety is not enforced
+unsafe impl Sync for Sink_anon_0 {}
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Sink {
@@ -72,7 +74,7 @@ unsafe fn main_0() -> i32 {
     let mut buf32: i32 = 0;
     let mut buf16: i16 = 0_i16;
     let mut s: Sink = <Sink>::default();
-    s.width = Width::W_64;
+    s.width = Width::from((Width::W_64 as i32));
     s.out.handle = ((&mut buf64 as *mut i64) as *mut i64 as *mut ::libc::c_void);
     (unsafe {
         let _s: *mut Sink = (&mut s as *mut Sink);
@@ -80,7 +82,7 @@ unsafe fn main_0() -> i32 {
         write_count_0(_s, _count)
     });
     assert!(((((buf64) == (1234605616436508552_i64)) as i32) != 0));
-    s.width = Width::W_32;
+    s.width = Width::from((Width::W_32 as i32));
     s.out.handle = ((&mut buf32 as *mut i32) as *mut i32 as *mut ::libc::c_void);
     (unsafe {
         let _s: *mut Sink = (&mut s as *mut Sink);
@@ -88,7 +90,7 @@ unsafe fn main_0() -> i32 {
         write_count_0(_s, _count)
     });
     assert!(((((buf32) == (305419896)) as i32) != 0));
-    s.width = Width::W_16;
+    s.width = Width::from((Width::W_16 as i32));
     s.out.handle = ((&mut buf16 as *mut i16) as *mut i16 as *mut ::libc::c_void);
     (unsafe {
         let _s: *mut Sink = (&mut s as *mut Sink);

--- a/tests/unit/send_sync_in_statics.cpp
+++ b/tests/unit/send_sync_in_statics.cpp
@@ -1,0 +1,22 @@
+#include <cassert>
+#include <cstddef>
+
+struct Entry {
+  const char *name;
+  int *p;
+};
+
+static const Entry single_entry = {"alone", nullptr};
+
+static const Entry entries[2] = {
+    {"first", nullptr},
+    {"second", nullptr},
+};
+
+int main() {
+  assert(single_entry.p == nullptr);
+  for (int i = 0; i < 2; ++i) {
+    assert(entries[i].p == nullptr);
+  }
+  return 0;
+}


### PR DESCRIPTION
To compile structs used in globals that contain raw pointers, we need to add the Sync marker trait.