### PR TITLE
Fix test failures on master

### DIFF
--- a/tests/unit/out/refcount/va_arg_null_int_ptr.rs
+++ b/tests/unit/out/refcount/va_arg_null_int_ptr.rs
@@ -6,10 +6,10 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-pub fn first_nonnull_0(count: i32, args: &[VaArg]) -> i32 {
+pub fn first_nonnull_0(count: i32, __args: &[VaArg]) -> i32 {
     let count: Value<i32> = Rc::new(RefCell::new(count));
     let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
-    (*ap.borrow_mut()) = VaList::new(args);
+    (*ap.borrow_mut()) = VaList::new(__args);
     let result: Value<i32> = Rc::new(RefCell::new(-1_i32));
     let i: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while ((((*i.borrow()) < (*count.borrow())) as i32) != 0) {

--- a/tests/unit/out/unsafe/va_arg_null_int_ptr.rs
+++ b/tests/unit/out/unsafe/va_arg_null_int_ptr.rs
@@ -6,9 +6,9 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-pub unsafe fn first_nonnull_0(mut count: i32, args: &[VaArg]) -> i32 {
+pub unsafe fn first_nonnull_0(mut count: i32, __args: &[VaArg]) -> i32 {
     let mut ap: VaList = VaList::default();
-    ap = VaList::new(args);
+    ap = VaList::new(__args);
     let mut result: i32 = -1_i32;
     let mut i: i32 = 0;
     'loop_: while ((((i) < (count)) as i32) != 0) {


### PR DESCRIPTION
When 8fb2e89ed7be2092c0d9120f1f4e91eabe9a3439 entered mater, the test output got out-of-sync. This fixes it.