### PR TITLE
Fix usage of extern functions accross multiple translation units

### DIFF
--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -332,19 +332,24 @@ unsigned GetAnonIndex(const clang::NamedDecl *decl) {
   return 0;
 }
 
-std::string GetID(const clang::Decl *decl) {
-  assert(decl);
-  const auto file_name = GetFileName(decl);
-  const auto line_num = GetLineNumber(decl);
-  const auto column_num = GetColumnNumber(decl);
+static std::string GetLocationID(const clang::Decl *decl) {
+  return GetFileName(decl) + std::to_string(GetLineNumber(decl)) +
+         std::to_string(GetColumnNumber(decl));
+}
+
+static std::string GetParamSignature(const clang::Decl *decl) {
   std::string args;
   if (auto fdecl = clang::dyn_cast<clang::FunctionDecl>(decl)) {
     for (unsigned i = 0; i < fdecl->getNumParams(); ++i) {
       args += fdecl->getParamDecl(i)->getType().getAsString();
     }
   }
-  return file_name + std::to_string(line_num) + std::to_string(column_num) +
-         args;
+  return args;
+}
+
+std::string GetID(const clang::Decl *decl) {
+  assert(decl);
+  return GetLocationID(decl) + GetParamSignature(decl);
 }
 
 static std::unordered_map<std::string, size_t> type_mapping;
@@ -368,7 +373,10 @@ std::string GetNamedDeclAsString(const clang::NamedDecl *decl) {
     if (!clang::isa<clang::CXXMethodDecl>(fn)) {
       auto mangled =
           clang::ASTNameGenerator(decl->getASTContext()).getName(decl) +
-          GetID(decl);
+          GetParamSignature(decl);
+      if (fn->getFormalLinkage() == clang::Linkage::Internal) {
+        mangled += GetLocationID(decl);
+      }
       auto id =
           type_mapping.try_emplace(mangled, type_mapping.size()).first->second;
       name += '_';

--- a/tests/multi-file/extern_functions/out/refcount/extern_functions.rs
+++ b/tests/multi-file/extern_functions/out/refcount/extern_functions.rs
@@ -31,7 +31,7 @@ pub fn unrelated2_2() -> i32 {
 pub fn unrelated3_3() -> i32 {
     return 3;
 }
-pub fn helper_4(x: i32) -> i32 {
+pub fn helper_0(x: i32) -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(x));
     ({ unrelated1_1() });
     ({ unrelated2_2() });

--- a/tests/multi-file/extern_functions/out/unsafe/extern_functions.rs
+++ b/tests/multi-file/extern_functions/out/unsafe/extern_functions.rs
@@ -33,7 +33,7 @@ pub unsafe fn unrelated2_2() -> i32 {
 pub unsafe fn unrelated3_3() -> i32 {
     return 3;
 }
-pub unsafe fn helper_4(mut x: i32) -> i32 {
+pub unsafe fn helper_0(mut x: i32) -> i32 {
     (unsafe { unrelated1_1() });
     (unsafe { unrelated2_2() });
     (unsafe { unrelated3_3() });

--- a/tests/multi-file/extern_functions/out/unsafe/extern_functions.rs
+++ b/tests/multi-file/extern_functions/out/unsafe/extern_functions.rs
@@ -34,8 +34,8 @@ pub unsafe fn unrelated3_3() -> i32 {
     return 3;
 }
 pub unsafe fn helper_0(mut x: i32) -> i32 {
-    (unsafe { unrelated1_1() });
-    (unsafe { unrelated2_2() });
-    (unsafe { unrelated3_3() });
+    &(unsafe { unrelated1_1() });
+    &(unsafe { unrelated2_2() });
+    &(unsafe { unrelated3_3() });
     return ((x) + (1));
 }

--- a/tests/multi-file/extern_functions/test.expectations
+++ b/tests/multi-file/extern_functions/test.expectations
@@ -1,1 +1,0 @@
-no-compile

--- a/tests/multi-file/header_function/CMakeLists.txt
+++ b/tests/multi-file/header_function/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.16)
+project(extern_functions LANGUAGES C)
+add_executable(app a.c b.c)

--- a/tests/multi-file/header_function/a.c
+++ b/tests/multi-file/header_function/a.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+
 #include "header.h"
 
 int main(void) {

--- a/tests/multi-file/header_function/a.c
+++ b/tests/multi-file/header_function/a.c
@@ -1,0 +1,7 @@
+#include <assert.h>
+#include "header.h"
+
+int main(void) {
+  assert(helper(42) == 43);
+  return 0;
+}

--- a/tests/multi-file/header_function/b.c
+++ b/tests/multi-file/header_function/b.c
@@ -1,0 +1,12 @@
+#include "header.h"
+
+static int unrelated1(void) { return 1; }
+static int unrelated2(void) { return 2; }
+static int unrelated3(void) { return 3; }
+
+int helper(int x) {
+  (void)unrelated1();
+  (void)unrelated2();
+  (void)unrelated3();
+  return x + 1;
+}

--- a/tests/multi-file/header_function/header.h
+++ b/tests/multi-file/header_function/header.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int helper(int x);

--- a/tests/multi-file/header_function/out/refcount/header_function.rs
+++ b/tests/multi-file/header_function/out/refcount/header_function.rs
@@ -1,0 +1,40 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+
+// a.rs
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (((({
+            let _x: i32 = 42;
+            helper_0(_x)
+        }) == 43) as i32)
+            != 0)
+    );
+    return 0;
+}
+// b.rs
+pub fn unrelated1_1() -> i32 {
+    return 1;
+}
+pub fn unrelated2_2() -> i32 {
+    return 2;
+}
+pub fn unrelated3_3() -> i32 {
+    return 3;
+}
+pub fn helper_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    ({ unrelated1_1() });
+    ({ unrelated2_2() });
+    ({ unrelated3_3() });
+    return ((*x.borrow()) + 1);
+}

--- a/tests/multi-file/header_function/out/unsafe/header_function.rs
+++ b/tests/multi-file/header_function/out/unsafe/header_function.rs
@@ -1,0 +1,41 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+
+// a.rs
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((((unsafe {
+            let _x: i32 = 42;
+            helper_0(_x)
+        }) == (43)) as i32)
+            != 0)
+    );
+    return 0;
+}
+// b.rs
+pub unsafe fn unrelated1_1() -> i32 {
+    return 1;
+}
+pub unsafe fn unrelated2_2() -> i32 {
+    return 2;
+}
+pub unsafe fn unrelated3_3() -> i32 {
+    return 3;
+}
+pub unsafe fn helper_0(mut x: i32) -> i32 {
+    (unsafe { unrelated1_1() });
+    (unsafe { unrelated2_2() });
+    (unsafe { unrelated3_3() });
+    return ((x) + (1));
+}

--- a/tests/multi-file/header_function/out/unsafe/header_function.rs
+++ b/tests/multi-file/header_function/out/unsafe/header_function.rs
@@ -34,8 +34,8 @@ pub unsafe fn unrelated3_3() -> i32 {
     return 3;
 }
 pub unsafe fn helper_0(mut x: i32) -> i32 {
-    (unsafe { unrelated1_1() });
-    (unsafe { unrelated2_2() });
-    (unsafe { unrelated3_3() });
+    &(unsafe { unrelated1_1() });
+    &(unsafe { unrelated2_2() });
+    &(unsafe { unrelated3_3() });
     return ((x) + (1));
 }


### PR DESCRIPTION
Do not merge yet, it depends on #69