### PR TITLE
Add rules for socket_type enum values

### DIFF
--- a/cpp2rust/converter/translation_rule.cpp
+++ b/cpp2rust/converter/translation_rule.cpp
@@ -130,6 +130,16 @@ TypeRule ParseTypeRuleJSON(const llvm::json::Object &obj) {
   return rule;
 }
 
+bool CfgMatchesHost(llvm::StringRef cfg) {
+#if defined(__linux__)
+  return cfg == "linux";
+#elif defined(__APPLE__)
+  return cfg == "macos";
+#else
+  return false;
+#endif
+}
+
 void LoadTgtFromIR(ExprRules &exprs, TypeRules &types,
                    const std::filesystem::path &json_path) {
   auto buf = llvm::MemoryBuffer::getFile(json_path.string());
@@ -152,6 +162,10 @@ void LoadTgtFromIR(ExprRules &exprs, TypeRules &types,
     auto *obj = entry_val.getAsObject();
     if (!obj)
       continue;
+
+    if (auto cfg = obj->getString("cfg"); cfg && !CfgMatchesHost(*cfg)) {
+      continue;
+    }
 
     auto name = entry_name.str();
     if (name[0] == 'f') {

--- a/cpp2rust/converter/translation_rule.cpp
+++ b/cpp2rust/converter/translation_rule.cpp
@@ -130,11 +130,11 @@ TypeRule ParseTypeRuleJSON(const llvm::json::Object &obj) {
   return rule;
 }
 
-bool CfgMatchesHost(llvm::StringRef cfg) {
+bool TargetOSMatchesHost(llvm::StringRef target_os) {
 #if defined(__linux__)
-  return cfg == "linux";
+  return target_os == "linux";
 #elif defined(__APPLE__)
-  return cfg == "macos";
+  return target_os == "macos";
 #else
   return false;
 #endif
@@ -163,7 +163,8 @@ void LoadTgtFromIR(ExprRules &exprs, TypeRules &types,
     if (!obj)
       continue;
 
-    if (auto cfg = obj->getString("cfg"); cfg && !CfgMatchesHost(*cfg)) {
+    if (auto target_os = obj->getString("target_os");
+        target_os && !TargetOSMatchesHost(*target_os)) {
       continue;
     }
 

--- a/rule-preprocessor/Cargo.toml
+++ b/rule-preprocessor/Cargo.toml
@@ -9,3 +9,4 @@ rules = { path = "../rules" }
 ra_ap_syntax = "0.0.266"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+syn = "2"

--- a/rule-preprocessor/src/ir.rs
+++ b/rule-preprocessor/src/ir.rs
@@ -50,8 +50,6 @@ pub struct TypeInfo {
 pub struct FnIr {
     pub body: Vec<BodyFragment>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub target_os: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub generics: Option<BTreeMap<String, Vec<String>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multi_statement: Option<bool>,
@@ -59,6 +57,8 @@ pub struct FnIr {
     pub params: Option<BTreeMap<String, TypeInfo>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub return_type: Option<TypeInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_os: Option<String>,
 }
 
 impl FnIr {

--- a/rule-preprocessor/src/ir.rs
+++ b/rule-preprocessor/src/ir.rs
@@ -48,8 +48,9 @@ pub struct TypeInfo {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FnIr {
-    // Fields ordered alphabetically to match the old serde_json::Map output
     pub body: Vec<BodyFragment>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cfg: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub generics: Option<BTreeMap<String, Vec<String>>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/rule-preprocessor/src/ir.rs
+++ b/rule-preprocessor/src/ir.rs
@@ -50,7 +50,7 @@ pub struct TypeInfo {
 pub struct FnIr {
     pub body: Vec<BodyFragment>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cfg: Option<String>,
+    pub target_os: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub generics: Option<BTreeMap<String, Vec<String>>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/rule-preprocessor/src/syntactic.rs
+++ b/rule-preprocessor/src/syntactic.rs
@@ -258,6 +258,31 @@ impl<'a> FnIrBuilder<'a> {
         Self { fn_item }
     }
 
+    fn cfg_target_os(&self) -> Option<String> {
+        use ast::HasAttrs;
+        for attr in self.fn_item.attrs() {
+            let meta_text = attr.meta()?.syntax().text().to_string();
+            let syn::Meta::List(list) = syn::parse_str(&meta_text).ok()? else {
+                continue;
+            };
+            if !list.path.is_ident("cfg") {
+                continue;
+            }
+            let mut found = None;
+            let _ = list.parse_nested_meta(|nested| {
+                if nested.path.is_ident("target_os") {
+                    let lit: syn::LitStr = nested.value()?.parse()?;
+                    found = Some(lit.value());
+                }
+                Ok(())
+            });
+            if found.is_some() {
+                return found;
+            }
+        }
+        None
+    }
+
     fn params(&self) -> Vec<ParamInfo> {
         let mut params = Vec::new();
         let Some(param_list) = self.fn_item.param_list() else {
@@ -499,6 +524,7 @@ impl<'a> FnIrBuilder<'a> {
             },
             multi_statement,
             body,
+            cfg: self.cfg_target_os(),
         };
         ir.validate(&format!("{}:{}", path.display(), fn_name));
         ir

--- a/rule-preprocessor/src/syntactic.rs
+++ b/rule-preprocessor/src/syntactic.rs
@@ -258,7 +258,7 @@ impl<'a> FnIrBuilder<'a> {
         Self { fn_item }
     }
 
-    fn cfg_target_os(&self) -> Option<String> {
+    fn get_target_os(&self) -> Option<String> {
         use ast::HasAttrs;
         for attr in self.fn_item.attrs() {
             let meta_text = attr.meta()?.syntax().text().to_string();
@@ -524,7 +524,7 @@ impl<'a> FnIrBuilder<'a> {
             },
             multi_statement,
             body,
-            cfg: self.cfg_target_os(),
+            target_os: self.get_target_os(),
         };
         ir.validate(&format!("{}:{}", path.display(), fn_name));
         ir

--- a/rules/socket/ir_unsafe.json
+++ b/rules/socket/ir_unsafe.json
@@ -35,7 +35,7 @@
         "text": "libc::SOCK_CLOEXEC"
       }
     ],
-    "cfg": "linux",
+    "target_os": "linux",
     "return_type": {
       "type": "i32"
     }
@@ -46,7 +46,7 @@
         "text": "libc::SOCK_NONBLOCK"
       }
     ],
-    "cfg": "linux",
+    "target_os": "linux",
     "return_type": {
       "type": "i32"
     }

--- a/rules/socket/ir_unsafe.json
+++ b/rules/socket/ir_unsafe.json
@@ -9,16 +9,6 @@
       "type": "i32"
     }
   },
-  "f10": {
-    "body": [
-      {
-        "text": "libc::SOCK_NONBLOCK"
-      }
-    ],
-    "return_type": {
-      "type": "i32"
-    }
-  },
   "f2": {
     "body": [
       {
@@ -42,7 +32,7 @@
   "f4": {
     "body": [
       {
-        "text": "libc::SOCK_RAW"
+        "text": "libc::SOCK_CLOEXEC"
       }
     ],
     "return_type": {
@@ -52,47 +42,7 @@
   "f5": {
     "body": [
       {
-        "text": "libc::SOCK_RDM"
-      }
-    ],
-    "return_type": {
-      "type": "i32"
-    }
-  },
-  "f6": {
-    "body": [
-      {
-        "text": "libc::SOCK_SEQPACKET"
-      }
-    ],
-    "return_type": {
-      "type": "i32"
-    }
-  },
-  "f7": {
-    "body": [
-      {
-        "text": "libc::SOCK_DCCP"
-      }
-    ],
-    "return_type": {
-      "type": "i32"
-    }
-  },
-  "f8": {
-    "body": [
-      {
-        "text": "libc::SOCK_PACKET"
-      }
-    ],
-    "return_type": {
-      "type": "i32"
-    }
-  },
-  "f9": {
-    "body": [
-      {
-        "text": "libc::SOCK_CLOEXEC"
+        "text": "libc::SOCK_NONBLOCK"
       }
     ],
     "return_type": {

--- a/rules/socket/ir_unsafe.json
+++ b/rules/socket/ir_unsafe.json
@@ -8,5 +8,95 @@
     "return_type": {
       "type": "i32"
     }
+  },
+  "f10": {
+    "body": [
+      {
+        "text": "libc::SOCK_NONBLOCK"
+      }
+    ],
+    "return_type": {
+      "type": "i32"
+    }
+  },
+  "f2": {
+    "body": [
+      {
+        "text": "libc::SOCK_STREAM"
+      }
+    ],
+    "return_type": {
+      "type": "i32"
+    }
+  },
+  "f3": {
+    "body": [
+      {
+        "text": "libc::SOCK_DGRAM"
+      }
+    ],
+    "return_type": {
+      "type": "i32"
+    }
+  },
+  "f4": {
+    "body": [
+      {
+        "text": "libc::SOCK_RAW"
+      }
+    ],
+    "return_type": {
+      "type": "i32"
+    }
+  },
+  "f5": {
+    "body": [
+      {
+        "text": "libc::SOCK_RDM"
+      }
+    ],
+    "return_type": {
+      "type": "i32"
+    }
+  },
+  "f6": {
+    "body": [
+      {
+        "text": "libc::SOCK_SEQPACKET"
+      }
+    ],
+    "return_type": {
+      "type": "i32"
+    }
+  },
+  "f7": {
+    "body": [
+      {
+        "text": "libc::SOCK_DCCP"
+      }
+    ],
+    "return_type": {
+      "type": "i32"
+    }
+  },
+  "f8": {
+    "body": [
+      {
+        "text": "libc::SOCK_PACKET"
+      }
+    ],
+    "return_type": {
+      "type": "i32"
+    }
+  },
+  "f9": {
+    "body": [
+      {
+        "text": "libc::SOCK_CLOEXEC"
+      }
+    ],
+    "return_type": {
+      "type": "i32"
+    }
   }
 }

--- a/rules/socket/ir_unsafe.json
+++ b/rules/socket/ir_unsafe.json
@@ -35,6 +35,7 @@
         "text": "libc::SOCK_CLOEXEC"
       }
     ],
+    "cfg": "linux",
     "return_type": {
       "type": "i32"
     }
@@ -45,6 +46,7 @@
         "text": "libc::SOCK_NONBLOCK"
       }
     ],
+    "cfg": "linux",
     "return_type": {
       "type": "i32"
     }

--- a/rules/socket/ir_unsafe.json
+++ b/rules/socket/ir_unsafe.json
@@ -35,10 +35,10 @@
         "text": "libc::SOCK_CLOEXEC"
       }
     ],
-    "target_os": "linux",
     "return_type": {
       "type": "i32"
-    }
+    },
+    "target_os": "linux"
   },
   "f5": {
     "body": [
@@ -46,9 +46,9 @@
         "text": "libc::SOCK_NONBLOCK"
       }
     ],
-    "target_os": "linux",
     "return_type": {
       "type": "i32"
-    }
+    },
+    "target_os": "linux"
   }
 }

--- a/rules/socket/src.cpp
+++ b/rules/socket/src.cpp
@@ -4,3 +4,39 @@
 int f1() {
   return MSG_NOSIGNAL;
 }
+
+int f2() {
+  return SOCK_STREAM;
+}
+
+int f3() {
+  return SOCK_DGRAM;
+}
+
+int f4() {
+  return SOCK_RAW;
+}
+
+int f5() {
+  return SOCK_RDM;
+}
+
+int f6() {
+  return SOCK_SEQPACKET;
+}
+
+int f7() {
+  return SOCK_DCCP;
+}
+
+int f8() {
+  return SOCK_PACKET;
+}
+
+int f9() {
+  return SOCK_CLOEXEC;
+}
+
+int f10() {
+  return SOCK_NONBLOCK;
+}

--- a/rules/socket/src.cpp
+++ b/rules/socket/src.cpp
@@ -13,6 +13,7 @@ int f3() {
   return SOCK_DGRAM;
 }
 
+#ifdef __linux__
 int f4() {
   return SOCK_CLOEXEC;
 }
@@ -20,3 +21,4 @@ int f4() {
 int f5() {
   return SOCK_NONBLOCK;
 }
+#endif

--- a/rules/socket/src.cpp
+++ b/rules/socket/src.cpp
@@ -14,29 +14,9 @@ int f3() {
 }
 
 int f4() {
-  return SOCK_RAW;
-}
-
-int f5() {
-  return SOCK_RDM;
-}
-
-int f6() {
-  return SOCK_SEQPACKET;
-}
-
-int f7() {
-  return SOCK_DCCP;
-}
-
-int f8() {
-  return SOCK_PACKET;
-}
-
-int f9() {
   return SOCK_CLOEXEC;
 }
 
-int f10() {
+int f5() {
   return SOCK_NONBLOCK;
 }

--- a/rules/socket/tgt_unsafe.rs
+++ b/rules/socket/tgt_unsafe.rs
@@ -11,29 +11,9 @@ unsafe fn f3() -> i32 {
 }
 
 unsafe fn f4() -> i32 {
-    libc::SOCK_RAW
-}
-
-unsafe fn f5() -> i32 {
-    libc::SOCK_RDM
-}
-
-unsafe fn f6() -> i32 {
-    libc::SOCK_SEQPACKET
-}
-
-unsafe fn f7() -> i32 {
-    libc::SOCK_DCCP
-}
-
-unsafe fn f8() -> i32 {
-    libc::SOCK_PACKET
-}
-
-unsafe fn f9() -> i32 {
     libc::SOCK_CLOEXEC
 }
 
-unsafe fn f10() -> i32 {
+unsafe fn f5() -> i32 {
     libc::SOCK_NONBLOCK
 }

--- a/rules/socket/tgt_unsafe.rs
+++ b/rules/socket/tgt_unsafe.rs
@@ -10,10 +10,12 @@ unsafe fn f3() -> i32 {
     libc::SOCK_DGRAM
 }
 
+#[cfg(target_os = "linux")]
 unsafe fn f4() -> i32 {
     libc::SOCK_CLOEXEC
 }
 
+#[cfg(target_os = "linux")]
 unsafe fn f5() -> i32 {
     libc::SOCK_NONBLOCK
 }

--- a/rules/socket/tgt_unsafe.rs
+++ b/rules/socket/tgt_unsafe.rs
@@ -1,3 +1,39 @@
 unsafe fn f1() -> i32 {
     libc::MSG_NOSIGNAL
 }
+
+unsafe fn f2() -> i32 {
+    libc::SOCK_STREAM
+}
+
+unsafe fn f3() -> i32 {
+    libc::SOCK_DGRAM
+}
+
+unsafe fn f4() -> i32 {
+    libc::SOCK_RAW
+}
+
+unsafe fn f5() -> i32 {
+    libc::SOCK_RDM
+}
+
+unsafe fn f6() -> i32 {
+    libc::SOCK_SEQPACKET
+}
+
+unsafe fn f7() -> i32 {
+    libc::SOCK_DCCP
+}
+
+unsafe fn f8() -> i32 {
+    libc::SOCK_PACKET
+}
+
+unsafe fn f9() -> i32 {
+    libc::SOCK_CLOEXEC
+}
+
+unsafe fn f10() -> i32 {
+    libc::SOCK_NONBLOCK
+}

--- a/tests/unit/out/refcount/socket_type_constants.rs
+++ b/tests/unit/out/refcount/socket_type_constants.rs
@@ -12,11 +12,5 @@ pub fn main() {
 fn main_0() -> i32 {
     assert!((((libc::SOCK_STREAM == 1) as i32) != 0));
     assert!((((libc::SOCK_DGRAM == 2) as i32) != 0));
-    let x: Value<i32> = Rc::new(RefCell::new((libc::SOCK_STREAM | libc::SOCK_CLOEXEC)));
-    assert!((((((*x.borrow()) & libc::SOCK_STREAM) == libc::SOCK_STREAM) as i32) != 0));
-    assert!((((((*x.borrow()) & libc::SOCK_CLOEXEC) == libc::SOCK_CLOEXEC) as i32) != 0));
-    let y: Value<i32> = Rc::new(RefCell::new((libc::SOCK_DGRAM | libc::SOCK_NONBLOCK)));
-    assert!((((((*y.borrow()) & libc::SOCK_DGRAM) == libc::SOCK_DGRAM) as i32) != 0));
-    assert!((((((*y.borrow()) & libc::SOCK_NONBLOCK) == libc::SOCK_NONBLOCK) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/refcount/socket_type_constants.rs
+++ b/tests/unit/out/refcount/socket_type_constants.rs
@@ -12,11 +12,6 @@ pub fn main() {
 fn main_0() -> i32 {
     assert!((((libc::SOCK_STREAM == 1) as i32) != 0));
     assert!((((libc::SOCK_DGRAM == 2) as i32) != 0));
-    assert!((((libc::SOCK_RAW == 3) as i32) != 0));
-    assert!((((libc::SOCK_RDM == 4) as i32) != 0));
-    assert!((((libc::SOCK_SEQPACKET == 5) as i32) != 0));
-    assert!((((libc::SOCK_DCCP == 6) as i32) != 0));
-    assert!((((libc::SOCK_PACKET == 10) as i32) != 0));
     let x: Value<i32> = Rc::new(RefCell::new((libc::SOCK_STREAM | libc::SOCK_CLOEXEC)));
     assert!((((((*x.borrow()) & libc::SOCK_STREAM) == libc::SOCK_STREAM) as i32) != 0));
     assert!((((((*x.borrow()) & libc::SOCK_CLOEXEC) == libc::SOCK_CLOEXEC) as i32) != 0));

--- a/tests/unit/out/refcount/socket_type_constants.rs
+++ b/tests/unit/out/refcount/socket_type_constants.rs
@@ -1,0 +1,27 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!((((libc::SOCK_STREAM == 1) as i32) != 0));
+    assert!((((libc::SOCK_DGRAM == 2) as i32) != 0));
+    assert!((((libc::SOCK_RAW == 3) as i32) != 0));
+    assert!((((libc::SOCK_RDM == 4) as i32) != 0));
+    assert!((((libc::SOCK_SEQPACKET == 5) as i32) != 0));
+    assert!((((libc::SOCK_DCCP == 6) as i32) != 0));
+    assert!((((libc::SOCK_PACKET == 10) as i32) != 0));
+    let x: Value<i32> = Rc::new(RefCell::new((libc::SOCK_STREAM | libc::SOCK_CLOEXEC)));
+    assert!((((((*x.borrow()) & libc::SOCK_STREAM) == libc::SOCK_STREAM) as i32) != 0));
+    assert!((((((*x.borrow()) & libc::SOCK_CLOEXEC) == libc::SOCK_CLOEXEC) as i32) != 0));
+    let y: Value<i32> = Rc::new(RefCell::new((libc::SOCK_DGRAM | libc::SOCK_NONBLOCK)));
+    assert!((((((*y.borrow()) & libc::SOCK_DGRAM) == libc::SOCK_DGRAM) as i32) != 0));
+    assert!((((((*y.borrow()) & libc::SOCK_NONBLOCK) == libc::SOCK_NONBLOCK) as i32) != 0));
+    return 0;
+}

--- a/tests/unit/out/unsafe/socket_type_constants.rs
+++ b/tests/unit/out/unsafe/socket_type_constants.rs
@@ -14,11 +14,5 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     assert!(((((libc::SOCK_STREAM) == (1)) as i32) != 0));
     assert!(((((libc::SOCK_DGRAM) == (2)) as i32) != 0));
-    let mut x: i32 = ((libc::SOCK_STREAM) | (libc::SOCK_CLOEXEC));
-    assert!((((((x) & (libc::SOCK_STREAM)) == (libc::SOCK_STREAM)) as i32) != 0));
-    assert!((((((x) & (libc::SOCK_CLOEXEC)) == (libc::SOCK_CLOEXEC)) as i32) != 0));
-    let mut y: i32 = ((libc::SOCK_DGRAM) | (libc::SOCK_NONBLOCK));
-    assert!((((((y) & (libc::SOCK_DGRAM)) == (libc::SOCK_DGRAM)) as i32) != 0));
-    assert!((((((y) & (libc::SOCK_NONBLOCK)) == (libc::SOCK_NONBLOCK)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/socket_type_constants.rs
+++ b/tests/unit/out/unsafe/socket_type_constants.rs
@@ -1,0 +1,29 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(((((libc::SOCK_STREAM) == (1)) as i32) != 0));
+    assert!(((((libc::SOCK_DGRAM) == (2)) as i32) != 0));
+    assert!(((((libc::SOCK_RAW) == (3)) as i32) != 0));
+    assert!(((((libc::SOCK_RDM) == (4)) as i32) != 0));
+    assert!(((((libc::SOCK_SEQPACKET) == (5)) as i32) != 0));
+    assert!(((((libc::SOCK_DCCP) == (6)) as i32) != 0));
+    assert!(((((libc::SOCK_PACKET) == (10)) as i32) != 0));
+    let mut x: i32 = ((libc::SOCK_STREAM) | (libc::SOCK_CLOEXEC));
+    assert!((((((x) & (libc::SOCK_STREAM)) == (libc::SOCK_STREAM)) as i32) != 0));
+    assert!((((((x) & (libc::SOCK_CLOEXEC)) == (libc::SOCK_CLOEXEC)) as i32) != 0));
+    let mut y: i32 = ((libc::SOCK_DGRAM) | (libc::SOCK_NONBLOCK));
+    assert!((((((y) & (libc::SOCK_DGRAM)) == (libc::SOCK_DGRAM)) as i32) != 0));
+    assert!((((((y) & (libc::SOCK_NONBLOCK)) == (libc::SOCK_NONBLOCK)) as i32) != 0));
+    return 0;
+}

--- a/tests/unit/out/unsafe/socket_type_constants.rs
+++ b/tests/unit/out/unsafe/socket_type_constants.rs
@@ -14,11 +14,6 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     assert!(((((libc::SOCK_STREAM) == (1)) as i32) != 0));
     assert!(((((libc::SOCK_DGRAM) == (2)) as i32) != 0));
-    assert!(((((libc::SOCK_RAW) == (3)) as i32) != 0));
-    assert!(((((libc::SOCK_RDM) == (4)) as i32) != 0));
-    assert!(((((libc::SOCK_SEQPACKET) == (5)) as i32) != 0));
-    assert!(((((libc::SOCK_DCCP) == (6)) as i32) != 0));
-    assert!(((((libc::SOCK_PACKET) == (10)) as i32) != 0));
     let mut x: i32 = ((libc::SOCK_STREAM) | (libc::SOCK_CLOEXEC));
     assert!((((((x) & (libc::SOCK_STREAM)) == (libc::SOCK_STREAM)) as i32) != 0));
     assert!((((((x) & (libc::SOCK_CLOEXEC)) == (libc::SOCK_CLOEXEC)) as i32) != 0));

--- a/tests/unit/socket_type_constants.c
+++ b/tests/unit/socket_type_constants.c
@@ -6,6 +6,7 @@ int main() {
   assert(SOCK_STREAM == 1);
   assert(SOCK_DGRAM == 2);
 
+#ifdef __linux__
   int x = SOCK_STREAM | SOCK_CLOEXEC;
   assert((x & SOCK_STREAM) == SOCK_STREAM);
   assert((x & SOCK_CLOEXEC) == SOCK_CLOEXEC);
@@ -13,6 +14,7 @@ int main() {
   int y = SOCK_DGRAM | SOCK_NONBLOCK;
   assert((y & SOCK_DGRAM) == SOCK_DGRAM);
   assert((y & SOCK_NONBLOCK) == SOCK_NONBLOCK);
+#endif
 
   return 0;
 }

--- a/tests/unit/socket_type_constants.c
+++ b/tests/unit/socket_type_constants.c
@@ -5,16 +5,5 @@
 int main() {
   assert(SOCK_STREAM == 1);
   assert(SOCK_DGRAM == 2);
-
-#ifdef __linux__
-  int x = SOCK_STREAM | SOCK_CLOEXEC;
-  assert((x & SOCK_STREAM) == SOCK_STREAM);
-  assert((x & SOCK_CLOEXEC) == SOCK_CLOEXEC);
-
-  int y = SOCK_DGRAM | SOCK_NONBLOCK;
-  assert((y & SOCK_DGRAM) == SOCK_DGRAM);
-  assert((y & SOCK_NONBLOCK) == SOCK_NONBLOCK);
-#endif
-
   return 0;
 }

--- a/tests/unit/socket_type_constants.c
+++ b/tests/unit/socket_type_constants.c
@@ -5,11 +5,6 @@
 int main() {
   assert(SOCK_STREAM == 1);
   assert(SOCK_DGRAM == 2);
-  assert(SOCK_RAW == 3);
-  assert(SOCK_RDM == 4);
-  assert(SOCK_SEQPACKET == 5);
-  assert(SOCK_DCCP == 6);
-  assert(SOCK_PACKET == 10);
 
   int x = SOCK_STREAM | SOCK_CLOEXEC;
   assert((x & SOCK_STREAM) == SOCK_STREAM);

--- a/tests/unit/socket_type_constants.c
+++ b/tests/unit/socket_type_constants.c
@@ -1,0 +1,23 @@
+#include <assert.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+int main() {
+  assert(SOCK_STREAM == 1);
+  assert(SOCK_DGRAM == 2);
+  assert(SOCK_RAW == 3);
+  assert(SOCK_RDM == 4);
+  assert(SOCK_SEQPACKET == 5);
+  assert(SOCK_DCCP == 6);
+  assert(SOCK_PACKET == 10);
+
+  int x = SOCK_STREAM | SOCK_CLOEXEC;
+  assert((x & SOCK_STREAM) == SOCK_STREAM);
+  assert((x & SOCK_CLOEXEC) == SOCK_CLOEXEC);
+
+  int y = SOCK_DGRAM | SOCK_NONBLOCK;
+  assert((y & SOCK_DGRAM) == SOCK_DGRAM);
+  assert((y & SOCK_NONBLOCK) == SOCK_NONBLOCK);
+
+  return 0;
+}


### PR DESCRIPTION
This adds support for translating socket_types values: SOCK_STREAM, SOCK_DGRAM, SOCK_CLOEXEC (Linux specific), SOCK_NONBLOCK (Linux specific).

The rules for CLOEXEC and NONBLOCK are only visible on Linux using the new IR field called `target_os`. On the C++ side, the rules are guarded with a macro:

```cpp
#ifdef __linux__
int f4() {
  return SOCK_CLOEXEC;
}

int f5() {
  return SOCK_NONBLOCK;
}
#endif
```

On the Rust side, they are guarded using the target_os attribute:

```rs
#[cfg(target_os = "linux")]
unsafe fn f4() -> i32 {
    libc::SOCK_CLOEXEC
}

#[cfg(target_os = "linux")]
unsafe fn f5() -> i32 {
    libc::SOCK_NONBLOCK
}
```

`rule-preprocessor` parses the attributes of a function and adds `target_os = linux` in the IR. `translation_rule.cpp` skips the rule if the current OS is not the same as the OS declared by `target_os`.