### PR TITLE
Distinguish between empty match and non-match

### DIFF
--- a/cpp2rust/converter/mapper.cpp
+++ b/cpp2rust/converter/mapper.cpp
@@ -9,6 +9,7 @@
 #include <llvm/Support/ThreadPool.h>
 
 #include <format>
+#include <optional>
 #include <regex>
 #include <unordered_map>
 #include <utility>
@@ -93,7 +94,7 @@ void AddTypeRule(std::string src, TranslationRule::TypeRule &&rule) {
 //   template_str   = "std::vector<T1>::vector()"
 //   instantiated   = "std::vector<int>::vector()"
 //   result         = { "int" }
-std::optional<std::vector<std::string>>
+std::optional<std::vector<std::optional<std::string>>>
 matchTemplate(const std::string &template_str,
               const std::string &instantiated) {
   auto matchLiteralAt = [&](const std::string &input_str, size_t pos,
@@ -220,7 +221,7 @@ matchTemplate(const std::string &template_str,
     return std::string::npos;
   };
 
-  std::vector<std::string> captured;
+  std::vector<std::optional<std::string>> captured;
 
   size_t ti = 0;
   size_t si = 0;
@@ -250,9 +251,9 @@ matchTemplate(const std::string &template_str,
 
       captured.resize(std::max(captured.size(), type_idx + 1));
       auto &repl = captured[type_idx];
-      if (!repl.empty()) {
+      if (repl.has_value()) {
         size_t end_pos = 0;
-        if (!matchLiteralAt(instantiated, si, repl, end_pos)) {
+        if (!matchLiteralAt(instantiated, si, *repl, end_pos)) {
           return std::nullopt;
         }
         si = end_pos;
@@ -338,7 +339,7 @@ matchTemplate(const std::string &template_str,
 //   types        = { {"i32"} }
 //   tgt_template = "Vec<T1>"
 //   result       = "Vec<i32>"
-std::string instantiateTgt(const std::vector<std::string> &types,
+std::string instantiateTgt(const std::vector<std::optional<std::string>> &types,
                            const std::string &tgt_template) {
   assert(types.size() <= 9);
   std::string instantiated_template = tgt_template;
@@ -351,7 +352,7 @@ std::string instantiateTgt(const std::vector<std::string> &types,
       ++pos;
       continue;
     }
-    auto &repl = types.at(instantiated_template[pos + 1] - '1');
+    const auto &repl = types.at(instantiated_template[pos + 1] - '1').value();
     instantiated_template.replace(pos, 2, repl);
     pos += repl.length();
   }
@@ -359,12 +360,12 @@ std::string instantiateTgt(const std::vector<std::string> &types,
 }
 
 template <typename T>
-std::pair<T *, std::vector<std::string>>
+std::pair<T *, std::vector<std::optional<std::string>>>
 search(std::unordered_multimap<std::string, T> &map, const std::string &txt,
        const std::string &key) {
   auto [it, end] = map.equal_range(key);
   T *rule = nullptr;
-  std::vector<std::string> subs;
+  std::vector<std::optional<std::string>> subs;
 
   for (; it != end; ++it) {
     auto &this_rule = it->second;
@@ -540,7 +541,9 @@ std::string mapTypeStringRecursive(const std::string &cpp_type) {
     assert(0 && "Type is not present in types_");
   }
   for (auto &ty : subs) {
-    ty = mapTypeStringRecursive(ty);
+    if (ty) {
+      ty = mapTypeStringRecursive(*ty);
+    }
   }
   return instantiateTgt(subs, rule->type_info.type);
 }
@@ -608,7 +611,9 @@ std::string InstantiateTemplate(const clang::Expr *expr, unsigned n) {
     return text;
   }
   for (auto &ty : subs) {
-    ty = mapTypeStringRecursive(ty);
+    if (ty) {
+      ty = mapTypeStringRecursive(*ty);
+    }
   }
   return instantiateTgt(subs, text);
 }
@@ -618,7 +623,9 @@ std::string Map(clang::QualType qual_type) {
   auto [rule, subs] = search(types_, type_str, GetTypeMapKey(type_str));
   if (rule) {
     for (auto &ty : subs) {
-      ty = mapTypeStringRecursive(ty);
+      if (ty) {
+        ty = mapTypeStringRecursive(*ty);
+      }
     }
     return instantiateTgt(subs, rule->type_info.type);
   }
@@ -651,7 +658,9 @@ std::string GetParamType(const clang::Expr *expr, unsigned index) {
   auto expr_str = ToString(expr);
   auto [rule, subs] = search(exprs_, expr_str, GetExprMapKey(expr_str));
   for (auto &ty : subs) {
-    ty = mapTypeStringRecursive(ty);
+    if (ty) {
+      ty = mapTypeStringRecursive(*ty);
+    }
   }
   return instantiateTgt(subs, rule->params.at(index).type);
 }

--- a/tests/unit/out/refcount/vector_addr_of_back.rs
+++ b/tests/unit/out/refcount/vector_addr_of_back.rs
@@ -1,0 +1,23 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let outer: Value<Vec<Value<Vec<i32>>>> = Rc::new(RefCell::new(Vec::new()));
+    let inner: Value<Vec<i32>> = Rc::new(RefCell::new(Vec::new()));
+    (outer.as_pointer() as Ptr<Vec<Value<Vec<i32>>>>).with_mut(|__v: &mut Vec<Value<Vec<i32>>>| {
+        __v.push(Rc::new(RefCell::new((*inner.borrow()).clone())))
+    });
+    let sink: Value<Ptr<Vec<i32>>> = Rc::new(RefCell::new(
+        ((*outer.borrow())[(*outer.borrow()).len() - 1].as_pointer()),
+    ));
+    assert!(((*(*sink.borrow()).upgrade().deref()).len() as u64 == 0_u64));
+    return 0;
+}

--- a/tests/unit/out/unsafe/vector_addr_of_back.rs
+++ b/tests/unit/out/unsafe/vector_addr_of_back.rs
@@ -1,0 +1,21 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut outer: Vec<Vec<i32>> = Vec::new();
+    let mut inner: Vec<i32> = Vec::new();
+    outer.push(inner.clone());
+    let mut sink: *mut Vec<i32> = ((outer).last_mut().unwrap());
+    assert!((((*sink.cast_const()).len() as u64) == (0_u64)));
+    return 0;
+}

--- a/tests/unit/vector_addr_of_back.cpp
+++ b/tests/unit/vector_addr_of_back.cpp
@@ -1,0 +1,11 @@
+#include <assert.h>
+#include <vector>
+
+int main() {
+  std::vector<std::vector<int>> outer;
+  std::vector<int> inner;
+  outer.push_back(inner);
+  auto *sink = &outer.back();
+  assert(sink->size() == 0);
+  return 0;
+}


### PR DESCRIPTION
After 4cb7e30, the matcher inside mapper.cpp broke for the following case:

```
template:     "T1 & std::vector<T1>::back()"
instantiated: "& std::vector<int> & std::vector<std::vector<int>>::back()"

Leading & comes from the call inside VisitUnaryOperator
```

The first T1 is matched to the empty string:

```
T1 & std::vector<   T1>::back()
   & std::vector<   int> & std::vector<std::vector<int>>::back()
```

Then, when the second T1 is matched (`int> & std::vector<std::vector<int>`), it goes to the else branch because it believes that the first T1 was never encountered:

https://github.com/Cpp2Rust/cpp2rust/blob/1ac73cce3139294d47b421c5d08efa927508bb2d/cpp2rust/converter/mapper.cpp#L253-L260

The fix is to replace the captured `std::vector<std::string>` with `std::vector<std::optional<std::string>>` so that empty matched string can be distinguished from non-matched stirng.