### PR TITLE
Support implicit conversion in std::vector constructor

### DIFF
--- a/rules/vector/ir_refcount.json
+++ b/rules/vector/ir_refcount.json
@@ -1235,12 +1235,43 @@
               "method_call": {
                 "receiver": [
                   {
-                    "text": "__a0"
+                    "method_call": {
+                      "receiver": [
+                        {
+                          "generic": 1
+                        },
+                        {
+                          "text": "::try_from("
+                        },
+                        {
+                          "method_call": {
+                            "receiver": [
+                              {
+                                "text": "__a0"
+                              }
+                            ],
+                            "body": [
+                              {
+                                "text": ".read()"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "text": ")"
+                        }
+                      ],
+                      "body": [
+                        {
+                          "text": ".ok()"
+                        }
+                      ]
+                    }
                   }
                 ],
                 "body": [
                   {
-                    "text": ".read()"
+                    "text": ".unwrap()"
                   }
                 ]
               }
@@ -1257,6 +1288,9 @@
     ],
     "generics": {
       "T1": [
+        "TryFrom<T2>"
+      ],
+      "T2": [
         "Clone",
         "ByteRepr"
       ]
@@ -1264,137 +1298,16 @@
     "multi_statement": true,
     "params": {
       "a0": {
-        "type": "Ptr<T1>",
+        "type": "Ptr<T2>",
         "is_refcount_pointer": true
       },
       "a1": {
-        "type": "Ptr<T1>",
+        "type": "Ptr<T2>",
         "is_refcount_pointer": true
       }
     },
     "return_type": {
       "type": "Vec<T1>"
-    }
-  },
-  "f39": {
-    "body": [
-      {
-        "text": "let mut __a0 = "
-      },
-      {
-        "method_call": {
-          "receiver": [
-            {
-              "placeholder": {
-                "arg": 0,
-                "access": "read"
-              }
-            }
-          ],
-          "body": [
-            {
-              "text": ".clone()"
-            }
-          ]
-        }
-      },
-      {
-        "text": ";\n    let mut __out = Vec::with_capacity("
-      },
-      {
-        "method_call": {
-          "receiver": [
-            {
-              "placeholder": {
-                "arg": 1,
-                "access": "read"
-              }
-            }
-          ],
-          "body": [
-            {
-              "text": ".get_offset()"
-            }
-          ]
-        }
-      },
-      {
-        "text": " - "
-      },
-      {
-        "method_call": {
-          "receiver": [
-            {
-              "text": "__a0"
-            }
-          ],
-          "body": [
-            {
-              "text": ".get_offset()"
-            }
-          ]
-        }
-      },
-      {
-        "text": ");\n    while __a0 != "
-      },
-      {
-        "placeholder": {
-          "arg": 1,
-          "access": "read"
-        }
-      },
-      {
-        "text": " {\n        "
-      },
-      {
-        "method_call": {
-          "receiver": [
-            {
-              "text": "__out"
-            }
-          ],
-          "body": [
-            {
-              "text": ".push("
-            },
-            {
-              "method_call": {
-                "receiver": [
-                  {
-                    "text": "__a0"
-                  }
-                ],
-                "body": [
-                  {
-                    "text": ".read()"
-                  }
-                ]
-              }
-            },
-            {
-              "text": " as i32)"
-            }
-          ]
-        }
-      },
-      {
-        "text": ";\n        __a0 += 1;\n    }\n    __out"
-      }
-    ],
-    "multi_statement": true,
-    "params": {
-      "a0": {
-        "type": "Ptr<u32>",
-        "is_refcount_pointer": true
-      },
-      "a1": {
-        "type": "Ptr<u32>",
-        "is_refcount_pointer": true
-      }
-    },
-    "return_type": {
-      "type": "Vec<i32>"
     }
   },
   "f40": {

--- a/rules/vector/ir_unsafe.json
+++ b/rules/vector/ir_unsafe.json
@@ -1437,144 +1437,6 @@
         "method_call": {
           "receiver": [
             {
-              "text": "core::slice::from_raw_parts("
-            },
-            {
-              "placeholder": {
-                "arg": 0,
-                "access": "read"
-              }
-            },
-            {
-              "text": ", "
-            },
-            {
-              "method_call": {
-                "receiver": [
-                  {
-                    "text": "("
-                  },
-                  {
-                    "placeholder": {
-                      "arg": 1,
-                      "access": "write"
-                    }
-                  },
-                  {
-                    "text": ")"
-                  }
-                ],
-                "body": [
-                  {
-                    "text": ".offset_from("
-                  },
-                  {
-                    "placeholder": {
-                      "arg": 0,
-                      "access": "read"
-                    }
-                  },
-                  {
-                    "text": ")"
-                  }
-                ]
-              }
-            },
-            {
-              "text": " as usize)"
-            }
-          ],
-          "body": [
-            {
-              "text": ".to_vec()"
-            }
-          ]
-        }
-      }
-    ],
-    "generics": {
-      "T1": [
-        "Clone"
-      ]
-    },
-    "params": {
-      "a0": {
-        "type": "*mut T1",
-        "is_unsafe_pointer": true
-      },
-      "a1": {
-        "type": "*mut T1",
-        "is_unsafe_pointer": true
-      }
-    },
-    "return_type": {
-      "type": "Vec<T1>"
-    }
-  },
-  "f38": {
-    "body": [
-      {
-        "method_call": {
-          "receiver": [
-            {
-              "method_call": {
-                "receiver": [
-                  {
-                    "text": "(0..("
-                  },
-                  {
-                    "placeholder": {
-                      "arg": 0,
-                      "access": "read"
-                    }
-                  },
-                  {
-                    "text": ") as usize)"
-                  }
-                ],
-                "body": [
-                  {
-                    "text": ".map(|_| "
-                  },
-                  {
-                    "placeholder": {
-                      "arg": 1,
-                      "access": "read"
-                    }
-                  },
-                  {
-                    "text": ")"
-                  }
-                ]
-              }
-            }
-          ],
-          "body": [
-            {
-              "text": ".collect::<Vec<bool>>()"
-            }
-          ]
-        }
-      }
-    ],
-    "params": {
-      "a0": {
-        "type": "usize"
-      },
-      "a1": {
-        "type": "bool"
-      }
-    },
-    "return_type": {
-      "type": "Vec<bool>"
-    }
-  },
-  "f39": {
-    "body": [
-      {
-        "method_call": {
-          "receiver": [
-            {
               "method_call": {
                 "receiver": [
                   {
@@ -1638,7 +1500,55 @@
                 ],
                 "body": [
                   {
-                    "text": ".map(|&x| x as i32)"
+                    "text": ".map(|x| "
+                  },
+                  {
+                    "method_call": {
+                      "receiver": [
+                        {
+                          "method_call": {
+                            "receiver": [
+                              {
+                                "generic": 1
+                              },
+                              {
+                                "text": "::try_from("
+                              },
+                              {
+                                "method_call": {
+                                  "receiver": [
+                                    {
+                                      "text": "x"
+                                    }
+                                  ],
+                                  "body": [
+                                    {
+                                      "text": ".clone()"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "text": ")"
+                              }
+                            ],
+                            "body": [
+                              {
+                                "text": ".ok()"
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "body": [
+                        {
+                          "text": ".unwrap()"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "text": ")"
                   }
                 ]
               }
@@ -1652,18 +1562,84 @@
         }
       }
     ],
+    "generics": {
+      "T1": [
+        "TryFrom<T2>"
+      ],
+      "T2": [
+        "Clone"
+      ]
+    },
     "params": {
       "a0": {
-        "type": "*mut u32",
+        "type": "*mut T2",
         "is_unsafe_pointer": true
       },
       "a1": {
-        "type": "*mut u32",
+        "type": "*mut T2",
         "is_unsafe_pointer": true
       }
     },
     "return_type": {
-      "type": "Vec<i32>"
+      "type": "Vec<T1>"
+    }
+  },
+  "f38": {
+    "body": [
+      {
+        "method_call": {
+          "receiver": [
+            {
+              "method_call": {
+                "receiver": [
+                  {
+                    "text": "(0..("
+                  },
+                  {
+                    "placeholder": {
+                      "arg": 0,
+                      "access": "read"
+                    }
+                  },
+                  {
+                    "text": ") as usize)"
+                  }
+                ],
+                "body": [
+                  {
+                    "text": ".map(|_| "
+                  },
+                  {
+                    "placeholder": {
+                      "arg": 1,
+                      "access": "read"
+                    }
+                  },
+                  {
+                    "text": ")"
+                  }
+                ]
+              }
+            }
+          ],
+          "body": [
+            {
+              "text": ".collect::<Vec<bool>>()"
+            }
+          ]
+        }
+      }
+    ],
+    "params": {
+      "a0": {
+        "type": "usize"
+      },
+      "a1": {
+        "type": "bool"
+      }
+    },
+    "return_type": {
+      "type": "Vec<bool>"
     }
   },
   "f4": {

--- a/rules/vector/src.cpp
+++ b/rules/vector/src.cpp
@@ -171,16 +171,13 @@ std::vector<T1> f36(const std::initializer_list<T1> &a0) {
   return std::vector<T1>(a0);
 }
 
-template <typename T1> std::vector<T1> f37(T1 *first, T1 *last) {
+template <typename T1, typename T2>
+std::vector<T1> f37(T2 *first, T2 *last) {
   return std::vector<T1>(first, last);
 }
 
 std::vector<bool> f38(std::size_t n, const bool &value) {
   return std::vector<bool>(n, value);
-}
-
-std::vector<int> f39(unsigned int *first, unsigned int *last) {
-  return std::vector<int>(first, last);
 }
 
 template <class T1, std::size_t T2> const T1 *f40(T1 const (&a0)[T2]) {

--- a/rules/vector/tgt_refcount.rs
+++ b/rules/vector/tgt_refcount.rs
@@ -122,21 +122,11 @@ fn f35<T1: Clone + ByteRepr>(a0: Ptr<T1>, a1: Ptr<T1>) -> Vec<T1> {
     __out
 }
 
-fn f37<T1: Clone + ByteRepr>(a0: Ptr<T1>, a1: Ptr<T1>) -> Vec<T1> {
+fn f37<T1: TryFrom<T2>, T2: Clone + ByteRepr>(a0: Ptr<T2>, a1: Ptr<T2>) -> Vec<T1> {
     let mut __a0 = a0.clone();
     let mut __out = Vec::with_capacity(a1.get_offset() - __a0.get_offset());
     while __a0 != a1 {
-        __out.push(__a0.read());
-        __a0 += 1;
-    }
-    __out
-}
-
-fn f39(a0: Ptr<u32>, a1: Ptr<u32>) -> Vec<i32> {
-    let mut __a0 = a0.clone();
-    let mut __out = Vec::with_capacity(a1.get_offset() - __a0.get_offset());
-    while __a0 != a1 {
-        __out.push(__a0.read() as i32);
+        __out.push(T1::try_from(__a0.read()).ok().unwrap());
         __a0 += 1;
     }
     __out

--- a/rules/vector/tgt_unsafe.rs
+++ b/rules/vector/tgt_unsafe.rs
@@ -142,19 +142,15 @@ unsafe fn f36<T1>(a0: Vec<T1>) -> Vec<T1> {
     a0
 }
 
-unsafe fn f37<T1: Clone>(a0: *mut T1, a1: *mut T1) -> Vec<T1> {
-    core::slice::from_raw_parts(a0, (a1).offset_from(a0) as usize).to_vec()
+unsafe fn f37<T1: TryFrom<T2>, T2: Clone>(a0: *mut T2, a1: *mut T2) -> Vec<T1> {
+    core::slice::from_raw_parts(a0, (a1).offset_from(a0) as usize)
+        .iter()
+        .map(|x| T1::try_from(x.clone()).ok().unwrap())
+        .collect()
 }
 
 unsafe fn f38(a0: usize, a1: bool) -> Vec<bool> {
     (0..(a0) as usize).map(|_| a1).collect::<Vec<bool>>()
-}
-
-unsafe fn f39(a0: *mut u32, a1: *mut u32) -> Vec<i32> {
-    core::slice::from_raw_parts(a0, (a1).offset_from(a0) as usize)
-        .iter()
-        .map(|&x| x as i32)
-        .collect()
 }
 
 unsafe fn f40<T1>(a0: Vec<T1>) -> *const T1 {

--- a/tests/unit/out/refcount/push_emplace_back.rs
+++ b/tests/unit/out/refcount/push_emplace_back.rs
@@ -88,7 +88,7 @@ pub fn push_local_from_field_1(jpg: Ptr<JPEGData>, cond: bool) {
                             - __a0.get_offset(),
                     );
                     while __a0 != (head.as_pointer() as Ptr<u8>).offset((3) as isize) {
-                        __out.push(__a0.read());
+                        __out.push(u8::try_from(__a0.read()).ok().unwrap());
                         __a0 += 1;
                     }
                     __out
@@ -134,7 +134,7 @@ pub fn emplace_local_from_field_4(jpg: Ptr<JPEGData>, cond: bool) {
                         - __a0.get_offset(),
                 );
                 while __a0 != (head.as_pointer() as Ptr<u8>).offset((3) as isize) {
-                    __out.push(__a0.read());
+                    __out.push(u8::try_from(__a0.read()).ok().unwrap());
                     __a0 += 1;
                 }
                 __out

--- a/tests/unit/out/refcount/vector_iter_range_ctor.rs
+++ b/tests/unit/out/refcount/vector_iter_range_ctor.rs
@@ -1,0 +1,75 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let src: Value<Box<[u32]>> = Rc::new(RefCell::new(Box::new([1_u32, 2_u32, 3_u32])));
+    let v1: Value<Vec<u32>> = Rc::new(RefCell::new({
+        let mut __a0 = (src.as_pointer() as Ptr<u32>).clone();
+        let mut __out = Vec::with_capacity(
+            (src.as_pointer() as Ptr<u32>)
+                .offset((3) as isize)
+                .get_offset()
+                - __a0.get_offset(),
+        );
+        while __a0 != (src.as_pointer() as Ptr<u32>).offset((3) as isize) {
+            __out.push(u32::try_from(__a0.read()).ok().unwrap());
+            __a0 += 1;
+        }
+        __out
+    }));
+    assert!(((*v1.borrow()).len() as u64 == 3_u64));
+    assert!(
+        ((((v1.as_pointer() as Ptr<u32>).offset(0_u64 as isize).read()) == 1_u32)
+            && (((v1.as_pointer() as Ptr<u32>).offset(1_u64 as isize).read()) == 2_u32))
+            && (((v1.as_pointer() as Ptr<u32>).offset(2_u64 as isize).read()) == 3_u32)
+    );
+    let v2: Value<Vec<u64>> = Rc::new(RefCell::new({
+        let mut __a0 = (src.as_pointer() as Ptr<u32>).clone();
+        let mut __out = Vec::with_capacity(
+            (src.as_pointer() as Ptr<u32>)
+                .offset((3) as isize)
+                .get_offset()
+                - __a0.get_offset(),
+        );
+        while __a0 != (src.as_pointer() as Ptr<u32>).offset((3) as isize) {
+            __out.push(u64::try_from(__a0.read()).ok().unwrap());
+            __a0 += 1;
+        }
+        __out
+    }));
+    assert!(((*v2.borrow()).len() as u64 == 3_u64));
+    assert!(
+        ((((v2.as_pointer() as Ptr<u64>).offset(0_u64 as isize).read()) == 1_u64)
+            && (((v2.as_pointer() as Ptr<u64>).offset(1_u64 as isize).read()) == 2_u64))
+            && (((v2.as_pointer() as Ptr<u64>).offset(2_u64 as isize).read()) == 3_u64)
+    );
+    let v3: Value<Vec<i32>> = Rc::new(RefCell::new({
+        let mut __a0 = (src.as_pointer() as Ptr<u32>).clone();
+        let mut __out = Vec::with_capacity(
+            (src.as_pointer() as Ptr<u32>)
+                .offset((3) as isize)
+                .get_offset()
+                - __a0.get_offset(),
+        );
+        while __a0 != (src.as_pointer() as Ptr<u32>).offset((3) as isize) {
+            __out.push(i32::try_from(__a0.read()).ok().unwrap());
+            __a0 += 1;
+        }
+        __out
+    }));
+    assert!(((*v3.borrow()).len() as u64 == 3_u64));
+    assert!(
+        ((((v3.as_pointer() as Ptr<i32>).offset(0_u64 as isize).read()) == 1)
+            && (((v3.as_pointer() as Ptr<i32>).offset(1_u64 as isize).read()) == 2))
+            && (((v3.as_pointer() as Ptr<i32>).offset(2_u64 as isize).read()) == 3)
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/push_emplace_back.rs
+++ b/tests/unit/out/unsafe/push_emplace_back.rs
@@ -39,7 +39,9 @@ pub unsafe fn push_local_from_field_1(mut jpg: *mut JPEGData, mut cond: bool) {
             head.as_mut_ptr(),
             (head.as_mut_ptr().offset((3) as isize)).offset_from(head.as_mut_ptr()) as usize,
         )
-        .to_vec(),
+        .iter()
+        .map(|x| u8::try_from(x.clone()).ok().unwrap())
+        .collect(),
     );
 }
 pub unsafe fn shrink_through_ptr_2(mut comps: *mut Vec<Chunk>) {
@@ -61,7 +63,9 @@ pub unsafe fn emplace_local_from_field_4(mut jpg: *mut JPEGData, mut cond: bool)
             head.as_mut_ptr(),
             (head.as_mut_ptr().offset((3) as isize)).offset_from(head.as_mut_ptr()) as usize,
         )
-        .to_vec(),
+        .iter()
+        .map(|x| u8::try_from(x.clone()).ok().unwrap())
+        .collect(),
     );
 }
 pub unsafe fn nested_emplace_move_5(mut bw: *mut Writer) {

--- a/tests/unit/out/unsafe/vector_iter_range_ctor.rs
+++ b/tests/unit/out/unsafe/vector_iter_range_ctor.rs
@@ -1,0 +1,53 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut src: [u32; 3] = [1_u32, 2_u32, 3_u32];
+    let mut v1: Vec<u32> = core::slice::from_raw_parts(
+        src.as_mut_ptr(),
+        (src.as_mut_ptr().offset((3) as isize)).offset_from(src.as_mut_ptr()) as usize,
+    )
+    .iter()
+    .map(|x| u32::try_from(x.clone()).ok().unwrap())
+    .collect();
+    assert!(((v1.len() as u64) == (3_u64)));
+    assert!(
+        (((v1[(0_u64) as usize]) == (1_u32)) && ((v1[(1_u64) as usize]) == (2_u32)))
+            && ((v1[(2_u64) as usize]) == (3_u32))
+    );
+    let mut v2: Vec<u64> = core::slice::from_raw_parts(
+        src.as_mut_ptr(),
+        (src.as_mut_ptr().offset((3) as isize)).offset_from(src.as_mut_ptr()) as usize,
+    )
+    .iter()
+    .map(|x| u64::try_from(x.clone()).ok().unwrap())
+    .collect();
+    assert!(((v2.len() as u64) == (3_u64)));
+    assert!(
+        (((v2[(0_u64) as usize]) == (1_u64)) && ((v2[(1_u64) as usize]) == (2_u64)))
+            && ((v2[(2_u64) as usize]) == (3_u64))
+    );
+    let mut v3: Vec<i32> = core::slice::from_raw_parts(
+        src.as_mut_ptr(),
+        (src.as_mut_ptr().offset((3) as isize)).offset_from(src.as_mut_ptr()) as usize,
+    )
+    .iter()
+    .map(|x| i32::try_from(x.clone()).ok().unwrap())
+    .collect();
+    assert!(((v3.len() as u64) == (3_u64)));
+    assert!(
+        (((v3[(0_u64) as usize]) == (1)) && ((v3[(1_u64) as usize]) == (2)))
+            && ((v3[(2_u64) as usize]) == (3))
+    );
+    return 0;
+}

--- a/tests/unit/vector_iter_range_ctor.cpp
+++ b/tests/unit/vector_iter_range_ctor.cpp
@@ -1,5 +1,4 @@
 #include <assert.h>
-
 #include <cstddef>
 #include <cstdint>
 #include <vector>

--- a/tests/unit/vector_iter_range_ctor.cpp
+++ b/tests/unit/vector_iter_range_ctor.cpp
@@ -1,0 +1,26 @@
+#include <assert.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+int main() {
+  uint32_t src[3] = {1, 2, 3};
+
+  // Same-type iterator-range constructor.
+  std::vector<uint32_t> v1(src, src + 3);
+  assert(v1.size() == 3);
+  assert(v1[0] == 1 && v1[1] == 2 && v1[2] == 3);
+
+  // Cross-type widening (uint32_t -> size_t).
+  std::vector<size_t> v2(src, src + 3);
+  assert(v2.size() == 3);
+  assert(v2[0] == 1 && v2[1] == 2 && v2[2] == 3);
+
+  // Cross-type sign-flip (uint32_t -> int).
+  std::vector<int> v3(src, src + 3);
+  assert(v3.size() == 3);
+  assert(v3[0] == 1 && v3[1] == 2 && v3[2] == 3);
+
+  return 0;
+}


### PR DESCRIPTION
Previously, f39 was a hack to support implicit cast in constructing a vector over the more generic f37 rule.

I changed f37 to support implicit casts so that can write:

```cpp
uint32_t src[3] = {1, 2, 3};
std::vector<int> v2(src, src + 3);
```