### PR TITLE
Avoid implicit autoderef on dereferences coming from rules

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -3700,8 +3700,11 @@ std::string Converter::ConvertPlaceholder(clang::Expr *expr, clang::Expr *arg,
 
   if (ph_ctx.needs_object_receiver()) {
     Buffer buf(*this);
-    PushExplicitAutoref autoref(*this, ph_ctx.access ==
-                                           TranslationRule::Access::kWrite);
+    PushExplicitAutoref autoref(
+        *this,
+        ph_ctx.needs_autoref
+            ? std::optional(ph_ctx.access == TranslationRule::Access::kWrite)
+            : std::nullopt);
     ConvertDeref(arg);
     return std::move(buf).str();
   }
@@ -3776,6 +3779,7 @@ std::string Converter::ConvertIRFragment(
           .maps_to_rust_ptr = Mapper::MapsToPointer(arg->getType()),
           .declared_in_rule_as_rust_ptr =
               Mapper::ParamIsPointer(GetCalleeOrExpr(expr), arg_idx),
+          .needs_autoref = ph->needs_autoref,
       };
       result += ConvertPlaceholder(expr, arg, ph_ctx);
     } else if (auto *mc =

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -3702,7 +3702,7 @@ std::string Converter::ConvertPlaceholder(clang::Expr *expr, clang::Expr *arg,
     Buffer buf(*this);
     PushExplicitAutoref autoref(
         *this,
-        ph_ctx.needs_autoref
+        ph_ctx.is_index_base
             ? std::optional(ph_ctx.access == TranslationRule::Access::kWrite)
             : std::nullopt);
     ConvertDeref(arg);
@@ -3779,7 +3779,7 @@ std::string Converter::ConvertIRFragment(
           .maps_to_rust_ptr = Mapper::MapsToPointer(arg->getType()),
           .declared_in_rule_as_rust_ptr =
               Mapper::ParamIsPointer(GetCalleeOrExpr(expr), arg_idx),
-          .needs_autoref = ph->needs_autoref,
+          .is_index_base = ph->is_index_base,
       };
       result += ConvertPlaceholder(expr, arg, ph_ctx);
     } else if (auto *mc =

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -3700,6 +3700,8 @@ std::string Converter::ConvertPlaceholder(clang::Expr *expr, clang::Expr *arg,
 
   if (ph_ctx.needs_object_receiver()) {
     Buffer buf(*this);
+    PushExplicitAutoref autoref(*this, ph_ctx.access ==
+                                           TranslationRule::Access::kWrite);
     ConvertDeref(arg);
     return std::move(buf).str();
   }

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -185,6 +185,7 @@ public:
     bool is_cpp_ptr;
     bool maps_to_rust_ptr;
     bool declared_in_rule_as_rust_ptr;
+    bool needs_autoref;
 
     bool needs_materialization() const {
       return materialize_ctx && materialize_idx >= 0 &&

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -185,7 +185,7 @@ public:
     bool is_cpp_ptr;
     bool maps_to_rust_ptr;
     bool declared_in_rule_as_rust_ptr;
-    bool needs_autoref;
+    bool is_index_base;
 
     bool needs_materialization() const {
       return materialize_ctx && materialize_idx >= 0 &&

--- a/cpp2rust/converter/translation_rule.cpp
+++ b/cpp2rust/converter/translation_rule.cpp
@@ -48,7 +48,7 @@ ParsePlaceholderFragmentJSON(const llvm::json::Object &obj) {
   return {
       (unsigned)*obj.getInteger("arg"),
       ParseAccessJSON(*access),
-      obj.getBoolean("needs_autoref").value_or(false),
+      obj.getBoolean("is_index_base").value_or(false),
   };
 }
 

--- a/cpp2rust/converter/translation_rule.cpp
+++ b/cpp2rust/converter/translation_rule.cpp
@@ -45,7 +45,11 @@ Access ParseAccessJSON(llvm::StringRef value) {
 PlaceholderFragment
 ParsePlaceholderFragmentJSON(const llvm::json::Object &obj) {
   auto access = obj.getString("access");
-  return {(unsigned)*obj.getInteger("arg"), ParseAccessJSON(*access)};
+  return {
+      (unsigned)*obj.getInteger("arg"),
+      ParseAccessJSON(*access),
+      obj.getBoolean("needs_autoref").value_or(false),
+  };
 }
 
 std::vector<BodyFragment> ParseBodyFragmentsJSON(const llvm::json::Array &arr);

--- a/cpp2rust/converter/translation_rule.h
+++ b/cpp2rust/converter/translation_rule.h
@@ -26,7 +26,7 @@ enum class Access { kRead, kWrite, kMove };
 struct PlaceholderFragment {
   unsigned n; // "a0", "a1", ...
   Access access;
-  bool needs_autoref = false;
+  bool is_index_base = false;
 
   void dump() const;
 };

--- a/cpp2rust/converter/translation_rule.h
+++ b/cpp2rust/converter/translation_rule.h
@@ -26,6 +26,7 @@ enum class Access { kRead, kWrite, kMove };
 struct PlaceholderFragment {
   unsigned n; // "a0", "a1", ...
   Access access;
+  bool needs_autoref = false;
 
   void dump() const;
 };

--- a/rule-preprocessor/src/ir.rs
+++ b/rule-preprocessor/src/ir.rs
@@ -140,7 +140,7 @@ pub struct PlaceholderInner {
     pub arg: i32,
     pub access: Access,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub needs_autoref: bool,
+    pub is_index_base: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/rule-preprocessor/src/ir.rs
+++ b/rule-preprocessor/src/ir.rs
@@ -63,17 +63,17 @@ pub struct FnIr {
 
 impl FnIr {
     /// Find the next unvisited placeholder for `param`, mark it visited,
-    /// and if it was "unknown", patch it with the given access.
-    /// Searches inside MethodCall bodies recursively.
+    /// and apply `patch` to it. Searches inside MethodCall bodies
+    /// recursively.
     pub fn resolve_next_param(
         &mut self,
         param: &str,
-        access: Access,
         visited: &mut HashMap<String, usize>,
+        patch: impl Fn(&mut PlaceholderInner),
     ) {
         let n = visited.entry(param.to_string()).or_insert(0);
         let nth = std::mem::replace(n, *n + 1);
-        resolve_nth_unknown(&mut self.body, param, access, nth);
+        resolve_nth_unknown(&mut self.body, param, nth, patch);
     }
 
     pub fn has_unknowns(&self) -> bool {
@@ -139,6 +139,8 @@ pub enum Access {
 pub struct PlaceholderInner {
     pub arg: i32,
     pub access: Access,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub needs_autoref: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -157,15 +159,21 @@ impl BodyFragment {
     }
 }
 
-/// Resolve the nth Unknown placeholder for `param` in a body fragment list.
-fn resolve_nth_unknown(body: &mut [BodyFragment], param: &str, access: Access, nth: usize) {
+/// Find the nth occurrence of `param` in a body fragment list and apply
+/// `patch` to it.
+fn resolve_nth_unknown(
+    body: &mut [BodyFragment],
+    param: &str,
+    nth: usize,
+    patch: impl Fn(&mut PlaceholderInner),
+) {
     let mut count = 0;
     fn resolve(
         body: &mut [BodyFragment],
         param: &str,
-        access: Access,
         nth: usize,
         count: &mut usize,
+        patch: &impl Fn(&mut PlaceholderInner),
     ) -> bool {
         for frag in body {
             match frag {
@@ -173,18 +181,16 @@ fn resolve_nth_unknown(body: &mut [BodyFragment], param: &str, access: Access, n
                     if placeholder.arg == param[1..].parse().unwrap_or(0) =>
                 {
                     if *count == nth {
-                        if placeholder.access == Access::Unknown {
-                            placeholder.access = access;
-                        }
+                        patch(placeholder);
                         return true;
                     }
                     *count += 1;
                 }
                 BodyFragment::MethodCall { method_call } => {
-                    if resolve(&mut method_call.receiver, param, access, nth, count) {
+                    if resolve(&mut method_call.receiver, param, nth, count, patch) {
                         return true;
                     }
-                    if resolve(&mut method_call.body, param, access, nth, count) {
+                    if resolve(&mut method_call.body, param, nth, count, patch) {
                         return true;
                     }
                 }
@@ -193,7 +199,7 @@ fn resolve_nth_unknown(body: &mut [BodyFragment], param: &str, access: Access, n
         }
         false
     }
-    resolve(body, param, access, nth, &mut count);
+    resolve(body, param, nth, &mut count, &patch);
 }
 
 // A rule file's IR: mix of function rules (f1, f2, ...) and type rules (t1, t2, ...)
@@ -211,7 +217,6 @@ pub type FileIr = BTreeMap<String, RuleIr>;
 /// All IR for all rule files.
 pub struct RulesIR {
     pub all_ir: HashMap<String, FileIr>,
-    pub has_unknowns: bool,
     pub crate_root: PathBuf,
 }
 

--- a/rule-preprocessor/src/semantic.rs
+++ b/rule-preprocessor/src/semantic.rs
@@ -220,7 +220,7 @@ impl<'a, 'tcx> AstVisitor<'a, 'tcx> {
                     if p.access == Access::Unknown {
                         p.access = context;
                     }
-                    p.needs_autoref = true;
+                    p.is_index_base = true;
                 });
             return;
         }

--- a/rule-preprocessor/src/semantic.rs
+++ b/rule-preprocessor/src/semantic.rs
@@ -10,10 +10,6 @@ pub struct SemanticAnalysis;
 
 impl SemanticAnalysis {
     pub fn run(ir: RulesIR) -> RulesIR {
-        if !ir.has_unknowns {
-            return ir;
-        }
-
         let args = build_rustc_args(&ir.crate_root);
         let mut resolver = MethodResolver { ir };
 
@@ -131,7 +127,6 @@ impl MethodResolver {
     fn resolve_fn_decl<'tcx>(&mut self, tcx: rustc_middle::ty::TyCtxt<'tcx>, f: &FnDecl<'tcx>) {
         if let Some(file_ir) = self.ir.all_ir.get_mut(&f.source_file)
             && let Some(RuleIr::Fn(fn_ir)) = file_ir.get_mut(&f.name)
-            && fn_ir.has_unknowns()
         {
             f.resolve_unknowns(tcx, fn_ir);
         }
@@ -218,11 +213,29 @@ struct AstVisitor<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> AstVisitor<'a, 'tcx> {
+    fn visit_expr_as_index_base(&mut self, expr: &'tcx rustc_hir::Expr<'tcx>, context: Access) {
+        if let Some(param) = self.expr_as_decl_ref(expr) {
+            self.fn_ir
+                .resolve_next_param(&param, &mut self.visited, |p| {
+                    if p.access == Access::Unknown {
+                        p.access = context;
+                    }
+                    p.needs_autoref = true;
+                });
+            return;
+        }
+        self.visit_expr(expr, context);
+    }
+
     fn visit_expr(&mut self, expr: &'tcx rustc_hir::Expr<'tcx>, context: Access) {
         // Reached an argument used inside the rule body
         if let Some(param) = self.expr_as_decl_ref(expr) {
             self.fn_ir
-                .resolve_next_param(&param, context, &mut self.visited);
+                .resolve_next_param(&param, &mut self.visited, |p| {
+                    if p.access == Access::Unknown {
+                        p.access = context;
+                    }
+                });
             return;
         }
 
@@ -311,7 +324,11 @@ impl<'a, 'tcx> AstVisitor<'a, 'tcx> {
             | rustc_hir::ExprKind::Repeat(e, _) => {
                 self.visit_expr(e, context);
             }
-            rustc_hir::ExprKind::Index(a, b, _) | rustc_hir::ExprKind::Binary(_, a, b) => {
+            rustc_hir::ExprKind::Index(base, idx, _) => {
+                self.visit_expr_as_index_base(base, context);
+                self.visit_expr(idx, context);
+            }
+            rustc_hir::ExprKind::Binary(_, a, b) => {
                 self.visit_expr(a, context);
                 self.visit_expr(b, context);
             }

--- a/rule-preprocessor/src/syntactic.rs
+++ b/rule-preprocessor/src/syntactic.rs
@@ -190,7 +190,7 @@ impl<'a> FragmentCtx<'a> {
                     placeholder: PlaceholderInner {
                         arg: token.text()[1..].parse().unwrap_or(0),
                         access,
-                        needs_autoref: false,
+                        is_index_base: false,
                     },
                 });
                 return;

--- a/rule-preprocessor/src/syntactic.rs
+++ b/rule-preprocessor/src/syntactic.rs
@@ -44,7 +44,6 @@ impl SyntacticAnalysis {
     pub fn run(crate_root: &Path) -> RulesIR {
         let rule_files = Self::collect_rule_files(crate_root);
         let mut all_ir = HashMap::new();
-        let mut has_unknowns = false;
 
         for rule_file in &rule_files {
             let source = std::fs::read_to_string(rule_file).unwrap();
@@ -56,10 +55,6 @@ impl SyntacticAnalysis {
                 rule_file.display()
             );
 
-            has_unknowns |= file_ir.values().any(|r| match r {
-                RuleIr::Fn(f) => f.has_unknowns(),
-                RuleIr::Type(_) => false,
-            });
             let canonical = rule_file
                 .canonicalize()
                 .unwrap_or_else(|_| rule_file.clone())
@@ -70,7 +65,6 @@ impl SyntacticAnalysis {
 
         RulesIR {
             all_ir,
-            has_unknowns,
             crate_root: crate_root.to_path_buf(),
         }
     }
@@ -196,6 +190,7 @@ impl<'a> FragmentCtx<'a> {
                     placeholder: PlaceholderInner {
                         arg: token.text()[1..].parse().unwrap_or(0),
                         access,
+                        needs_autoref: false,
                     },
                 });
                 return;

--- a/rules/string/ir_refcount.json
+++ b/rules/string/ir_refcount.json
@@ -10,7 +10,8 @@
             {
               "placeholder": {
                 "arg": 0,
-                "access": "read"
+                "access": "read",
+                "needs_autoref": true
               }
             },
             {

--- a/rules/string/ir_refcount.json
+++ b/rules/string/ir_refcount.json
@@ -11,7 +11,7 @@
               "placeholder": {
                 "arg": 0,
                 "access": "read",
-                "needs_autoref": true
+                "is_index_base": true
               }
             },
             {

--- a/rules/string/ir_unsafe.json
+++ b/rules/string/ir_unsafe.json
@@ -11,7 +11,7 @@
               "placeholder": {
                 "arg": 0,
                 "access": "read",
-                "needs_autoref": true
+                "is_index_base": true
               }
             },
             {
@@ -1196,7 +1196,7 @@
         "placeholder": {
           "arg": 0,
           "access": "write",
-          "needs_autoref": true
+          "is_index_base": true
         }
       },
       {

--- a/rules/string/ir_unsafe.json
+++ b/rules/string/ir_unsafe.json
@@ -10,7 +10,8 @@
             {
               "placeholder": {
                 "arg": 0,
-                "access": "read"
+                "access": "read",
+                "needs_autoref": true
               }
             },
             {
@@ -1194,7 +1195,8 @@
       {
         "placeholder": {
           "arg": 0,
-          "access": "write"
+          "access": "write",
+          "needs_autoref": true
         }
       },
       {

--- a/rules/vector/ir_refcount.json
+++ b/rules/vector/ir_refcount.json
@@ -2098,7 +2098,8 @@
             {
               "placeholder": {
                 "arg": 0,
-                "access": "read"
+                "access": "read",
+                "needs_autoref": true
               }
             },
             {

--- a/rules/vector/ir_refcount.json
+++ b/rules/vector/ir_refcount.json
@@ -2099,7 +2099,7 @@
               "placeholder": {
                 "arg": 0,
                 "access": "read",
-                "needs_autoref": true
+                "is_index_base": true
               }
             },
             {

--- a/rules/vector/ir_unsafe.json
+++ b/rules/vector/ir_unsafe.json
@@ -2775,7 +2775,8 @@
       {
         "placeholder": {
           "arg": 0,
-          "access": "write"
+          "access": "write",
+          "needs_autoref": true
         }
       },
       {

--- a/rules/vector/ir_unsafe.json
+++ b/rules/vector/ir_unsafe.json
@@ -2776,7 +2776,7 @@
         "placeholder": {
           "arg": 0,
           "access": "write",
-          "needs_autoref": true
+          "is_index_base": true
         }
       },
       {

--- a/tests/unit/implicit_autoref.cpp
+++ b/tests/unit/implicit_autoref.cpp
@@ -5,6 +5,8 @@ struct Holder {
   std::vector<int> v;
 };
 
+static void write_through(int *p) { *p = 42; }
+
 int main() {
   std::vector<int> v;
   v.push_back(10);
@@ -25,5 +27,8 @@ int main() {
   assert((*p)[1] == 30);
   assert(b == 40);
   assert((*hp).v[1] == 60);
+
+  write_through(&p->at(0));
+  assert((*p)[0] == 42);
   return 0;
 }

--- a/tests/unit/out/refcount/implicit_autoref.rs
+++ b/tests/unit/out/refcount/implicit_autoref.rs
@@ -19,6 +19,10 @@ impl Clone for Holder {
     }
 }
 impl ByteRepr for Holder {}
+pub fn write_through_0(p: Ptr<i32>) {
+    let p: Value<Ptr<i32>> = Rc::new(RefCell::new(p));
+    (*p.borrow()).write(42);
+}
 pub fn main() {
     std::process::exit(main_0());
 }
@@ -60,6 +64,17 @@ fn main_0() -> i32 {
             .offset(1_u64 as isize)
             .read())
             == 60)
+    );
+    ({
+        let _p: Ptr<i32> =
+            (((*p.borrow()).to_strong().as_pointer() as Ptr<i32>).offset(0_u64 as isize));
+        write_through_0(_p)
+    });
+    assert!(
+        (((((*p.borrow()).to_strong().as_pointer()) as Ptr<i32>)
+            .offset(0_u64 as isize)
+            .read())
+            == 42)
     );
     return 0;
 }

--- a/tests/unit/out/unsafe/implicit_autoref.rs
+++ b/tests/unit/out/unsafe/implicit_autoref.rs
@@ -11,6 +11,9 @@ use std::rc::Rc;
 pub struct Holder {
     pub v: Vec<i32>,
 }
+pub unsafe fn write_through_0(mut p: *mut i32) {
+    (*p) = 42;
+}
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
@@ -33,5 +36,10 @@ unsafe fn main_0() -> i32 {
     assert!((((&mut (*p))[(1_u64) as usize]) == (30)));
     assert!(((b) == (40)));
     assert!((((&mut (*hp)).v[(1_u64) as usize]) == (60)));
+    (unsafe {
+        let _p: *mut i32 = (&mut (&mut (*p))[0_u64 as usize]);
+        write_through_0(_p)
+    });
+    assert!((((&mut (*p))[(0_u64) as usize]) == (42)));
     return 0;
 }


### PR DESCRIPTION
Adds the `is_index_base` field in the IR for indexed arguments, for example in `a0[a1]`, `a0` is decorated with `is_index_base = true`. Inside Converter, when a deref is needed and `is_index_base == true`, then explicit autoref is triggered.