### PR TITLE
Fix args: &[VaArg] name collision

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -1363,7 +1363,8 @@ std::optional<std::string> Converter::TryPluginConvert(clang::CallExpr *call) {
 
 void Converter::ConvertVAArgCall(clang::CallExpr *expr) {
   if (IsBuiltinVaStart(expr)) {
-    StrCat(ToString(expr->getArg(0)->IgnoreImpCasts()), "= VaList::new(args)");
+    StrCat(ToString(expr->getArg(0)->IgnoreImpCasts()),
+           "= VaList::new(__args)");
     return;
   }
   if (IsBuiltinVaEnd(expr)) {
@@ -3295,7 +3296,7 @@ void Converter::ConvertFunctionParameters(clang::FunctionDecl *decl) {
     StrCat(token::kComma);
   }
   if (decl->isVariadic()) {
-    StrCat("args: &[VaArg]", token::kComma);
+    StrCat("__args: &[VaArg]", token::kComma);
   }
   in_function_formals_ = false;
 }

--- a/tests/unit/out/refcount/va_arg_chain.rs
+++ b/tests/unit/out/refcount/va_arg_chain.rs
@@ -25,10 +25,10 @@ pub fn middle_layer_1(n: i32, ap: VaList) -> i32 {
         extract_nth_0(_n, _ap)
     });
 }
-pub fn top_level_2(n: i32, args: &[VaArg]) -> i32 {
+pub fn top_level_2(n: i32, __args: &[VaArg]) -> i32 {
     let n: Value<i32> = Rc::new(RefCell::new(n));
     let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
-    (*ap.borrow_mut()) = VaList::new(args);
+    (*ap.borrow_mut()) = VaList::new(__args);
     let result: Value<i32> = Rc::new(RefCell::new(
         ({
             let _n: i32 = (*n.borrow());

--- a/tests/unit/out/refcount/va_arg_concat.rs
+++ b/tests/unit/out/refcount/va_arg_concat.rs
@@ -6,14 +6,14 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-pub fn sum_ints_0(first: i32, args: &[VaArg]) -> i32 {
+pub fn sum_ints_0(first: i32, __args: &[VaArg]) -> i32 {
     let first: Value<i32> = Rc::new(RefCell::new(first));
-    let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
+    let args: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
     let total: Value<i32> = Rc::new(RefCell::new((*first.borrow())));
-    (*ap.borrow_mut()) = VaList::new(args);
+    (*args.borrow_mut()) = VaList::new(__args);
     let val: Value<i32> = <Value<i32>>::default();
     'loop_: while (((({
-        (*val.borrow_mut()) = ((*ap.borrow_mut()).arg::<i32>()).clone();
+        (*val.borrow_mut()) = ((*args.borrow_mut()).arg::<i32>()).clone();
         (*val.borrow())
     }) != 0) as i32)
         != 0)

--- a/tests/unit/out/refcount/va_arg_conditional.rs
+++ b/tests/unit/out/refcount/va_arg_conditional.rs
@@ -6,12 +6,12 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-pub fn conditional_log_0(verbose: i32, fmt: Ptr<u8>, args: &[VaArg]) -> i32 {
+pub fn conditional_log_0(verbose: i32, fmt: Ptr<u8>, __args: &[VaArg]) -> i32 {
     let verbose: Value<i32> = Rc::new(RefCell::new(verbose));
     let fmt: Value<Ptr<u8>> = Rc::new(RefCell::new(fmt));
     if ((*verbose.borrow()) != 0) {
         let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
-        (*ap.borrow_mut()) = VaList::new(args);
+        (*ap.borrow_mut()) = VaList::new(__args);
         let result: Value<i32> = Rc::new(RefCell::new(((*ap.borrow_mut()).arg::<i32>()).clone()));
         return (*result.borrow());
     }

--- a/tests/unit/out/refcount/va_arg_copy.rs
+++ b/tests/unit/out/refcount/va_arg_copy.rs
@@ -6,11 +6,11 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-pub fn sum_with_copy_0(count: i32, args: &[VaArg]) -> i32 {
+pub fn sum_with_copy_0(count: i32, __args: &[VaArg]) -> i32 {
     let count: Value<i32> = Rc::new(RefCell::new(count));
     let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
     let aq: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
-    (*ap.borrow_mut()) = VaList::new(args);
+    (*ap.borrow_mut()) = VaList::new(__args);
     (*aq.borrow_mut()) = (*ap.borrow_mut()).clone();
     let sum1: Value<i32> = Rc::new(RefCell::new(0));
     let i: Value<i32> = Rc::new(RefCell::new(0));

--- a/tests/unit/out/refcount/va_arg_forward.rs
+++ b/tests/unit/out/refcount/va_arg_forward.rs
@@ -17,10 +17,10 @@ pub fn inner_0(count: i32, ap: VaList) -> i32 {
     }
     return (*total.borrow());
 }
-pub fn outer_1(count: i32, args: &[VaArg]) -> i32 {
+pub fn outer_1(count: i32, __args: &[VaArg]) -> i32 {
     let count: Value<i32> = Rc::new(RefCell::new(count));
     let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
-    (*ap.borrow_mut()) = VaList::new(args);
+    (*ap.borrow_mut()) = VaList::new(__args);
     let result: Value<i32> = Rc::new(RefCell::new(
         ({
             let _count: i32 = (*count.borrow());

--- a/tests/unit/out/refcount/va_arg_mixed_int_ptr.rs
+++ b/tests/unit/out/refcount/va_arg_mixed_int_ptr.rs
@@ -6,10 +6,10 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-pub fn mixed_args_0(count: i32, args: &[VaArg]) -> i32 {
+pub fn mixed_args_0(count: i32, __args: &[VaArg]) -> i32 {
     let count: Value<i32> = Rc::new(RefCell::new(count));
     let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
-    (*ap.borrow_mut()) = VaList::new(args);
+    (*ap.borrow_mut()) = VaList::new(__args);
     let total: Value<i32> = Rc::new(RefCell::new(0));
     let i: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while ((((*i.borrow()) < (*count.borrow())) as i32) != 0) {

--- a/tests/unit/out/refcount/va_arg_mixed_types.rs
+++ b/tests/unit/out/refcount/va_arg_mixed_types.rs
@@ -6,10 +6,10 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-pub fn sum_mixed_0(count: i32, args: &[VaArg]) -> i32 {
+pub fn sum_mixed_0(count: i32, __args: &[VaArg]) -> i32 {
     let count: Value<i32> = Rc::new(RefCell::new(count));
     let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
-    (*ap.borrow_mut()) = VaList::new(args);
+    (*ap.borrow_mut()) = VaList::new(__args);
     let total: Value<i32> = Rc::new(RefCell::new(0));
     let i: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while ((((*i.borrow()) < (*count.borrow())) as i32) != 0) {

--- a/tests/unit/out/refcount/va_arg_printf.rs
+++ b/tests/unit/out/refcount/va_arg_printf.rs
@@ -15,10 +15,10 @@ pub fn logf_impl_0(fmt: Ptr<u8>, ap: VaList) -> i32 {
         _lhs + ((*ap.borrow_mut()).arg::<i32>()).clone()
     };
 }
-pub fn logf_1(fmt: Ptr<u8>, args: &[VaArg]) -> i32 {
+pub fn logf_1(fmt: Ptr<u8>, __args: &[VaArg]) -> i32 {
     let fmt: Value<Ptr<u8>> = Rc::new(RefCell::new(fmt));
     let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
-    (*ap.borrow_mut()) = VaList::new(args);
+    (*ap.borrow_mut()) = VaList::new(__args);
     let result: Value<i32> = Rc::new(RefCell::new(
         ({
             let _fmt: Ptr<u8> = (*fmt.borrow()).clone();

--- a/tests/unit/out/refcount/va_arg_promotion.rs
+++ b/tests/unit/out/refcount/va_arg_promotion.rs
@@ -6,10 +6,10 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-pub fn test_promotions_0(count: i32, args: &[VaArg]) -> i32 {
+pub fn test_promotions_0(count: i32, __args: &[VaArg]) -> i32 {
     let count: Value<i32> = Rc::new(RefCell::new(count));
     let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
-    (*ap.borrow_mut()) = VaList::new(args);
+    (*ap.borrow_mut()) = VaList::new(__args);
     let a: Value<i32> = Rc::new(RefCell::new(((*ap.borrow_mut()).arg::<i32>()).clone()));
     let b: Value<i32> = Rc::new(RefCell::new(((*ap.borrow_mut()).arg::<i32>()).clone()));
     let c: Value<f64> = Rc::new(RefCell::new(((*ap.borrow_mut()).arg::<f64>()).clone()));

--- a/tests/unit/out/refcount/va_arg_snprintf.rs
+++ b/tests/unit/out/refcount/va_arg_snprintf.rs
@@ -6,12 +6,12 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-pub fn extract_first_0(buf: Ptr<u8>, size: i32, fmt: Ptr<u8>, args: &[VaArg]) -> i32 {
+pub fn extract_first_0(buf: Ptr<u8>, size: i32, fmt: Ptr<u8>, __args: &[VaArg]) -> i32 {
     let buf: Value<Ptr<u8>> = Rc::new(RefCell::new(buf));
     let size: Value<i32> = Rc::new(RefCell::new(size));
     let fmt: Value<Ptr<u8>> = Rc::new(RefCell::new(fmt));
     let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
-    (*ap.borrow_mut()) = VaList::new(args);
+    (*ap.borrow_mut()) = VaList::new(__args);
     let n: Value<i32> = Rc::new(RefCell::new(((*ap.borrow_mut()).arg::<i32>()).clone()));
     let __rhs = ((*n.borrow()) as u8);
     (*buf.borrow()).offset((0) as isize).write(__rhs);

--- a/tests/unit/out/refcount/va_arg_struct_ctx.rs
+++ b/tests/unit/out/refcount/va_arg_struct_ctx.rs
@@ -12,12 +12,12 @@ pub struct context {
     pub last_error: Value<i32>,
 }
 impl ByteRepr for context {}
-pub fn set_error_0(ctx: Ptr<context>, fmt: Ptr<u8>, args: &[VaArg]) {
+pub fn set_error_0(ctx: Ptr<context>, fmt: Ptr<u8>, __args: &[VaArg]) {
     let ctx: Value<Ptr<context>> = Rc::new(RefCell::new(ctx));
     let fmt: Value<Ptr<u8>> = Rc::new(RefCell::new(fmt));
     if ((*(*(*ctx.borrow()).upgrade().deref()).verbose.borrow()) != 0) {
         let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
-        (*ap.borrow_mut()) = VaList::new(args);
+        (*ap.borrow_mut()) = VaList::new(__args);
         (*(*(*ctx.borrow()).upgrade().deref()).last_error.borrow_mut()) =
             ((*ap.borrow_mut()).arg::<i32>()).clone();
     }

--- a/tests/unit/out/refcount/va_arg_two_passes.rs
+++ b/tests/unit/out/refcount/va_arg_two_passes.rs
@@ -6,12 +6,12 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-pub fn sum_then_product_0(first: i32, args: &[VaArg]) -> i32 {
+pub fn sum_then_product_0(first: i32, __args: &[VaArg]) -> i32 {
     let first: Value<i32> = Rc::new(RefCell::new(first));
     let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
     let sum: Value<i32> = Rc::new(RefCell::new((*first.borrow())));
     let product: Value<i32> = Rc::new(RefCell::new((*first.borrow())));
-    (*ap.borrow_mut()) = VaList::new(args);
+    (*ap.borrow_mut()) = VaList::new(__args);
     let val: Value<i32> = <Value<i32>>::default();
     'loop_: while (((({
         (*val.borrow_mut()) = ((*ap.borrow_mut()).arg::<i32>()).clone();
@@ -21,7 +21,7 @@ pub fn sum_then_product_0(first: i32, args: &[VaArg]) -> i32 {
     {
         (*sum.borrow_mut()) += (*val.borrow());
     }
-    (*ap.borrow_mut()) = VaList::new(args);
+    (*ap.borrow_mut()) = VaList::new(__args);
     'loop_: while (((({
         (*val.borrow_mut()) = ((*ap.borrow_mut()).arg::<i32>()).clone();
         (*val.borrow())

--- a/tests/unit/out/unsafe/va_arg_chain.rs
+++ b/tests/unit/out/unsafe/va_arg_chain.rs
@@ -21,9 +21,9 @@ pub unsafe fn middle_layer_1(mut n: i32, mut ap: VaList) -> i32 {
         extract_nth_0(_n, _ap)
     });
 }
-pub unsafe fn top_level_2(mut n: i32, args: &[VaArg]) -> i32 {
+pub unsafe fn top_level_2(mut n: i32, __args: &[VaArg]) -> i32 {
     let mut ap: VaList = VaList::default();
-    ap = VaList::new(args);
+    ap = VaList::new(__args);
     let mut result: i32 = (unsafe {
         let _n: i32 = n;
         let _ap: VaList = ap;

--- a/tests/unit/out/unsafe/va_arg_concat.rs
+++ b/tests/unit/out/unsafe/va_arg_concat.rs
@@ -6,13 +6,13 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-pub unsafe fn sum_ints_0(mut first: i32, args: &[VaArg]) -> i32 {
-    let mut ap: VaList = VaList::default();
+pub unsafe fn sum_ints_0(mut first: i32, __args: &[VaArg]) -> i32 {
+    let mut args: VaList = VaList::default();
     let mut total: i32 = first;
-    ap = VaList::new(args);
+    args = VaList::new(__args);
     let mut val: i32 = 0_i32;
     'loop_: while (((({
-        val = ap.arg::<i32>();
+        val = args.arg::<i32>();
         val
     }) != (0)) as i32)
         != 0)

--- a/tests/unit/out/unsafe/va_arg_conditional.rs
+++ b/tests/unit/out/unsafe/va_arg_conditional.rs
@@ -6,10 +6,10 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-pub unsafe fn conditional_log_0(mut verbose: i32, mut fmt: *const u8, args: &[VaArg]) -> i32 {
+pub unsafe fn conditional_log_0(mut verbose: i32, mut fmt: *const u8, __args: &[VaArg]) -> i32 {
     if (verbose != 0) {
         let mut ap: VaList = VaList::default();
-        ap = VaList::new(args);
+        ap = VaList::new(__args);
         let mut result: i32 = ap.arg::<i32>();
         return result;
     }

--- a/tests/unit/out/unsafe/va_arg_copy.rs
+++ b/tests/unit/out/unsafe/va_arg_copy.rs
@@ -6,10 +6,10 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-pub unsafe fn sum_with_copy_0(mut count: i32, args: &[VaArg]) -> i32 {
+pub unsafe fn sum_with_copy_0(mut count: i32, __args: &[VaArg]) -> i32 {
     let mut ap: VaList = VaList::default();
     let mut aq: VaList = VaList::default();
-    ap = VaList::new(args);
+    ap = VaList::new(__args);
     aq = ap.clone();
     let mut sum1: i32 = 0;
     let mut i: i32 = 0;

--- a/tests/unit/out/unsafe/va_arg_forward.rs
+++ b/tests/unit/out/unsafe/va_arg_forward.rs
@@ -15,9 +15,9 @@ pub unsafe fn inner_0(mut count: i32, mut ap: VaList) -> i32 {
     }
     return total;
 }
-pub unsafe fn outer_1(mut count: i32, args: &[VaArg]) -> i32 {
+pub unsafe fn outer_1(mut count: i32, __args: &[VaArg]) -> i32 {
     let mut ap: VaList = VaList::default();
-    ap = VaList::new(args);
+    ap = VaList::new(__args);
     let mut result: i32 = (unsafe {
         let _count: i32 = count;
         let _ap: VaList = ap;

--- a/tests/unit/out/unsafe/va_arg_mixed_int_ptr.rs
+++ b/tests/unit/out/unsafe/va_arg_mixed_int_ptr.rs
@@ -6,9 +6,9 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-pub unsafe fn mixed_args_0(mut count: i32, args: &[VaArg]) -> i32 {
+pub unsafe fn mixed_args_0(mut count: i32, __args: &[VaArg]) -> i32 {
     let mut ap: VaList = VaList::default();
-    ap = VaList::new(args);
+    ap = VaList::new(__args);
     let mut total: i32 = 0;
     let mut i: i32 = 0;
     'loop_: while ((((i) < (count)) as i32) != 0) {

--- a/tests/unit/out/unsafe/va_arg_mixed_types.rs
+++ b/tests/unit/out/unsafe/va_arg_mixed_types.rs
@@ -6,9 +6,9 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-pub unsafe fn sum_mixed_0(mut count: i32, args: &[VaArg]) -> i32 {
+pub unsafe fn sum_mixed_0(mut count: i32, __args: &[VaArg]) -> i32 {
     let mut ap: VaList = VaList::default();
-    ap = VaList::new(args);
+    ap = VaList::new(__args);
     let mut total: i32 = 0;
     let mut i: i32 = 0;
     'loop_: while ((((i) < (count)) as i32) != 0) {

--- a/tests/unit/out/unsafe/va_arg_printf.rs
+++ b/tests/unit/out/unsafe/va_arg_printf.rs
@@ -10,9 +10,9 @@ pub unsafe fn logf_impl_0(mut fmt: *const u8, mut ap: VaList) -> i32 {
     fmt;
     return ((ap.arg::<i32>()) + (ap.arg::<i32>()));
 }
-pub unsafe fn logf_1(mut fmt: *const u8, args: &[VaArg]) -> i32 {
+pub unsafe fn logf_1(mut fmt: *const u8, __args: &[VaArg]) -> i32 {
     let mut ap: VaList = VaList::default();
-    ap = VaList::new(args);
+    ap = VaList::new(__args);
     let mut result: i32 = (unsafe {
         let _fmt: *const u8 = fmt;
         let _ap: VaList = ap;

--- a/tests/unit/out/unsafe/va_arg_promotion.rs
+++ b/tests/unit/out/unsafe/va_arg_promotion.rs
@@ -6,9 +6,9 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-pub unsafe fn test_promotions_0(mut count: i32, args: &[VaArg]) -> i32 {
+pub unsafe fn test_promotions_0(mut count: i32, __args: &[VaArg]) -> i32 {
     let mut ap: VaList = VaList::default();
-    ap = VaList::new(args);
+    ap = VaList::new(__args);
     let mut a: i32 = ap.arg::<i32>();
     let mut b: i32 = ap.arg::<i32>();
     let mut c: f64 = ap.arg::<f64>();

--- a/tests/unit/out/unsafe/va_arg_snprintf.rs
+++ b/tests/unit/out/unsafe/va_arg_snprintf.rs
@@ -10,10 +10,10 @@ pub unsafe fn extract_first_0(
     mut buf: *mut u8,
     mut size: i32,
     mut fmt: *const u8,
-    args: &[VaArg],
+    __args: &[VaArg],
 ) -> i32 {
     let mut ap: VaList = VaList::default();
-    ap = VaList::new(args);
+    ap = VaList::new(__args);
     let mut n: i32 = ap.arg::<i32>();
     (*buf.offset((0) as isize)) = (n as u8);
     return n;

--- a/tests/unit/out/unsafe/va_arg_struct_ctx.rs
+++ b/tests/unit/out/unsafe/va_arg_struct_ctx.rs
@@ -12,10 +12,10 @@ pub struct context {
     pub verbose: i32,
     pub last_error: i32,
 }
-pub unsafe fn set_error_0(mut ctx: *mut context, mut fmt: *const u8, args: &[VaArg]) {
+pub unsafe fn set_error_0(mut ctx: *mut context, mut fmt: *const u8, __args: &[VaArg]) {
     if ((*ctx).verbose != 0) {
         let mut ap: VaList = VaList::default();
-        ap = VaList::new(args);
+        ap = VaList::new(__args);
         (*ctx).last_error = (ap.arg::<i32>()).clone();
     }
 }

--- a/tests/unit/out/unsafe/va_arg_two_passes.rs
+++ b/tests/unit/out/unsafe/va_arg_two_passes.rs
@@ -6,11 +6,11 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-pub unsafe fn sum_then_product_0(mut first: i32, args: &[VaArg]) -> i32 {
+pub unsafe fn sum_then_product_0(mut first: i32, __args: &[VaArg]) -> i32 {
     let mut ap: VaList = VaList::default();
     let mut sum: i32 = first;
     let mut product: i32 = first;
-    ap = VaList::new(args);
+    ap = VaList::new(__args);
     let mut val: i32 = 0_i32;
     'loop_: while (((({
         val = ap.arg::<i32>();
@@ -20,7 +20,7 @@ pub unsafe fn sum_then_product_0(mut first: i32, args: &[VaArg]) -> i32 {
     {
         sum += val;
     }
-    ap = VaList::new(args);
+    ap = VaList::new(__args);
     'loop_: while (((({
         val = ap.arg::<i32>();
         val

--- a/tests/unit/va_arg_concat.c
+++ b/tests/unit/va_arg_concat.c
@@ -2,15 +2,15 @@
 #include <stdarg.h>
 
 int sum_ints(int first, ...) {
-  va_list ap;
+  va_list args;
   int total = first;
 
-  va_start(ap, first);
+  va_start(args, first);
   int val;
-  while ((val = va_arg(ap, int)) != 0) {
+  while ((val = va_arg(args, int)) != 0) {
     total += val;
   }
-  va_end(ap);
+  va_end(args);
 
   return total;
 }


### PR DESCRIPTION
`args` can create a name collision with a local variable named `args`. Rename the `args` argument to `__args`