### PR TITLE
Only emit mem::zeroed() on POD types

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -3092,7 +3092,8 @@ std::string Converter::GetDefaultAsStringFallback(clang::QualType qual_type) {
   }
 
   if (auto record = qual_type->getAsRecordDecl()) {
-    if (ctx_.getSourceManager().isInSystemHeader(record->getLocation())) {
+    if (ctx_.getSourceManager().isInSystemHeader(record->getLocation()) &&
+        qual_type.isPODType(ctx_)) {
       return std::format("std::mem::zeroed::<{}>()", ToString(qual_type));
     }
   }

--- a/tests/unit/libc_struct_without_default.cpp
+++ b/tests/unit/libc_struct_without_default.cpp
@@ -1,9 +1,16 @@
 // no-compile: refcount
+#include <array>
 #include <assert.h>
 #include <netinet/in.h>
 #include <poll.h>
 #include <sys/stat.h>
 #include <time.h>
+#include <vector>
+
+struct UserDefined {
+  std::array<int, 1> a;
+  std::vector<int> v;
+};
 
 int main() {
   struct pollfd p;
@@ -29,5 +36,9 @@ int main() {
   struct stat st;
   st.st_size = 1024;
   assert(st.st_size == 1024);
+
+  UserDefined ud;
+  assert(ud.a[0] == 0);
+  assert(ud.v.size() == 0);
   return 0;
 }

--- a/tests/unit/out/unsafe/libc_struct_without_default.rs
+++ b/tests/unit/out/unsafe/libc_struct_without_default.rs
@@ -6,6 +6,20 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
+#[repr(C)]
+#[derive(Clone)]
+pub struct UserDefined {
+    pub a: Vec<i32>,
+    pub v: Vec<i32>,
+}
+impl Default for UserDefined {
+    fn default() -> Self {
+        UserDefined {
+            a: std::array::from_fn::<_, 1, _>(|_| Default::default()).to_vec(),
+            v: <Vec<i32>>::default(),
+        }
+    }
+}
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
@@ -16,21 +30,24 @@ unsafe fn main_0() -> i32 {
     p.fd = -1_i32;
     p.events = 0_i16;
     p.revents = 2_i16;
-    assert!(((((p.fd) == (-1_i32)) as i32) != 0));
-    assert!(((((p.events as i32) == (0)) as i32) != 0));
-    assert!(((((p.revents as i32) == (2)) as i32) != 0));
+    assert!(((p.fd) == (-1_i32)));
+    assert!(((p.events as i32) == (0)));
+    assert!(((p.revents as i32) == (2)));
     let mut ia: in_addr = std::mem::zeroed::<in_addr>();
     ia.s_addr = 1_u32;
-    assert!(((((ia.s_addr) == (1_u32)) as i32) != 0));
+    assert!(((ia.s_addr) == (1_u32)));
     let mut t: tm = std::mem::zeroed::<tm>();
     t.tm_year = 124;
     t.tm_mon = 5;
     t.tm_mday = 15;
-    assert!(((((t.tm_year) == (124)) as i32) != 0));
-    assert!(((((t.tm_mon) == (5)) as i32) != 0));
-    assert!(((((t.tm_mday) == (15)) as i32) != 0));
+    assert!(((t.tm_year) == (124)));
+    assert!(((t.tm_mon) == (5)));
+    assert!(((t.tm_mday) == (15)));
     let mut st: stat = std::mem::zeroed::<stat>();
     st.st_size = 1024_i64;
-    assert!(((((st.st_size) == (1024_i64)) as i32) != 0));
+    assert!(((st.st_size) == (1024_i64)));
+    let mut ud: UserDefined = <UserDefined>::default();
+    assert!(((ud.a[(0_u64) as usize]) == (0)));
+    assert!(((ud.v.len() as u64) == (0_u64)));
     return 0;
 }


### PR DESCRIPTION
The previous check, i.e. `ctx_.getSourceManager().isInSystemHeader(record->getLocation())`, was too permissive and also matched against types such as `std::vector` which are not POD and cannot be initialized using `std::mem::zeroed()`