### PR TITLE
Fix void cast for pointer dereference

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -1924,6 +1924,8 @@ bool Converter::VisitExplicitCastExpr(clang::ExplicitCastExpr *expr) {
   auto type = expr->getTypeAsWritten();
   auto *sub_expr = expr->getSubExpr();
   if (type->isVoidType()) {
+    StrCat(token::kRef);
+    PushParen paren(*this);
     PushExprKind push(*this, ExprKind::Void);
     Convert(expr->getSubExpr());
     return false;

--- a/tests/unit/out/refcount/void_cast.rs
+++ b/tests/unit/out/refcount/void_cast.rs
@@ -10,10 +10,30 @@ pub fn unused_param_0(x: i32) {
     let x: Value<i32> = Rc::new(RefCell::new(x));
     (*x.borrow_mut());
 }
+#[derive(Default)]
+pub struct NonTrivial {
+    pub data: Value<Vec<i32>>,
+}
+impl Clone for NonTrivial {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            data: Rc::new(RefCell::new((*self.data.borrow()).clone())),
+        };
+        this
+    }
+}
+impl ByteRepr for NonTrivial {}
+pub fn unused_ref_param_1(x: Ptr<NonTrivial>) {
+    (*x.upgrade().deref()).clone();
+}
+pub fn unused_ptr_param_2(p: Ptr<NonTrivial>) {
+    let p: Value<Ptr<NonTrivial>> = Rc::new(RefCell::new(p));
+    (*(*p.borrow()).upgrade().deref()).clone();
+}
 thread_local!(
     pub static side_effect_counter: Value<i32> = Rc::new(RefCell::new(0));
 );
-pub fn bump_and_return_1() -> i32 {
+pub fn bump_and_return_3() -> i32 {
     (*side_effect_counter.with(Value::clone).borrow_mut()).prefix_inc();
     return (*side_effect_counter.with(Value::clone).borrow());
 }
@@ -53,10 +73,10 @@ fn main_0() -> i32 {
     }));
     assert!(((*w.borrow()) == 3));
     assert!(((*counter.borrow()) == 3));
-    ({ bump_and_return_1() });
+    ({ bump_and_return_3() });
     assert!(((*side_effect_counter.with(Value::clone).borrow()) == 1));
     let v: Value<i32> = Rc::new(RefCell::new({
-        ({ bump_and_return_1() });
+        ({ bump_and_return_3() });
         99
     }));
     assert!(((*side_effect_counter.with(Value::clone).borrow()) == 2));
@@ -75,11 +95,11 @@ fn main_0() -> i32 {
     }));
     assert!(((*err.borrow()) == 7));
     assert!(((*chosen.borrow()) == 123));
-    bump_and_return_1;
+    bump_and_return_3;
     assert!(((*side_effect_counter.with(Value::clone).borrow()) == 2));
-    (FnPtr::<fn() -> i32>::new(bump_and_return_1));
+    (FnPtr::<fn() -> i32>::new(bump_and_return_3));
     assert!(((*side_effect_counter.with(Value::clone).borrow()) == 2));
-    ((FnPtr::<fn() -> i32>::new(bump_and_return_1)).cast::<fn() -> i32>(None));
+    ((FnPtr::<fn() -> i32>::new(bump_and_return_3)).cast::<fn() -> i32>(None));
     assert!(((*side_effect_counter.with(Value::clone).borrow()) == 2));
     let storage: Value<i32> = Rc::new(RefCell::new(11));
     let p: Value<Ptr<i32>> = Rc::new(RefCell::new((storage.as_pointer())));
@@ -93,5 +113,14 @@ fn main_0() -> i32 {
     (*(*h.borrow()).field.borrow_mut());
     let hp: Value<Ptr<Holder>> = Rc::new(RefCell::new((h.as_pointer())));
     (*(*(*hp.borrow()).upgrade().deref()).field.borrow_mut());
+    let nt: Value<NonTrivial> = Rc::new(RefCell::new(<NonTrivial>::default()));
+    ({
+        let _x: Ptr<NonTrivial> = nt.as_pointer();
+        unused_ref_param_1(_x)
+    });
+    ({
+        let _p: Ptr<NonTrivial> = (nt.as_pointer());
+        unused_ptr_param_2(_p)
+    });
     return 0;
 }

--- a/tests/unit/out/unsafe/reinterpret_cast_oob_read.rs
+++ b/tests/unit/out/unsafe/reinterpret_cast_oob_read.rs
@@ -15,6 +15,6 @@ unsafe fn main_0() -> i32 {
     let mut val: u32 = 67305985_u32;
     let mut bytes: *mut u8 = ((&mut val as *mut u32) as *mut u8);
     let mut x: u8 = (*bytes.offset((4) as isize));
-    x;
+    &(x);
     return 0;
 }

--- a/tests/unit/out/unsafe/reinterpret_cast_undersize.rs
+++ b/tests/unit/out/unsafe/reinterpret_cast_undersize.rs
@@ -15,6 +15,6 @@ unsafe fn main_0() -> i32 {
     let mut b: u8 = 66_u8;
     let mut p: *mut u32 = ((&mut b as *mut u8) as *mut u32);
     let mut val: u32 = (*p);
-    val;
+    &(val);
     return 0;
 }

--- a/tests/unit/out/unsafe/va_arg_printf.rs
+++ b/tests/unit/out/unsafe/va_arg_printf.rs
@@ -7,7 +7,7 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn logf_impl_0(mut fmt: *const u8, mut ap: VaList) -> i32 {
-    fmt;
+    &(fmt);
     return ((ap.arg::<i32>()) + (ap.arg::<i32>()));
 }
 pub unsafe fn logf_1(mut fmt: *const u8, __args: &[VaArg]) -> i32 {

--- a/tests/unit/out/unsafe/void_cast.rs
+++ b/tests/unit/out/unsafe/void_cast.rs
@@ -20,7 +20,7 @@ pub unsafe fn unused_ref_param_1(x: *const NonTrivial) {
 pub unsafe fn unused_ptr_param_2(mut p: *const NonTrivial) {
     &(*p);
 }
-pub static mut side_effect_counter: i32 = unsafe { 0 };
+pub static mut side_effect_counter: i32 = 0;
 pub unsafe fn bump_and_return_3() -> i32 {
     side_effect_counter.prefix_inc();
     return side_effect_counter;

--- a/tests/unit/out/unsafe/void_cast.rs
+++ b/tests/unit/out/unsafe/void_cast.rs
@@ -7,10 +7,21 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn unused_param_0(mut x: i32) {
-    x;
+    &(x);
 }
-pub static mut side_effect_counter: i32 = 0;
-pub unsafe fn bump_and_return_1() -> i32 {
+#[repr(C)]
+#[derive(Clone, Default)]
+pub struct NonTrivial {
+    pub data: Vec<i32>,
+}
+pub unsafe fn unused_ref_param_1(x: *const NonTrivial) {
+    &(*x);
+}
+pub unsafe fn unused_ptr_param_2(mut p: *const NonTrivial) {
+    &(*p);
+}
+pub static mut side_effect_counter: i32 = unsafe { 0 };
+pub unsafe fn bump_and_return_3() -> i32 {
     side_effect_counter.prefix_inc();
     return side_effect_counter;
 }
@@ -30,59 +41,68 @@ unsafe fn main_0() -> i32 {
         unused_param_0(_x)
     });
     let mut y: i32 = 5;
-    y;
+    &(y);
     let mut z: i32 = {
-        y;
+        &(y);
         7
     };
     assert!(((z) == (7)));
     let mut counter: i32 = 0;
     let mut w: i32 = {
-        counter;
+        &(counter);
         counter = 3;
         counter
     };
     assert!(((w) == (3)));
     assert!(((counter) == (3)));
-    (unsafe { bump_and_return_1() });
+    &(unsafe { bump_and_return_3() });
     assert!(((side_effect_counter) == (1)));
     let mut v: i32 = {
-        (unsafe { bump_and_return_1() });
+        &(unsafe { bump_and_return_3() });
         99
     };
     assert!(((side_effect_counter) == (2)));
     assert!(((v) == (99)));
-    0;
-    (0);
-    (y);
-    (0);
-    (y);
+    &(0);
+    &(0);
+    &(y);
+    (&(0));
+    (&(y));
     let mut err: i32 = 0;
-    (err = 42);
+    (&(err = 42));
     assert!(((err) == (42)));
     let mut chosen: i32 = {
-        (err = 7);
+        &(err = 7);
         123
     };
     assert!(((err) == (7)));
     assert!(((chosen) == (123)));
-    bump_and_return_1;
+    &(bump_and_return_3);
     assert!(((side_effect_counter) == (2)));
-    (Some(bump_and_return_1));
+    &(Some(bump_and_return_3));
     assert!(((side_effect_counter) == (2)));
-    (std::mem::transmute::<Option<unsafe fn() -> i32>, Option<unsafe fn() -> i32>>(
-        (Some(bump_and_return_1)),
+    &(std::mem::transmute::<Option<unsafe fn() -> i32>, Option<unsafe fn() -> i32>>(
+        (Some(bump_and_return_3)),
     ));
     assert!(((side_effect_counter) == (2)));
     let mut storage: i32 = 11;
     let mut p: *mut i32 = (&mut storage as *mut i32);
-    (*p);
-    (p);
+    &(*p);
+    &(p);
     let mut arr: [i32; 3] = [1, 2, 3];
-    (arr[(1) as usize]);
+    &(arr[(1) as usize]);
     let mut h: Holder = Holder { field: 17 };
-    (h.field);
+    &(h.field);
     let mut hp: *mut Holder = (&mut h as *mut Holder);
-    ((*hp).field);
+    &((*hp).field);
+    let mut nt: NonTrivial = <NonTrivial>::default();
+    (unsafe {
+        let _x: *const NonTrivial = &nt as *const NonTrivial;
+        unused_ref_param_1(_x)
+    });
+    (unsafe {
+        let _p: *const NonTrivial = (&mut nt as *mut NonTrivial).cast_const();
+        unused_ptr_param_2(_p)
+    });
     return 0;
 }

--- a/tests/unit/void_cast.cpp
+++ b/tests/unit/void_cast.cpp
@@ -1,6 +1,15 @@
 #include <cassert>
+#include <vector>
 
 void unused_param(int x) { (void)x; }
+
+struct NonTrivial {
+  std::vector<int> data;
+};
+
+void unused_ref_param(const NonTrivial &x) { (void)x; }
+
+void unused_ptr_param(const NonTrivial *p) { (void)(*p); }
 
 int side_effect_counter = 0;
 int bump_and_return() {
@@ -70,6 +79,10 @@ int main() {
   (void)(h.field);
   Holder *hp = &h;
   (void)(hp->field);
+
+  NonTrivial nt;
+  unused_ref_param(nt);
+  unused_ptr_param(&nt);
 
   return 0;
 }


### PR DESCRIPTION
`(void)(*p)` tried to move the dereference value. To fix this, wrap the `*p` in a `&(...)` because borrowing the value does not move it.