### PR TITLE
Use &raw to get address of globals

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -3551,6 +3551,12 @@ void Converter::ConvertAddrOf(clang::Expr *expr, clang::QualType pointer_type) {
   if (IsReferenceType(expr) || pointer_type->isFunctionPointerType()) {
     PushExprKind push(*this, ExprKind::AddrOf);
     Convert(expr);
+  } else if (IsGlobalVar(expr)) {
+    StrCat("&raw", pointer_type->getPointeeType().isConstQualified()
+                       ? keyword::kConst
+                       : keyword_mut_);
+    Convert(expr);
+    ConvertCast(pointer_type);
   } else {
     StrCat(token::kRef);
     if (!pointer_type->getPointeeType().isConstQualified()) {

--- a/tests/unit/addr_of_global.cpp
+++ b/tests/unit/addr_of_global.cpp
@@ -1,0 +1,27 @@
+#include <cassert>
+
+struct Inner {
+  int value;
+};
+
+struct Outer {
+  Inner *p;
+};
+
+Inner alpha = {1};
+Inner beta = {2};
+Inner shared = {42};
+
+Inner *items[2] = {&alpha, &beta};
+Outer obj = {&shared};
+
+int main() {
+  assert(items[0]->value == 1);
+  assert(items[1]->value == 2);
+  assert(obj.p->value == 42);
+
+  static Inner *cache[2] = {&alpha, &beta};
+  assert(cache[0]->value == 1);
+  assert(cache[1]->value == 2);
+  return 0;
+}

--- a/tests/unit/out/refcount/addr_of_global.rs
+++ b/tests/unit/out/refcount/addr_of_global.rs
@@ -1,0 +1,112 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+#[derive(Default)]
+pub struct Inner {
+    pub value: Value<i32>,
+}
+impl Clone for Inner {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            value: Rc::new(RefCell::new((*self.value.borrow()))),
+        };
+        this
+    }
+}
+impl ByteRepr for Inner {}
+#[derive(Default)]
+pub struct Outer {
+    pub p: Value<Ptr<Inner>>,
+}
+impl Clone for Outer {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            p: Rc::new(RefCell::new((*self.p.borrow()).clone())),
+        };
+        this
+    }
+}
+impl ByteRepr for Outer {}
+thread_local!(
+    pub static alpha: Value<Inner> = Rc::new(RefCell::new(Inner {
+        value: Rc::new(RefCell::new(1)),
+    }));
+);
+thread_local!(
+    pub static beta: Value<Inner> = Rc::new(RefCell::new(Inner {
+        value: Rc::new(RefCell::new(2)),
+    }));
+);
+thread_local!(
+    pub static shared: Value<Inner> = Rc::new(RefCell::new(Inner {
+        value: Rc::new(RefCell::new(42)),
+    }));
+);
+thread_local!(
+    pub static items: Value<Box<[Ptr<Inner>]>> = Rc::new(RefCell::new(Box::new([
+        (alpha.with(Value::clone).as_pointer()),
+        (beta.with(Value::clone).as_pointer()),
+    ])));
+);
+thread_local!(
+    pub static obj: Value<Outer> = Rc::new(RefCell::new(Outer {
+        p: Rc::new(RefCell::new((shared.with(Value::clone).as_pointer()))),
+    }));
+);
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        ((*(*(*items.with(Value::clone).borrow())[(0) as usize]
+            .upgrade()
+            .deref())
+        .value
+        .borrow())
+            == 1)
+    );
+    assert!(
+        ((*(*(*items.with(Value::clone).borrow())[(1) as usize]
+            .upgrade()
+            .deref())
+        .value
+        .borrow())
+            == 2)
+    );
+    assert!(
+        ((*(*(*(*obj.with(Value::clone).borrow()).p.borrow())
+            .upgrade()
+            .deref())
+        .value
+        .borrow())
+            == 42)
+    );
+    thread_local!(
+        static cache: Value<Box<[Ptr<Inner>]>> = Rc::new(RefCell::new(Box::new([
+            (alpha.with(Value::clone).as_pointer()),
+            (beta.with(Value::clone).as_pointer()),
+        ])));
+    );
+    assert!(
+        ((*(*(*cache.with(Value::clone).borrow())[(0) as usize]
+            .upgrade()
+            .deref())
+        .value
+        .borrow())
+            == 1)
+    );
+    assert!(
+        ((*(*(*cache.with(Value::clone).borrow())[(1) as usize]
+            .upgrade()
+            .deref())
+        .value
+        .borrow())
+            == 2)
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/addr_of_global.rs
+++ b/tests/unit/out/unsafe/addr_of_global.rs
@@ -1,0 +1,45 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct Inner {
+    pub value: i32,
+}
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct Outer {
+    pub p: *mut Inner,
+}
+pub static mut alpha: Inner = Inner { value: 1 };
+pub static mut beta: Inner = Inner { value: 2 };
+pub static mut shared: Inner = Inner { value: 42 };
+pub static mut items: [*mut Inner; 2] = [
+    (&raw mut alpha as *mut Inner),
+    (&raw mut beta as *mut Inner),
+];
+pub static mut obj: Outer = Outer {
+    p: (&raw mut shared as *mut Inner),
+};
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!((((*items[(0) as usize]).value) == (1)));
+    assert!((((*items[(1) as usize]).value) == (2)));
+    assert!((((*obj.p).value) == (42)));
+    static mut cache: [*mut Inner; 2] = [
+        (&raw mut alpha as *mut Inner),
+        (&raw mut beta as *mut Inner),
+    ];;
+    assert!((((*cache[(0) as usize]).value) == (1)));
+    assert!((((*cache[(1) as usize]).value) == (2)));
+    return 0;
+}

--- a/tests/unit/out/unsafe/fn_ptr_vtable.rs
+++ b/tests/unit/out/unsafe/fn_ptr_vtable.rs
@@ -25,7 +25,7 @@ impl Default for Vtable {
 pub static mut storage: i32 = 0_i32;
 pub unsafe fn int_create_0(mut val: i32) -> *mut ::libc::c_void {
     storage = val;
-    return ((&mut storage as *mut i32) as *mut i32 as *mut ::libc::c_void);
+    return ((&raw mut storage as *mut i32) as *mut i32 as *mut ::libc::c_void);
 }
 pub unsafe fn int_get_1(mut p: *mut ::libc::c_void) -> i32 {
     return (*(p as *mut i32));


### PR DESCRIPTION
Globals are translated as `static mut`. Taking the address of globals using `&T as *const T` is unsafe and not allowed in const initializers. `&T` creates a reference to the `static mut`, and the Rust compiler cannot prove the soudness of this operation.

To overcome this, use `&raw const T` instead of `&T as &const T`. `&raw` simply computes the address without creating an immutable reference. 