### PR TITLE
Fix translation of nullptr creation and comparison

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -1871,13 +1871,7 @@ bool Converter::VisitImplicitCastExpr(clang::ImplicitCastExpr *expr) {
     ConvertEqualsNullPtr(sub_expr);
     break;
   case clang::CastKind::CK_NullToPointer:
-    if (type->isFunctionPointerType()) {
-      StrCat("None");
-    } else {
-      StrCat(type->getPointeeType().isConstQualified()
-                 ? "std::ptr::null()"
-                 : "std::ptr::null_mut()");
-    }
+    StrCat(GetDefaultAsString(type));
     computed_expr_type_ = ComputedExprType::FreshPointer;
     break;
   default:

--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -105,13 +105,21 @@ bool IsBuiltinConstantP(const clang::Expr *expr) {
 }
 
 bool IsComparisonWithNullOp(const clang::BinaryOperator *expr) {
-  const auto *rhs = expr->getRHS()->IgnoreCasts();
-  switch (rhs->getStmtClass()) {
-  case clang::Stmt::CXXNullPtrLiteralExprClass:
-    return expr->isComparisonOp();
-  default:
+  if (!expr->isComparisonOp()) {
     return false;
   }
+  auto rhs = expr->getRHS()->IgnoreParenCasts();
+  // C++ nullptr/NULL
+  if (clang::isa<clang::CXXNullPtrLiteralExpr>(rhs) ||
+      clang::isa<clang::GNUNullExpr>(rhs)) {
+    return true;
+  }
+  // C NULL
+  if (auto lit = clang::dyn_cast<clang::IntegerLiteral>(rhs)) {
+    return lit->getValue() == 0 &&
+           expr->getLHS()->IgnoreParenImpCasts()->getType()->isPointerType();
+  }
+  return false;
 }
 
 bool IsInMainFile(const clang::Decl *decl) {

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -1160,7 +1160,7 @@ bool ConverterRefCount::VisitExplicitCastExpr(clang::ExplicitCastExpr *expr) {
       Convert(expr->getSubExpr());
       PushConversionKind push(*this, ConversionKind::Unboxed);
       StrCat(std::format(".cast::<{}>().expect(\"ub:wrong type\")",
-                         ToString(expr->getType()->getPointeeType())));
+                         ConvertPointeeType(expr->getType())));
       return false;
     } else if (expr->getSubExpr()->getType()->isPointerType() &&
                !expr->getSubExpr()->isNullPointerConstant(
@@ -1609,7 +1609,10 @@ bool ConverterRefCount::VisitVAArgExpr(clang::VAArgExpr *expr) {
   }
   StrCat(ConvertLValue(va_list_expr));
   StrCat(".arg::<");
-  StrCat(GetUnsafeTypeAsString(expr->getType()));
+  {
+    PushConversionKind push(*this, ConversionKind::Unboxed);
+    StrCat(ToString(expr->getType()));
+  }
   StrCat(">()");
   return false;
 }

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -1048,11 +1048,8 @@ bool ConverterRefCount::VisitImplicitCastExpr(clang::ImplicitCastExpr *expr) {
   }
 
   if (expr->getCastKind() == clang::CastKind::CK_NullToPointer) {
-    if (expr->getType()->isFunctionPointerType()) {
-      StrCat("FnPtr::null()");
-    } else {
-      StrCat("Default::default()");
-    }
+    PushConversionKind push(*this, ConversionKind::Unboxed);
+    StrCat(GetDefaultAsString(expr->getType()));
     computed_expr_type_ = ComputedExprType::FreshPointer;
     return false;
   }
@@ -1142,7 +1139,7 @@ bool ConverterRefCount::VisitExplicitCastExpr(clang::ExplicitCastExpr *expr) {
     return false;
   }
   if (expr->getCastKind() == clang::CK_NullToPointer) {
-    StrCat("Default::default()");
+    StrCat(GetDefaultAsString(expr->getType()));
     computed_expr_type_ = ComputedExprType::FreshPointer;
     return false;
   }
@@ -2241,8 +2238,9 @@ std::string ConverterRefCount::ConvertMappedMethodCall(
 
 std::string ConverterRefCount::ConvertPointeeType(clang::QualType ptr_type) {
   assert(!ptr_type.isNull() && ptr_type->isPointerType());
-  if (ptr_type->getPointeeType()->isIntegerType()) {
-    return ToString(ptr_type->getPointeeType());
+  auto pointee = ptr_type->getPointeeType();
+  if (!pointee->isRecordType()) {
+    return ToString(pointee);
   }
 
   // Pointee of a pointer to incomplete type is an incomplete type that does

--- a/tests/benchmarks/out/refcount/bfs.rs
+++ b/tests/benchmarks/out/refcount/bfs.rs
@@ -206,7 +206,7 @@ fn main_0() -> i32 {
     'loop_: while (((*i.borrow()) as u64) < (*V.borrow())) {
         (*(*graph.borrow()).adj.borrow())
             .offset((*i.borrow()) as isize)
-            .write(Default::default());
+            .write(Ptr::<GraphNode>::null());
         (*i.borrow_mut()).prefix_inc();
     }
     let i: Value<u32> = Rc::new(RefCell::new(0_u32));

--- a/tests/benchmarks/out/refcount/bst.rs
+++ b/tests/benchmarks/out/refcount/bst.rs
@@ -53,7 +53,7 @@ pub fn find_0(node: Ptr<node_t>, value: i32) -> Ptr<node_t> {
     } {
         return (*node.borrow()).clone();
     }
-    return Default::default();
+    return Ptr::<node_t>::null();
 }
 pub fn insert_1(node: Ptr<node_t>, new_node: Ptr<node_t>) -> Ptr<node_t> {
     let node: Value<Ptr<node_t>> = Rc::new(RefCell::new(node));
@@ -91,8 +91,8 @@ pub fn main() {
 fn main_0() -> i32 {
     let N: Value<i32> = Rc::new(RefCell::new(25000));
     let tree: Value<Ptr<node_t>> = Rc::new(RefCell::new(Ptr::alloc(node_t {
-        left: Rc::new(RefCell::new(Default::default())),
-        right: Rc::new(RefCell::new(Default::default())),
+        left: Rc::new(RefCell::new(Ptr::<node_t>::null())),
+        right: Rc::new(RefCell::new(Ptr::<node_t>::null())),
         value: Rc::new(RefCell::new(0)),
     })));
     let i: Value<i32> = Rc::new(RefCell::new(0));
@@ -100,8 +100,8 @@ fn main_0() -> i32 {
         ({
             let _node: Ptr<node_t> = (*tree.borrow()).clone();
             let _new_node: Ptr<node_t> = Ptr::alloc(node_t {
-                left: Rc::new(RefCell::new(Default::default())),
-                right: Rc::new(RefCell::new(Default::default())),
+                left: Rc::new(RefCell::new(Ptr::<node_t>::null())),
+                right: Rc::new(RefCell::new(Ptr::<node_t>::null())),
                 value: Rc::new(RefCell::new((*i.borrow()))),
             });
             insert_1(_node, _new_node)

--- a/tests/ub/out/refcount/ub2.rs
+++ b/tests/ub/out/refcount/ub2.rs
@@ -7,7 +7,7 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 pub fn null_0() -> Ptr<i32> {
-    let p: Value<Ptr<i32>> = Rc::new(RefCell::new(Default::default()));
+    let p: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
     return (*p.borrow()).clone();
 }
 pub fn main() {

--- a/tests/ub/out/refcount/ub4.rs
+++ b/tests/ub/out/refcount/ub4.rs
@@ -20,7 +20,7 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    let out: Value<Ptr<i32>> = Rc::new(RefCell::new(Default::default()));
+    let out: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
     let x1: Value<i32> = Rc::new(RefCell::new(1));
     if ((*x1.borrow()) != 0) {
         let x2: Value<i32> = Rc::new(RefCell::new(-1_i32));

--- a/tests/ub/out/refcount/ub5.rs
+++ b/tests/ub/out/refcount/ub5.rs
@@ -8,7 +8,7 @@ use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 pub fn null_0(p: Ptr<Ptr<i32>>) {
     let p: Value<Ptr<Ptr<i32>>> = Rc::new(RefCell::new(p));
-    (*p.borrow()).write(Default::default());
+    (*p.borrow()).write(Ptr::<i32>::null());
 }
 pub fn main() {
     std::process::exit(main_0());

--- a/tests/unit/null_compare.c
+++ b/tests/unit/null_compare.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+#include <stdlib.h>
+int main() {
+  int a = 0;
+  int *p = &a;
+  assert(p != NULL);
+  assert(p != 0);
+
+  p = NULL;
+  assert(p == NULL);
+  assert(p == 0);
+  return 0;
+}

--- a/tests/unit/out/refcount/10_struct.rs
+++ b/tests/unit/out/refcount/10_struct.rs
@@ -66,7 +66,7 @@ pub fn main() {
 fn main_0() -> i32 {
     let g: Value<Graph> = Rc::new(RefCell::new(Graph {
         V: Rc::new(RefCell::new(5_u32)),
-        adj: Rc::new(RefCell::new(Default::default())),
+        adj: Rc::new(RefCell::new(Ptr::<Ptr<GraphNode>>::null())),
     }));
     return 0;
 }

--- a/tests/unit/out/refcount/bool_condition_logical.rs
+++ b/tests/unit/out/refcount/bool_condition_logical.rs
@@ -45,7 +45,7 @@ fn main_0() -> i32 {
     let zero: Value<i32> = Rc::new(RefCell::new(0));
     let storage: Value<i32> = Rc::new(RefCell::new(7));
     let p: Value<Ptr<i32>> = Rc::new(RefCell::new((storage.as_pointer())));
-    let np: Value<Ptr<i32>> = Rc::new(RefCell::new(Default::default()));
+    let np: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
     let u: Value<u32> = Rc::new(RefCell::new(4_u32));
     let code: Value<Code> = Rc::new(RefCell::new(Code::CODE_OK));
     if ((*n.borrow()) != 0) && (!(*p.borrow()).is_null()) {
@@ -127,7 +127,7 @@ fn main_0() -> i32 {
         assert!(true);
     }
     let cp: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal("hi")));
-    let cnp: Value<Ptr<u8>> = Rc::new(RefCell::new(Default::default()));
+    let cnp: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::<u8>::null()));
     if ((*x.borrow()) > (*y.borrow())) && (!(*cp.borrow()).is_null()) {
         assert!(true);
     }

--- a/tests/unit/out/refcount/bool_condition_logical_c.rs
+++ b/tests/unit/out/refcount/bool_condition_logical_c.rs
@@ -45,7 +45,7 @@ fn main_0() -> i32 {
     let zero: Value<i32> = Rc::new(RefCell::new(0));
     let storage: Value<i32> = Rc::new(RefCell::new(7));
     let p: Value<Ptr<i32>> = Rc::new(RefCell::new((storage.as_pointer())));
-    let np: Value<Ptr<i32>> = Rc::new(RefCell::new(Default::default()));
+    let np: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
     let u: Value<u32> = Rc::new(RefCell::new(4_u32));
     let code: Value<Code> = Rc::new(RefCell::new(Code::CODE_OK));
     if (((((*n.borrow()) != 0) && (!(*p.borrow()).is_null())) as i32) != 0) {
@@ -115,8 +115,8 @@ fn main_0() -> i32 {
         assert!((1 != 0));
     }
     let s: Value<i32> = Rc::new(RefCell::new(-1_i32));
-    if (((((((*p.borrow()) != (Default::default())) as i32) != 0)
-        && ((((*s.borrow()) < 0) as i32) != 0)) as i32)
+    if ((((((!((*p.borrow()).is_null())) as i32) != 0) && ((((*s.borrow()) < 0) as i32) != 0))
+        as i32)
         != 0)
     {
         assert!((1 != 0));
@@ -133,10 +133,7 @@ fn main_0() -> i32 {
         assert!((1 != 0));
     }
     let ull: Value<u64> = Rc::new(RefCell::new(7_u64));
-    if (((((((*p.borrow()) != (Default::default())) as i32) != 0) && ((*ull.borrow()) != 0))
-        as i32)
-        != 0)
-    {
+    if ((((((!((*p.borrow()).is_null())) as i32) != 0) && ((*ull.borrow()) != 0)) as i32) != 0) {
         assert!((1 != 0));
     }
     if (((((((*x.borrow()) > (*y.borrow())) as i32) != 0) && ((*ull.borrow()) != 0)) as i32) != 0) {
@@ -155,7 +152,7 @@ fn main_0() -> i32 {
         assert!((1 != 0));
     }
     let cp: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal("hi")));
-    let cnp: Value<Ptr<u8>> = Rc::new(RefCell::new(Default::default()));
+    let cnp: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::<u8>::null()));
     if (((((((*x.borrow()) > (*y.borrow())) as i32) != 0) && (!(*cp.borrow()).is_null())) as i32)
         != 0)
     {
@@ -194,8 +191,7 @@ fn main_0() -> i32 {
     {
         assert!((0 != 0));
     }
-    if ((((((((((*p.borrow()) != (Default::default())) as i32) != 0)
-        && (({ returns_one_1() }) != 0)) as i32)
+    if (((((((((!((*p.borrow()).is_null())) as i32) != 0) && (({ returns_one_1() }) != 0)) as i32)
         != 0)
         && ((((*n.borrow()) != 0) as i32) != 0)) as i32)
         != 0)

--- a/tests/unit/out/refcount/bool_condition_ptr.rs
+++ b/tests/unit/out/refcount/bool_condition_ptr.rs
@@ -12,7 +12,7 @@ pub fn main() {
 fn main_0() -> i32 {
     let storage: Value<i32> = Rc::new(RefCell::new(7));
     let p: Value<Ptr<i32>> = Rc::new(RefCell::new((storage.as_pointer())));
-    let np: Value<Ptr<i32>> = Rc::new(RefCell::new(Default::default()));
+    let np: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
     if !(*p.borrow()).is_null() {
         assert!(true);
     }
@@ -29,7 +29,7 @@ fn main_0() -> i32 {
     let iters: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while !(*iter.borrow()).is_null() {
         (*iters.borrow_mut()).prefix_inc();
-        (*iter.borrow_mut()) = Default::default();
+        (*iter.borrow_mut()) = Ptr::<i32>::null();
     }
     assert!(((*iters.borrow()) == 1));
     let t3: Value<i32> = Rc::new(RefCell::new(if !(*p.borrow()).is_null() { 1 } else { 0 }));

--- a/tests/unit/out/refcount/bool_condition_ptr_c.rs
+++ b/tests/unit/out/refcount/bool_condition_ptr_c.rs
@@ -12,7 +12,7 @@ pub fn main() {
 fn main_0() -> i32 {
     let storage: Value<i32> = Rc::new(RefCell::new(7));
     let p: Value<Ptr<i32>> = Rc::new(RefCell::new((storage.as_pointer())));
-    let np: Value<Ptr<i32>> = Rc::new(RefCell::new(Default::default()));
+    let np: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
     if !(*p.borrow()).is_null() {
         assert!((1 != 0));
     }
@@ -29,7 +29,7 @@ fn main_0() -> i32 {
     let iters: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while !(*iter.borrow()).is_null() {
         (*iters.borrow_mut()).prefix_inc();
-        (*iter.borrow_mut()) = Default::default();
+        (*iter.borrow_mut()) = Ptr::<i32>::null();
     }
     assert!(((((*iters.borrow()) == 1) as i32) != 0));
     let t3: Value<i32> = Rc::new(RefCell::new(if !(*p.borrow()).is_null() { 1 } else { 0 }));

--- a/tests/unit/out/refcount/bst.rs
+++ b/tests/unit/out/refcount/bst.rs
@@ -53,7 +53,7 @@ pub fn find_0(node: Ptr<node_t>, value: i32) -> Ptr<node_t> {
     } {
         return (*node.borrow()).clone();
     }
-    return Default::default();
+    return Ptr::<node_t>::null();
 }
 pub fn insert_1(node: Ptr<node_t>, new_node: Ptr<node_t>) -> Ptr<node_t> {
     let node: Value<Ptr<node_t>> = Rc::new(RefCell::new(node));
@@ -91,32 +91,32 @@ pub fn main() {
 fn main_0() -> i32 {
     let tree: Value<Option<Value<node_t>>> =
         Rc::new(RefCell::new(Some(Rc::new(RefCell::new(node_t {
-            left: Rc::new(RefCell::new(Default::default())),
-            right: Rc::new(RefCell::new(Default::default())),
+            left: Rc::new(RefCell::new(Ptr::<node_t>::null())),
+            right: Rc::new(RefCell::new(Ptr::<node_t>::null())),
             value: Rc::new(RefCell::new(0)),
         })))));
     let n1: Value<Option<Value<node_t>>> =
         Rc::new(RefCell::new(Some(Rc::new(RefCell::new(node_t {
-            left: Rc::new(RefCell::new(Default::default())),
-            right: Rc::new(RefCell::new(Default::default())),
+            left: Rc::new(RefCell::new(Ptr::<node_t>::null())),
+            right: Rc::new(RefCell::new(Ptr::<node_t>::null())),
             value: Rc::new(RefCell::new(1)),
         })))));
     let n2: Value<Option<Value<node_t>>> =
         Rc::new(RefCell::new(Some(Rc::new(RefCell::new(node_t {
-            left: Rc::new(RefCell::new(Default::default())),
-            right: Rc::new(RefCell::new(Default::default())),
+            left: Rc::new(RefCell::new(Ptr::<node_t>::null())),
+            right: Rc::new(RefCell::new(Ptr::<node_t>::null())),
             value: Rc::new(RefCell::new(2)),
         })))));
     let n3: Value<Option<Value<node_t>>> =
         Rc::new(RefCell::new(Some(Rc::new(RefCell::new(node_t {
-            left: Rc::new(RefCell::new(Default::default())),
-            right: Rc::new(RefCell::new(Default::default())),
+            left: Rc::new(RefCell::new(Ptr::<node_t>::null())),
+            right: Rc::new(RefCell::new(Ptr::<node_t>::null())),
             value: Rc::new(RefCell::new(3)),
         })))));
     let n4: Value<Option<Value<node_t>>> =
         Rc::new(RefCell::new(Some(Rc::new(RefCell::new(node_t {
-            left: Rc::new(RefCell::new(Default::default())),
-            right: Rc::new(RefCell::new(Default::default())),
+            left: Rc::new(RefCell::new(Ptr::<node_t>::null())),
+            right: Rc::new(RefCell::new(Ptr::<node_t>::null())),
             value: Rc::new(RefCell::new(4)),
         })))));
     let ptr1: Value<Ptr<node_t>> = Rc::new(RefCell::new(((*tree.borrow()).as_pointer())));

--- a/tests/unit/out/refcount/builtin_types_compatible.rs
+++ b/tests/unit/out/refcount/builtin_types_compatible.rs
@@ -15,7 +15,7 @@ fn main_0() -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(0));
     assert!((((1 == 1) as i32) != 0));
     assert!((((0 == 0) as i32) != 0));
-    let p: Value<Ptr<i32>> = Rc::new(RefCell::new(Default::default()));
+    let p: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
     assert!((((1 == 1) as i32) != 0));
     assert!((((0 == 0) as i32) != 0));
     let ul: Value<u64> = Rc::new(RefCell::new(0_u64));

--- a/tests/unit/out/refcount/c_struct.rs
+++ b/tests/unit/out/refcount/c_struct.rs
@@ -78,7 +78,7 @@ fn main_0() -> i32 {
     assert!(((((*(*(*l.borrow()).end.borrow()).y.borrow()) == 4) as i32) != 0));
     let a: Value<Node> = Rc::new(RefCell::new(Node {
         value: Rc::new(RefCell::new(1)),
-        next: Rc::new(RefCell::new(Default::default())),
+        next: Rc::new(RefCell::new(Ptr::<Node>::null())),
     }));
     let b: Value<Node> = Rc::new(RefCell::new(Node {
         value: Rc::new(RefCell::new(2)),

--- a/tests/unit/out/refcount/default_in_statics.rs
+++ b/tests/unit/out/refcount/default_in_statics.rs
@@ -112,7 +112,7 @@ thread_local!(
 thread_local!(
     pub static static_foo: Value<Foo> = Rc::new(RefCell::new(Foo {
         s1: Rc::new(RefCell::new(Ptr::from_string_literal("hello"))),
-        s2: Rc::new(RefCell::new(Default::default())),
+        s2: Rc::new(RefCell::new(Ptr::<u8>::null())),
         fn1: Rc::new(RefCell::new(FnPtr::null())),
         fn2: Rc::new(RefCell::new(FnPtr::null())),
         n: Rc::new(RefCell::new(42)),
@@ -122,14 +122,14 @@ thread_local!(
     pub static static_foo_array: Value<Box<[Foo]>> = Rc::new(RefCell::new(Box::new([
         Foo {
             s1: Rc::new(RefCell::new(Ptr::from_string_literal("first"))),
-            s2: Rc::new(RefCell::new(Default::default())),
+            s2: Rc::new(RefCell::new(Ptr::<u8>::null())),
             fn1: Rc::new(RefCell::new(FnPtr::null())),
             fn2: Rc::new(RefCell::new(FnPtr::null())),
             n: Rc::new(RefCell::new(1)),
         },
         Foo {
             s1: Rc::new(RefCell::new(Ptr::from_string_literal("second"))),
-            s2: Rc::new(RefCell::new(Default::default())),
+            s2: Rc::new(RefCell::new(Ptr::<u8>::null())),
             fn1: Rc::new(RefCell::new(FnPtr::null())),
             fn2: Rc::new(RefCell::new(FnPtr::null())),
             n: Rc::new(RefCell::new(2)),

--- a/tests/unit/out/refcount/expr_as_bool_c.rs
+++ b/tests/unit/out/refcount/expr_as_bool_c.rs
@@ -18,8 +18,9 @@ pub fn cmp_or_ptr_1(p: Ptr<u8>, q: Ptr<u8>) -> i32 {
 pub fn both_null_2(s1: Ptr<u8>, s2: Ptr<u8>) -> i32 {
     let s1: Value<Ptr<u8>> = Rc::new(RefCell::new(s1));
     let s2: Value<Ptr<u8>> = Rc::new(RefCell::new(s2));
-    return ((((((*s1.borrow()) == (Default::default())) as i32) != 0)
-        && ((((*s2.borrow()) == (Default::default())) as i32) != 0)) as i32);
+    return ((((((*s1.borrow()).is_null()) as i32) != 0)
+        && ((((*s2.borrow()).is_null()) as i32) != 0)) as i32)
+        .clone();
 }
 pub fn main() {
     std::process::exit(main_0());
@@ -71,7 +72,7 @@ fn main_0() -> i32 {
     assert!(((((*lt.borrow()) == 0) as i32) != 0));
     assert!(((((*neq.borrow()) == 0) as i32) != 0));
     let p1: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal("hi")));
-    let p2: Value<Ptr<u8>> = Rc::new(RefCell::new(Default::default()));
+    let p2: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::<u8>::null()));
     let either: Value<i32> = Rc::new(RefCell::new(
         (((!(*p1.borrow()).is_null()) || (!(*p2.borrow()).is_null())) as i32).clone(),
     ));
@@ -104,16 +105,16 @@ fn main_0() -> i32 {
     );
     assert!(
         (((({
-            let _p: Ptr<u8> = Default::default();
-            let _q: Ptr<u8> = Default::default();
+            let _p: Ptr<u8> = Ptr::<u8>::null();
+            let _q: Ptr<u8> = Ptr::<u8>::null();
             cmp_or_ptr_1(_p, _q)
         }) == 0) as i32)
             != 0)
     );
     assert!(
         (((({
-            let _s1: Ptr<u8> = Default::default();
-            let _s2: Ptr<u8> = Default::default();
+            let _s1: Ptr<u8> = Ptr::<u8>::null();
+            let _s2: Ptr<u8> = Ptr::<u8>::null();
             both_null_2(_s1, _s2)
         }) == 1) as i32)
             != 0)
@@ -121,7 +122,7 @@ fn main_0() -> i32 {
     assert!(
         (((({
             let _s1: Ptr<u8> = (*p1.borrow()).clone();
-            let _s2: Ptr<u8> = Default::default();
+            let _s2: Ptr<u8> = Ptr::<u8>::null();
             both_null_2(_s1, _s2)
         }) == 0) as i32)
             != 0)

--- a/tests/unit/out/refcount/expr_as_bool_cpp.rs
+++ b/tests/unit/out/refcount/expr_as_bool_cpp.rs
@@ -67,7 +67,7 @@ fn main_0() -> i32 {
     assert!(((*lt.borrow()) == 0));
     assert!(((*neq.borrow()) == 0));
     let p1: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal("hi")));
-    let p2: Value<Ptr<u8>> = Rc::new(RefCell::new(Default::default()));
+    let p2: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::<u8>::null()));
     let either: Value<i32> = Rc::new(RefCell::new(
         (((!(*p1.borrow()).is_null()) || (!(*p2.borrow()).is_null())) as i32).clone(),
     ));
@@ -97,22 +97,22 @@ fn main_0() -> i32 {
     );
     assert!(
         (({
-            let _p: Ptr<u8> = Default::default();
-            let _q: Ptr<u8> = Default::default();
+            let _p: Ptr<u8> = Ptr::<u8>::null();
+            let _q: Ptr<u8> = Ptr::<u8>::null();
             cmp_or_ptr_1(_p, _q)
         }) == 0)
     );
     assert!(
         (({
-            let _s1: Ptr<u8> = Default::default();
-            let _s2: Ptr<u8> = Default::default();
+            let _s1: Ptr<u8> = Ptr::<u8>::null();
+            let _s2: Ptr<u8> = Ptr::<u8>::null();
             both_null_2(_s1, _s2)
         }) == 1)
     );
     assert!(
         (({
             let _s1: Ptr<u8> = (*p1.borrow()).clone();
-            let _s2: Ptr<u8> = Default::default();
+            let _s2: Ptr<u8> = Ptr::<u8>::null();
             both_null_2(_s1, _s2)
         }) == 0)
     );

--- a/tests/unit/out/refcount/fflush_null.rs
+++ b/tests/unit/out/refcount/fflush_null.rs
@@ -10,7 +10,8 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    let file_ptr: Value<Ptr<::std::fs::File>> = Rc::new(RefCell::new(Default::default()));
+    let file_ptr: Value<Ptr<::std::fs::File>> =
+        Rc::new(RefCell::new(Ptr::<::std::fs::File>::null()));
     return if !(*file_ptr.borrow()).is_null() {
         match (*file_ptr.borrow()).with_mut(|v| v.sync_all()) {
             Ok(_) => 0,

--- a/tests/unit/out/refcount/fn_ptr_stdlib_compare.rs
+++ b/tests/unit/out/refcount/fn_ptr_stdlib_compare.rs
@@ -59,10 +59,10 @@ fn main_0() -> i32 {
         ));
     assert!(
         (({
-            let _arg0: AnyPtr = Default::default();
+            let _arg0: AnyPtr = AnyPtr::default();
             let _arg1: u64 = 0_u64;
             let _arg2: u64 = 0_u64;
-            let _arg3: Ptr<::std::fs::File> = Default::default();
+            let _arg3: Ptr<::std::fs::File> = Ptr::<::std::fs::File>::null();
             (*(*f3.borrow()))(_arg0, _arg1, _arg2, _arg3)
         }) == 22_u64)
     );

--- a/tests/unit/out/refcount/global_pointers.rs
+++ b/tests/unit/out/refcount/global_pointers.rs
@@ -24,18 +24,18 @@ impl ByteRepr for Entry {}
 thread_local!(
     pub static single_entry: Value<Entry> = Rc::new(RefCell::new(Entry {
         name: Rc::new(RefCell::new(Ptr::from_string_literal("alone"))),
-        p: Rc::new(RefCell::new(Default::default())),
+        p: Rc::new(RefCell::new(Ptr::<i32>::null())),
     }));
 );
 thread_local!(
     pub static entries: Value<Box<[Entry]>> = Rc::new(RefCell::new(Box::new([
         Entry {
             name: Rc::new(RefCell::new(Ptr::from_string_literal("first"))),
-            p: Rc::new(RefCell::new(Default::default())),
+            p: Rc::new(RefCell::new(Ptr::<i32>::null())),
         },
         Entry {
             name: Rc::new(RefCell::new(Ptr::from_string_literal("second"))),
-            p: Rc::new(RefCell::new(Default::default())),
+            p: Rc::new(RefCell::new(Ptr::<i32>::null())),
         },
     ])));
 );

--- a/tests/unit/out/refcount/huffman.rs
+++ b/tests/unit/out/refcount/huffman.rs
@@ -76,8 +76,8 @@ impl MinHeap {
             [((*self.next.borrow()) as u64) as usize] = MinHeapNode {
             data: Rc::new(RefCell::new((*data.borrow()))),
             freq: Rc::new(RefCell::new((*freq.borrow()))),
-            left: Rc::new(RefCell::new(Default::default())),
-            right: Rc::new(RefCell::new(Default::default())),
+            left: Rc::new(RefCell::new(Ptr::<MinHeapNode>::null())),
+            right: Rc::new(RefCell::new(Ptr::<MinHeapNode>::null())),
         };
         return ((*self.alloc.borrow())
             .as_ref()

--- a/tests/unit/out/refcount/linked_list.rs
+++ b/tests/unit/out/refcount/linked_list.rs
@@ -54,7 +54,7 @@ pub fn Delete_2(head: Ptr<Node>, val: i32) -> Ptr<Node> {
     let head: Value<Ptr<Node>> = Rc::new(RefCell::new(head));
     let val: Value<i32> = Rc::new(RefCell::new(val));
     let curr: Value<Ptr<Node>> = Rc::new(RefCell::new((*head.borrow()).clone()));
-    let prev: Value<Ptr<Node>> = Rc::new(RefCell::new(Default::default()));
+    let prev: Value<Ptr<Node>> = Rc::new(RefCell::new(Ptr::<Node>::null()));
     'loop_: while !((*curr.borrow()).is_null()) {
         if {
             let _lhs = (*(*(*curr.borrow()).upgrade().deref()).val.borrow());
@@ -80,36 +80,36 @@ pub fn main() {
 fn main_0() -> i32 {
     let n0: Value<Node> = Rc::new(RefCell::new(Node {
         val: Rc::new(RefCell::new(5)),
-        next: Rc::new(RefCell::new(Default::default())),
+        next: Rc::new(RefCell::new(Ptr::<Node>::null())),
     }));
     let head: Value<Ptr<Node>> = Rc::new(RefCell::new((n0.as_pointer())));
     let n1: Value<Node> = Rc::new(RefCell::new(Node {
         val: Rc::new(RefCell::new(4)),
-        next: Rc::new(RefCell::new(Default::default())),
+        next: Rc::new(RefCell::new(Ptr::<Node>::null())),
     }));
     let n2: Value<Node> = Rc::new(RefCell::new(Node {
         val: Rc::new(RefCell::new(3)),
-        next: Rc::new(RefCell::new(Default::default())),
+        next: Rc::new(RefCell::new(Ptr::<Node>::null())),
     }));
     let n3: Value<Node> = Rc::new(RefCell::new(Node {
         val: Rc::new(RefCell::new(2)),
-        next: Rc::new(RefCell::new(Default::default())),
+        next: Rc::new(RefCell::new(Ptr::<Node>::null())),
     }));
     let n4: Value<Node> = Rc::new(RefCell::new(Node {
         val: Rc::new(RefCell::new(1)),
-        next: Rc::new(RefCell::new(Default::default())),
+        next: Rc::new(RefCell::new(Ptr::<Node>::null())),
     }));
     let n5: Value<Node> = Rc::new(RefCell::new(Node {
         val: Rc::new(RefCell::new(0)),
-        next: Rc::new(RefCell::new(Default::default())),
+        next: Rc::new(RefCell::new(Ptr::<Node>::null())),
     }));
     let n6: Value<Node> = Rc::new(RefCell::new(Node {
         val: Rc::new(RefCell::new(-1_i32)),
-        next: Rc::new(RefCell::new(Default::default())),
+        next: Rc::new(RefCell::new(Ptr::<Node>::null())),
     }));
     let n7: Value<Node> = Rc::new(RefCell::new(Node {
         val: Rc::new(RefCell::new(-2_i32)),
-        next: Rc::new(RefCell::new(Default::default())),
+        next: Rc::new(RefCell::new(Ptr::<Node>::null())),
     }));
     ({
         let _head: Ptr<Node> = (*head.borrow()).clone();

--- a/tests/unit/out/refcount/new_bst.rs
+++ b/tests/unit/out/refcount/new_bst.rs
@@ -53,15 +53,15 @@ pub fn find_0(node: Ptr<node_t>, value: i32) -> Ptr<node_t> {
     } {
         return (*node.borrow()).clone();
     }
-    return Default::default();
+    return Ptr::<node_t>::null();
 }
 pub fn insert_1(node: Ptr<node_t>, value: i32) -> Ptr<node_t> {
     let node: Value<Ptr<node_t>> = Rc::new(RefCell::new(node));
     let value: Value<i32> = Rc::new(RefCell::new(value));
     if (*node.borrow()).is_null() {
         return Ptr::alloc(node_t {
-            left: Rc::new(RefCell::new(Default::default())),
-            right: Rc::new(RefCell::new(Default::default())),
+            left: Rc::new(RefCell::new(Ptr::<node_t>::null())),
+            right: Rc::new(RefCell::new(Ptr::<node_t>::null())),
             value: Rc::new(RefCell::new((*value.borrow()))),
         });
     }
@@ -111,8 +111,8 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let root: Value<Ptr<node_t>> = Rc::new(RefCell::new(Ptr::alloc(node_t {
-        left: Rc::new(RefCell::new(Default::default())),
-        right: Rc::new(RefCell::new(Default::default())),
+        left: Rc::new(RefCell::new(Ptr::<node_t>::null())),
+        right: Rc::new(RefCell::new(Ptr::<node_t>::null())),
         value: Rc::new(RefCell::new(0)),
     })));
     let __rhs = ({

--- a/tests/unit/out/refcount/null_compare.rs
+++ b/tests/unit/out/refcount/null_compare.rs
@@ -1,0 +1,21 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let a: Value<i32> = Rc::new(RefCell::new(0));
+    let p: Value<Ptr<i32>> = Rc::new(RefCell::new((a.as_pointer())));
+    assert!((((!((*p.borrow()).is_null())) as i32) != 0));
+    assert!((((!((*p.borrow()).is_null())) as i32) != 0));
+    (*p.borrow_mut()) = Ptr::<i32>::null();
+    assert!(((((*p.borrow()).is_null()) as i32) != 0));
+    assert!(((((*p.borrow()).is_null()) as i32) != 0));
+    return 0;
+}

--- a/tests/unit/out/refcount/null_in_statics.rs
+++ b/tests/unit/out/refcount/null_in_statics.rs
@@ -33,10 +33,10 @@ thread_local!(
     ));
 );
 thread_local!(
-    pub static cp_explicit_null: Value<Ptr<u8>> = Rc::new(RefCell::new(Default::default()));
+    pub static cp_explicit_null: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::<u8>::null()));
 );
 thread_local!(
-    pub static p_zero: Value<Ptr<i32>> = Rc::new(RefCell::new(Default::default()));
+    pub static p_zero: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
 );
 pub fn main() {
     std::process::exit(main_0());

--- a/tests/unit/out/refcount/pointer_to_boolean.rs
+++ b/tests/unit/out/refcount/pointer_to_boolean.rs
@@ -10,7 +10,7 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    let x: Value<Ptr<i32>> = Rc::new(RefCell::new(Default::default()));
+    let x: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
     if !(*x.borrow()).is_null() {
         return 1;
     }

--- a/tests/unit/out/refcount/pointers.rs
+++ b/tests/unit/out/refcount/pointers.rs
@@ -67,7 +67,7 @@ fn main_0() -> i32 {
             Update_0(_t)
         }),
     ));
-    let t3: Value<Ptr<Test>> = Rc::new(RefCell::new(Default::default()));
+    let t3: Value<Ptr<Test>> = Rc::new(RefCell::new(Ptr::<Test>::null()));
     (*t3.borrow_mut()) = (*t2.borrow()).clone();
     (*(*(*t3.borrow()).upgrade().deref()).x.borrow_mut()) = 15;
     {

--- a/tests/unit/out/refcount/random.rs
+++ b/tests/unit/out/refcount/random.rs
@@ -22,9 +22,9 @@ impl Pair {
         (*self.y.borrow_mut()).prefix_inc();
         (*self.a.borrow_mut())[(4) as usize] = 1;
         self.r.write(1);
-        (*self.p.borrow_mut()) = Default::default();
-        (*self.pair.borrow_mut()) = Default::default();
-        (*self.ap.borrow_mut())[(0) as usize] = Default::default();
+        (*self.p.borrow_mut()) = Ptr::<i32>::null();
+        (*self.pair.borrow_mut()) = Ptr::<Pair>::null();
+        (*self.ap.borrow_mut())[(0) as usize] = Ptr::<i32>::null();
     }
     pub fn as_val(&self) -> i32 {
         return (*self.x.borrow());
@@ -108,11 +108,11 @@ fn main_0() -> i32 {
         y: Rc::new(RefCell::new(2)),
         a: Rc::new(RefCell::new(Box::new([1, 2, 3, 4, 5]))),
         r: x1.as_pointer(),
-        p: Rc::new(RefCell::new(Default::default())),
-        pair: Rc::new(RefCell::new(Default::default())),
+        p: Rc::new(RefCell::new(Ptr::<i32>::null())),
+        pair: Rc::new(RefCell::new(Ptr::<Pair>::null())),
         ap: Rc::new(RefCell::new(Box::new([
-            Default::default(),
-            Default::default(),
+            Ptr::<i32>::null(),
+            Ptr::<i32>::null(),
         ]))),
     }));
     let y4: Value<Pair> = Rc::new(RefCell::new(Pair {
@@ -185,7 +185,7 @@ fn main_0() -> i32 {
     }));
     let ry3: Ptr<Pair> = (*py1.borrow()).clone();
     let py3: Value<Ptr<Pair>> = Rc::new(RefCell::new((*py1.borrow()).clone()));
-    (*py3.borrow_mut()) = Default::default();
+    (*py3.borrow_mut()) = Ptr::<Pair>::null();
     let ptr2pair: Value<Ptr<Pair>> = Rc::new(RefCell::new((*py3.borrow()).clone()));
     ({
         let _x1: i32 = (*x1.borrow());
@@ -264,11 +264,11 @@ fn main_0() -> i32 {
         y: Rc::new(RefCell::new(2)),
         a: Rc::new(RefCell::new(Box::new([1, 2, 3, 4, 5]))),
         r: j.as_pointer(),
-        p: Rc::new(RefCell::new(Default::default())),
-        pair: Rc::new(RefCell::new(Default::default())),
+        p: Rc::new(RefCell::new(Ptr::<i32>::null())),
+        pair: Rc::new(RefCell::new(Ptr::<Pair>::null())),
         ap: Rc::new(RefCell::new(Box::new([
-            Default::default(),
-            Default::default(),
+            Ptr::<i32>::null(),
+            Ptr::<i32>::null(),
         ]))),
     }));
     let __rhs = (*(*new_y.borrow()).x.borrow());

--- a/tests/unit/out/refcount/templates.rs
+++ b/tests/unit/out/refcount/templates.rs
@@ -20,7 +20,7 @@ pub fn bar_2(p: Ptr<i32>, flag: bool) -> Ptr<i32> {
     return if (*flag.borrow()) {
         (*p.borrow()).clone()
     } else {
-        Default::default()
+        Ptr::<i32>::null()
     };
 }
 pub fn bar_3(p: Ptr<f64>, flag: bool) -> Ptr<f64> {
@@ -29,7 +29,7 @@ pub fn bar_3(p: Ptr<f64>, flag: bool) -> Ptr<f64> {
     return if (*flag.borrow()) {
         (*p.borrow()).clone()
     } else {
-        Default::default()
+        Ptr::<f64>::null()
     };
 }
 pub fn func_4(x1: i32, x2: i32, x3: i32) -> i32 {

--- a/tests/unit/out/refcount/va_arg_null_int_ptr.rs
+++ b/tests/unit/out/refcount/va_arg_null_int_ptr.rs
@@ -1,0 +1,64 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn first_nonnull_0(count: i32, args: &[VaArg]) -> i32 {
+    let count: Value<i32> = Rc::new(RefCell::new(count));
+    let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
+    (*ap.borrow_mut()) = VaList::new(args);
+    let result: Value<i32> = Rc::new(RefCell::new(-1_i32));
+    let i: Value<i32> = Rc::new(RefCell::new(0));
+    'loop_: while ((((*i.borrow()) < (*count.borrow())) as i32) != 0) {
+        let p: Value<Ptr<i32>> =
+            Rc::new(RefCell::new(((*ap.borrow_mut()).arg::<Ptr<i32>>()).clone()));
+        if (((!((*p.borrow()).is_null())) as i32) != 0) {
+            let __rhs = ((*p.borrow()).read());
+            (*result.borrow_mut()) = __rhs;
+            break;
+        }
+        (*i.borrow_mut()).postfix_inc();
+    }
+    return (*result.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(42));
+    assert!(
+        (((({
+            let _count: i32 = 2;
+            first_nonnull_0(
+                _count,
+                &[(AnyPtr::default()).into(), (x.as_pointer()).into()],
+            )
+        }) == 42) as i32)
+            != 0)
+    );
+    assert!(
+        (((({
+            let _count: i32 = 3;
+            first_nonnull_0(
+                _count,
+                &[
+                    (AnyPtr::default()).into(),
+                    (AnyPtr::default()).into(),
+                    (x.as_pointer()).into(),
+                ],
+            )
+        }) == 42) as i32)
+            != 0)
+    );
+    assert!(
+        (((({
+            let _count: i32 = 1;
+            first_nonnull_0(_count, &[(AnyPtr::default()).into()])
+        }) == -1_i32) as i32)
+            != 0)
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/bool_condition_logical_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical_c.rs
@@ -102,10 +102,7 @@ unsafe fn main_0() -> i32 {
         assert!((1 != 0));
     }
     let mut s: i32 = -1_i32;
-    if (((((((p) != ((0 as *mut ::libc::c_void) as *mut i32)) as i32) != 0)
-        && ((((s) < (0)) as i32) != 0)) as i32)
-        != 0)
-    {
+    if ((((((!((p).is_null())) as i32) != 0) && ((((s) < (0)) as i32) != 0)) as i32) != 0) {
         assert!((1 != 0));
     }
     let mut k: u32 = 2_u32;
@@ -117,9 +114,7 @@ unsafe fn main_0() -> i32 {
         assert!((1 != 0));
     }
     let mut ull: u64 = 7_u64;
-    if (((((((p) != ((0 as *mut ::libc::c_void) as *mut i32)) as i32) != 0) && (ull != 0)) as i32)
-        != 0)
-    {
+    if ((((((!((p).is_null())) as i32) != 0) && (ull != 0)) as i32) != 0) {
         assert!((1 != 0));
     }
     if (((((((x) > (y)) as i32) != 0) && (ull != 0)) as i32) != 0) {
@@ -158,8 +153,7 @@ unsafe fn main_0() -> i32 {
     if (((((((x) < (y)) as i32) != 0) || (!((unsafe { returns_one_1() }) != 0))) as i32) != 0) {
         assert!((0 != 0));
     }
-    if ((((((((((p) != ((0 as *mut ::libc::c_void) as *mut i32)) as i32) != 0)
-        && ((unsafe { returns_one_1() }) != 0)) as i32)
+    if (((((((((!((p).is_null())) as i32) != 0) && ((unsafe { returns_one_1() }) != 0)) as i32)
         != 0)
         && ((((n) != (0)) as i32) != 0)) as i32)
         != 0)

--- a/tests/unit/out/unsafe/expr_as_bool_c.rs
+++ b/tests/unit/out/unsafe/expr_as_bool_c.rs
@@ -13,9 +13,7 @@ pub unsafe fn cmp_or_ptr_1(mut p: *const u8, mut q: *const u8) -> i32 {
     return (((!(p).is_null()) || (!(q).is_null())) as i32);
 }
 pub unsafe fn both_null_2(mut s1: *const u8, mut s2: *const u8) -> i32 {
-    return ((((((s1) == ((0 as *mut ::libc::c_void) as *const u8)) as i32) != 0)
-        && ((((s2) == ((0 as *mut ::libc::c_void) as *const u8)) as i32) != 0))
-        as i32);
+    return ((((((s1).is_null()) as i32) != 0) && ((((s2).is_null()) as i32) != 0)) as i32);
 }
 pub fn main() {
     unsafe {

--- a/tests/unit/out/unsafe/null_compare.rs
+++ b/tests/unit/out/unsafe/null_compare.rs
@@ -1,0 +1,23 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut a: i32 = 0;
+    let mut p: *mut i32 = (&mut a as *mut i32);
+    assert!((((!((p).is_null())) as i32) != 0));
+    assert!((((!((p).is_null())) as i32) != 0));
+    p = std::ptr::null_mut();
+    assert!(((((p).is_null()) as i32) != 0));
+    assert!(((((p).is_null()) as i32) != 0));
+    return 0;
+}

--- a/tests/unit/out/unsafe/va_arg_null_int_ptr.rs
+++ b/tests/unit/out/unsafe/va_arg_null_int_ptr.rs
@@ -1,0 +1,66 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn first_nonnull_0(mut count: i32, args: &[VaArg]) -> i32 {
+    let mut ap: VaList = VaList::default();
+    ap = VaList::new(args);
+    let mut result: i32 = -1_i32;
+    let mut i: i32 = 0;
+    'loop_: while ((((i) < (count)) as i32) != 0) {
+        let mut p: *mut i32 = ap.arg::<*mut i32>();
+        if (((!((p).is_null())) as i32) != 0) {
+            result = (*p);
+            break;
+        }
+        i.postfix_inc();
+    }
+    return result;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut x: i32 = 42;
+    assert!(
+        ((((unsafe {
+            let _count: i32 = 2;
+            first_nonnull_0(
+                _count,
+                &[
+                    (0 as *mut ::libc::c_void).into(),
+                    (&mut x as *mut i32).into(),
+                ],
+            )
+        }) == (42)) as i32)
+            != 0)
+    );
+    assert!(
+        ((((unsafe {
+            let _count: i32 = 3;
+            first_nonnull_0(
+                _count,
+                &[
+                    (0 as *mut ::libc::c_void).into(),
+                    (0 as *mut ::libc::c_void).into(),
+                    (&mut x as *mut i32).into(),
+                ],
+            )
+        }) == (42)) as i32)
+            != 0)
+    );
+    assert!(
+        ((((unsafe {
+            let _count: i32 = 1;
+            first_nonnull_0(_count, &[(0 as *mut ::libc::c_void).into()])
+        }) == (-1_i32)) as i32)
+            != 0)
+    );
+    return 0;
+}

--- a/tests/unit/va_arg_null_int_ptr.c
+++ b/tests/unit/va_arg_null_int_ptr.c
@@ -1,0 +1,26 @@
+#include <assert.h>
+#include <stdarg.h>
+#include <stddef.h>
+
+int first_nonnull(int count, ...) {
+  va_list ap;
+  va_start(ap, count);
+  int result = -1;
+  for (int i = 0; i < count; i++) {
+    int *p = va_arg(ap, int *);
+    if (p != NULL) {
+      result = *p;
+      break;
+    }
+  }
+  va_end(ap);
+  return result;
+}
+
+int main() {
+  int x = 42;
+  assert(first_nonnull(2, NULL, &x) == 42);
+  assert(first_nonnull(3, NULL, NULL, &x) == 42);
+  assert(first_nonnull(1, NULL) == -1);
+  return 0;
+}


### PR DESCRIPTION
This PR translates default pointers using `GetDefaultAsString`, resulting in `Ptr::<T>::null()` being generated instead of `Default::default()`. This is useful for contexts where `Default::default()` cannot be correctly deduced as a `Ptr`.

Pointer comparisson is also fixed to allow C NULL comparissons such as `p != NULL` or `p != 0`.