### PR TITLE
Suppress clone in iterator conversion

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -2757,6 +2757,8 @@ void Converter::ConvertCXXConstructExprArgs(clang::CXXConstructExpr *expr) {
 }
 
 bool Converter::VisitCXXConstructExpr(clang::CXXConstructExpr *expr) {
+  PushSuppressIteratorClone push(*this, expr);
+
   if (auto str = GetMappedAsString(expr, expr->getArgs(), expr->getNumArgs());
       !str.empty()) {
     StrCat(str);
@@ -2767,8 +2769,10 @@ bool Converter::VisitCXXConstructExpr(clang::CXXConstructExpr *expr) {
   if (ctor->isCopyOrMoveConstructor() ||
       (ctor->isConvertingConstructor(false) && ctor->getNumParams() == 1 &&
        ctor->getParamDecl(0)->getType()->isRValueReferenceType())) {
+    // Take supress before recursing into the child.
+    bool suppress = PushSuppressIteratorClone::take(*this, expr);
     Convert(expr->getArg(0));
-    if (ctor->isCopyConstructor() && !IsRedundantCopyInConversion(ctx_, expr)) {
+    if (ctor->isCopyConstructor() && !suppress) {
       StrCat(".clone()");
     }
     return false;

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -2770,7 +2770,7 @@ bool Converter::VisitCXXConstructExpr(clang::CXXConstructExpr *expr) {
       (ctor->isConvertingConstructor(false) && ctor->getNumParams() == 1 &&
        ctor->getParamDecl(0)->getType()->isRValueReferenceType())) {
     // Take supress before recursing into the child.
-    bool suppress = PushSuppressIteratorClone::take(*this, expr);
+    bool suppress = PushSuppressIteratorClone::take(*this);
     Convert(expr->getArg(0));
     if (ctor->isCopyConstructor() && !suppress) {
       StrCat(".clone()");

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -529,6 +529,7 @@ protected:
   bool in_function_formals_ = false;
   bool in_const_initializer_ = false;
   std::optional<bool> autoref_mut_;
+  bool suppress_iterator_clone_ = false;
 
   struct PushExplicitAutoref {
     Converter &c;
@@ -538,6 +539,43 @@ protected:
       c.autoref_mut_ = v;
     }
     ~PushExplicitAutoref() { c.autoref_mut_ = prev; }
+  };
+
+  struct PushSuppressIteratorClone {
+    Converter &c;
+    bool prev;
+    PushSuppressIteratorClone(Converter &c, clang::CXXConstructExpr *expr)
+        : c(c), prev(c.suppress_iterator_clone_) {
+      auto *ctor = expr->getConstructor();
+      if (ctor->isConvertingConstructor(/*AllowExplicit=*/false) &&
+          ctor->getNumParams() == 1 && IsIteratorType(expr->getType())) {
+        c.suppress_iterator_clone_ = true;
+      }
+    }
+    ~PushSuppressIteratorClone() { c.suppress_iterator_clone_ = prev; }
+    PushSuppressIteratorClone(const PushSuppressIteratorClone &) = delete;
+    PushSuppressIteratorClone &
+    operator=(const PushSuppressIteratorClone &) = delete;
+
+    static bool take(Converter &c, clang::CXXConstructExpr *inner) {
+      bool suppress =
+          c.suppress_iterator_clone_ && IsIteratorType(inner->getType());
+      c.suppress_iterator_clone_ = false;
+      return suppress;
+    }
+
+  private:
+    static bool IsIteratorType(clang::QualType qt) {
+      if (auto *record = qt->getAsCXXRecordDecl()) {
+        for (auto *d : record->decls()) {
+          if (auto *tnd = llvm::dyn_cast<clang::TypedefNameDecl>(d)) {
+            if (tnd->getName() == "iterator_category")
+              return true;
+          }
+        }
+      }
+      return false;
+    }
   };
 
   struct PushConstInitializer {

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "converter/lex.h"
@@ -547,8 +548,9 @@ protected:
     PushSuppressIteratorClone(Converter &c, clang::CXXConstructExpr *expr)
         : c(c), prev(c.suppress_iterator_clone_) {
       auto *ctor = expr->getConstructor();
-      if (ctor->isConvertingConstructor(/*AllowExplicit=*/false) &&
-          ctor->getNumParams() == 1 && IsIteratorType(expr->getType())) {
+      if (!ctor->isCopyOrMoveConstructor() &&
+          ctor->isConvertingConstructor(/*AllowExplicit=*/false) &&
+          ctor->getNumParams() == 1) {
         c.suppress_iterator_clone_ = true;
       }
     }
@@ -557,24 +559,8 @@ protected:
     PushSuppressIteratorClone &
     operator=(const PushSuppressIteratorClone &) = delete;
 
-    static bool take(Converter &c, clang::CXXConstructExpr *inner) {
-      bool suppress =
-          c.suppress_iterator_clone_ && IsIteratorType(inner->getType());
-      c.suppress_iterator_clone_ = false;
-      return suppress;
-    }
-
-  private:
-    static bool IsIteratorType(clang::QualType qt) {
-      if (auto *record = qt->getAsCXXRecordDecl()) {
-        for (auto *d : record->decls()) {
-          if (auto *tnd = llvm::dyn_cast<clang::TypedefNameDecl>(d)) {
-            if (tnd->getName() == "iterator_category")
-              return true;
-          }
-        }
-      }
-      return false;
+    static bool take(Converter &c) {
+      return std::exchange(c.suppress_iterator_clone_, false);
     }
   };
 

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -550,7 +550,7 @@ protected:
       auto *ctor = expr->getConstructor();
       if (!ctor->isCopyOrMoveConstructor() &&
           ctor->isConvertingConstructor(/*AllowExplicit=*/false) &&
-          ctor->getNumParams() == 1) {
+          ctor->getNumParams() == 1 && IsIteratorType(expr->getType())) {
         c.suppress_iterator_clone_ = true;
       }
     }
@@ -561,6 +561,19 @@ protected:
 
     static bool take(Converter &c) {
       return std::exchange(c.suppress_iterator_clone_, false);
+    }
+
+  private:
+    static bool IsIteratorType(clang::QualType qt) {
+      if (auto *record = qt->getAsCXXRecordDecl()) {
+        for (auto *d : record->decls()) {
+          if (auto *tnd = llvm::dyn_cast<clang::TypedefNameDecl>(d)) {
+            if (tnd->getName() == "iterator_category")
+              return true;
+          }
+        }
+      }
+      return false;
     }
   };
 

--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -644,34 +644,6 @@ std::string GetClassName(clang::QualType type) {
   return {};
 }
 
-static bool IsIteratorType(clang::QualType qt) {
-  if (auto *record = qt->getAsCXXRecordDecl()) {
-    for (auto *d : record->decls()) {
-      if (auto *tnd = llvm::dyn_cast<clang::TypedefNameDecl>(d)) {
-        if (tnd->getName() == "iterator_category")
-          return true;
-      }
-    }
-  }
-  return false;
-}
-
-bool IsRedundantCopyInConversion(clang::ASTContext &ctx,
-                                 const clang::CXXConstructExpr *expr) {
-  return false;
-  if (auto parents = ctx.getParentMapContext().getParents(*expr);
-      !parents.empty()) {
-    if (auto *parent = parents[0].get<clang::CXXConstructExpr>()) {
-      if (parent->getConstructor()->isConvertingConstructor(
-              /* AllowExplicit= */ false)) {
-        return IsIteratorType(expr->getType()) &&
-               IsIteratorType(parent->getType());
-      }
-    }
-  }
-  return false;
-}
-
 bool IsVaListType(clang::QualType type) {
   for (auto t = type; !t.isNull();) {
     if (auto *adjusted = t->getAs<clang::AdjustedType>()) {

--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -644,14 +644,31 @@ std::string GetClassName(clang::QualType type) {
   return {};
 }
 
+static bool IsIteratorType(clang::QualType qt) {
+  if (auto *record = qt->getAsCXXRecordDecl()) {
+    for (auto *d : record->decls()) {
+      if (auto *tnd = llvm::dyn_cast<clang::TypedefNameDecl>(d)) {
+        if (tnd->getName() == "iterator_category")
+          return true;
+      }
+    }
+  }
+  return false;
+}
+
 bool IsRedundantCopyInConversion(clang::ASTContext &ctx,
                                  const clang::CXXConstructExpr *expr) {
-  auto parents = ctx.getParentMapContext().getParents(*expr);
-  if (parents.empty()) {
-    return false;
+  if (auto parents = ctx.getParentMapContext().getParents(*expr);
+      !parents.empty()) {
+    if (auto *parent = parents[0].get<clang::CXXConstructExpr>()) {
+      if (parent->getConstructor()->isConvertingConstructor(
+              /* AllowExplicit= */ false)) {
+        return IsIteratorType(expr->getType()) &&
+               IsIteratorType(parent->getType());
+      }
+    }
   }
-  auto *parent = parents[0].get<clang::CXXConstructExpr>();
-  return parent && parent->getConstructor()->isConvertingConstructor(false);
+  return false;
 }
 
 bool IsVaListType(clang::QualType type) {

--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -658,6 +658,7 @@ static bool IsIteratorType(clang::QualType qt) {
 
 bool IsRedundantCopyInConversion(clang::ASTContext &ctx,
                                  const clang::CXXConstructExpr *expr) {
+  return false;
   if (auto parents = ctx.getParentMapContext().getParents(*expr);
       !parents.empty()) {
     if (auto *parent = parents[0].get<clang::CXXConstructExpr>()) {

--- a/cpp2rust/converter/converter_lib.h
+++ b/cpp2rust/converter/converter_lib.h
@@ -145,9 +145,6 @@ GetForRangeIteratorType(const clang::CXXForRangeStmt *for_range);
 
 std::string GetClassName(clang::QualType type);
 
-bool IsRedundantCopyInConversion(clang::ASTContext &ctx,
-                                 const clang::CXXConstructExpr *expr);
-
 bool IsVaListType(clang::QualType type);
 
 bool IsBuiltinVaStart(const clang::CallExpr *expr);

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -1564,7 +1564,9 @@ bool ConverterRefCount::VisitCXXConstructExpr(clang::CXXConstructExpr *expr) {
   }
 
   if (ctor->isCopyConstructor()) {
-    StrCat(ConvertRValue(expr->getArg(0)));
+    StrCat(IsRedundantCopyInConversion(ctx_, expr)
+               ? ConvertRValue(expr->getArg(0))
+               : ConvertFreshRValue(expr->getArg(0)));
     return false;
   }
 

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -1565,7 +1565,7 @@ bool ConverterRefCount::VisitCXXConstructExpr(clang::CXXConstructExpr *expr) {
   }
 
   if (ctor->isCopyConstructor()) {
-    StrCat(PushSuppressIteratorClone::take(*this, expr)
+    StrCat(PushSuppressIteratorClone::take(*this)
                ? ConvertRValue(expr->getArg(0))
                : ConvertFreshRValue(expr->getArg(0)));
     return false;

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -1541,6 +1541,7 @@ std::string ConverterRefCount::ConvertStream(clang::Expr *expr) {
 
 bool ConverterRefCount::VisitCXXConstructExpr(clang::CXXConstructExpr *expr) {
   PushConversionKind push(*this, ConversionKind::Unboxed);
+  PushSuppressIteratorClone push_suppress(*this, expr);
 
   if (auto str = GetMappedAsString(expr, expr->getArgs(), expr->getNumArgs());
       !str.empty()) {
@@ -1564,7 +1565,7 @@ bool ConverterRefCount::VisitCXXConstructExpr(clang::CXXConstructExpr *expr) {
   }
 
   if (ctor->isCopyConstructor()) {
-    StrCat(IsRedundantCopyInConversion(ctx_, expr)
+    StrCat(PushSuppressIteratorClone::take(*this, expr)
                ? ConvertRValue(expr->getArg(0))
                : ConvertFreshRValue(expr->getArg(0)));
     return false;

--- a/rules/map/ir_refcount.json
+++ b/rules/map/ir_refcount.json
@@ -462,14 +462,27 @@
   "f19": {
     "body": [
       {
-        "placeholder": {
-          "arg": 0,
-          "access": "read"
+        "method_call": {
+          "receiver": [
+            {
+              "placeholder": {
+                "arg": 0,
+                "access": "read"
+              }
+            }
+          ],
+          "body": [
+            {
+              "text": ".clone()"
+            }
+          ]
         }
       }
     ],
     "generics": {
-      "T1": [],
+      "T1": [
+        "Clone"
+      ],
       "T2": []
     },
     "params": {

--- a/rules/map/ir_unsafe.json
+++ b/rules/map/ir_unsafe.json
@@ -466,14 +466,27 @@
   "f19": {
     "body": [
       {
-        "placeholder": {
-          "arg": 0,
-          "access": "read"
+        "method_call": {
+          "receiver": [
+            {
+              "placeholder": {
+                "arg": 0,
+                "access": "read"
+              }
+            }
+          ],
+          "body": [
+            {
+              "text": ".clone()"
+            }
+          ]
         }
       }
     ],
     "generics": {
-      "T1": [],
+      "T1": [
+        "Clone"
+      ],
       "T2": []
     },
     "params": {

--- a/rules/map/tgt_refcount.rs
+++ b/rules/map/tgt_refcount.rs
@@ -120,8 +120,8 @@ fn f17<T1: Ord + Clone + 'static, T2: 'static>(
     RefcountMapIter::find_key(a0, &a1)
 }
 
-fn f19<T1, T2>(a0: RefcountMapIter<T1, T2>) -> RefcountMapIter<T1, T2> {
-    a0
+fn f19<T1: Clone, T2>(a0: RefcountMapIter<T1, T2>) -> RefcountMapIter<T1, T2> {
+    a0.clone()
 }
 
 fn f20<T1: Ord + Clone + 'static, T2: 'static>(a0: RefcountMapIter<T1, T2>) -> Value<T1> {

--- a/rules/map/tgt_unsafe.rs
+++ b/rules/map/tgt_unsafe.rs
@@ -83,8 +83,8 @@ unsafe fn f17<T1: Ord + Clone, T2>(a0: BTreeMap<T1, Box<T2>>, a1: T1) -> UnsafeM
     UnsafeMapIterator::find_key(&a0 as *const BTreeMap<T1, Box<T2>>, &a1)
 }
 
-unsafe fn f19<T1, T2>(a0: UnsafeMapIterator<T1, T2>) -> UnsafeMapIterator<T1, T2> {
-    a0
+unsafe fn f19<T1: Clone, T2>(a0: UnsafeMapIterator<T1, T2>) -> UnsafeMapIterator<T1, T2> {
+    a0.clone()
 }
 
 unsafe fn f20<T1: Ord + Clone, T2>(a0: UnsafeMapIterator<T1, T2>) -> *const T1 {

--- a/tests/unit/initializer_list.cpp
+++ b/tests/unit/initializer_list.cpp
@@ -1,0 +1,16 @@
+#include <cassert>
+#include <cstddef>
+#include <initializer_list>
+#include <vector>
+
+size_t f(std::initializer_list<int> bytes) {
+  std::vector<int> *buf = new std::vector<int>(bytes);
+  size_t n = bytes.size();
+  delete buf;
+  return n;
+}
+
+int main() {
+  assert(f({1, 2, 3}) == 3);
+  return 0;
+}

--- a/tests/unit/out/refcount/initializer_list.rs
+++ b/tests/unit/out/refcount/initializer_list.rs
@@ -8,7 +8,7 @@ use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 pub fn f_0(bytes: Vec<i32>) -> u64 {
     let bytes: Value<Vec<i32>> = Rc::new(RefCell::new(bytes));
-    let buf: Value<Ptr<Vec<i32>>> = Rc::new(RefCell::new(Ptr::alloc((*bytes.borrow()))));
+    let buf: Value<Ptr<Vec<i32>>> = Rc::new(RefCell::new(Ptr::alloc((*bytes.borrow()).clone())));
     let n: Value<u64> = Rc::new(RefCell::new((*bytes.borrow()).len() as u64));
     (*buf.borrow()).delete();
     return (*n.borrow());

--- a/tests/unit/out/refcount/initializer_list.rs
+++ b/tests/unit/out/refcount/initializer_list.rs
@@ -1,0 +1,27 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn f_0(bytes: Vec<i32>) -> u64 {
+    let bytes: Value<Vec<i32>> = Rc::new(RefCell::new(bytes));
+    let buf: Value<Ptr<Vec<i32>>> = Rc::new(RefCell::new(Ptr::alloc((*bytes.borrow()))));
+    let n: Value<u64> = Rc::new(RefCell::new((*bytes.borrow()).len() as u64));
+    (*buf.borrow()).delete();
+    return (*n.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (({
+            let _bytes: Vec<i32> = vec![1, 2, 3];
+            f_0(_bytes)
+        }) == 3_u64)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/map.rs
+++ b/tests/unit/out/refcount/map.rs
@@ -274,7 +274,7 @@ fn main_0() -> i32 {
     );
     RefcountMapIter::erase(
         ((r).clone() as Ptr<BTreeMap<i16, Value<u32>>>),
-        &(*it4.borrow()),
+        &(*it4.borrow()).clone(),
     );
     assert!(((*r.upgrade().deref()).len() as u64 == 3_u64));
     assert!(

--- a/tests/unit/out/refcount/map.rs
+++ b/tests/unit/out/refcount/map.rs
@@ -192,7 +192,8 @@ fn main_0() -> i32 {
         &1_i16,
     )));
     let const_it: Value<RefcountMapIter<i16, u32>> = Rc::new(RefCell::new(
-        RefcountMapIter::find_key((m.as_pointer() as Ptr<BTreeMap<i16, Value<u32>>>), &10_i16),
+        RefcountMapIter::find_key((m.as_pointer() as Ptr<BTreeMap<i16, Value<u32>>>), &10_i16)
+            .clone(),
     ));
     let x1: Value<u32> = Rc::new(RefCell::new(if (*it.borrow()) == (*end.borrow()) {
         0_u32
@@ -200,11 +201,13 @@ fn main_0() -> i32 {
         (*(*it.borrow()).second().borrow())
     }));
     assert!(((*x1.borrow()) == 4_u32));
-    let x2: Value<u32> = Rc::new(RefCell::new(if (*const_it.borrow()) == (*end.borrow()) {
-        0_u32
-    } else {
-        (*(*const_it.borrow()).second().borrow())
-    }));
+    let x2: Value<u32> = Rc::new(RefCell::new(
+        if (*const_it.borrow()) == (*end.borrow()).clone() {
+            0_u32
+        } else {
+            (*(*const_it.borrow()).second().borrow())
+        },
+    ));
     assert!(((*x2.borrow()) == 0_u32));
     let x3: Value<u32> = Rc::new(RefCell::new(
         if (*it.borrow())
@@ -218,7 +221,7 @@ fn main_0() -> i32 {
     assert!(((*x3.borrow()) == 4_u32));
     let x4: Value<u32> = Rc::new(RefCell::new(
         if (*const_it.borrow())
-            == RefcountMapIter::end((m.as_pointer() as Ptr<BTreeMap<i16, Value<u32>>>))
+            == RefcountMapIter::end((m.as_pointer() as Ptr<BTreeMap<i16, Value<u32>>>)).clone()
         {
             0_u32
         } else {

--- a/tests/unit/out/refcount/map.rs
+++ b/tests/unit/out/refcount/map.rs
@@ -274,7 +274,7 @@ fn main_0() -> i32 {
     );
     RefcountMapIter::erase(
         ((r).clone() as Ptr<BTreeMap<i16, Value<u32>>>),
-        &(*it4.borrow()).clone(),
+        &(*it4.borrow()),
     );
     assert!(((*r.upgrade().deref()).len() as u64 == 3_u64));
     assert!(

--- a/tests/unit/out/refcount/redundant_copy_in_conversion.rs
+++ b/tests/unit/out/refcount/redundant_copy_in_conversion.rs
@@ -1,0 +1,59 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+#[derive(Default)]
+pub struct iter {
+    pub p: Value<Ptr<i32>>,
+}
+impl Clone for iter {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            p: Rc::new(RefCell::new((*self.p.borrow()).clone())),
+        };
+        this
+    }
+}
+impl ByteRepr for iter {}
+#[derive(Default)]
+pub struct const_iter {
+    pub p: Value<Ptr<i32>>,
+}
+impl const_iter {
+    pub fn const_iter(o: Ptr<iter>) -> Self {
+        let mut this = Self {
+            p: Rc::new(RefCell::new((*(*o.upgrade().deref()).p.borrow()).clone())),
+        };
+        this
+    }
+}
+impl Clone for const_iter {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            p: Rc::new(RefCell::new(Ptr::<i32>::null())),
+        };
+        this
+    }
+}
+impl ByteRepr for const_iter {}
+pub fn sink_0(i: const_iter) {
+    let i: Value<const_iter> = Rc::new(RefCell::new(i));
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let buf: Value<Box<[i32]>> = Rc::new(RefCell::new(Box::new([0, 0])));
+    let it: Value<iter> = Rc::new(RefCell::new(iter {
+        p: Rc::new(RefCell::new((buf.as_pointer() as Ptr<i32>))),
+    }));
+    ({
+        let _i: const_iter = const_iter::const_iter(it.as_pointer());
+        sink_0(_i)
+    });
+    return 0;
+}

--- a/tests/unit/out/refcount/redundant_copy_in_conversion.rs
+++ b/tests/unit/out/refcount/redundant_copy_in_conversion.rs
@@ -6,6 +6,15 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
+pub fn sink_0(it: RefcountMapIter<i32, i32>) -> i32 {
+    let it: Value<RefcountMapIter<i32, i32>> = Rc::new(RefCell::new(it));
+    let cit: Value<RefcountMapIter<i32, i32>> = Rc::new(RefCell::new((*it.borrow()).clone()));
+    return if (*cit.borrow()) == (*it.borrow()).clone() {
+        (*(*it.borrow()).second().borrow())
+    } else {
+        0
+    };
+}
 pub fn main() {
     std::process::exit(main_0());
 }
@@ -21,12 +30,26 @@ fn main_0() -> i32 {
     let end: Value<RefcountMapIter<i32, i32>> = Rc::new(RefCell::new(RefcountMapIter::end(
         (m.as_pointer() as Ptr<BTreeMap<i32, Value<i32>>>),
     )));
-    let const_it: Value<RefcountMapIter<i32, i32>> = Rc::new(RefCell::new(
-        RefcountMapIter::find_key((m.as_pointer() as Ptr<BTreeMap<i32, Value<i32>>>), &0),
+    let it0: Value<RefcountMapIter<i32, i32>> = Rc::new(RefCell::new(RefcountMapIter::find_key(
+        (m.as_pointer() as Ptr<BTreeMap<i32, Value<i32>>>),
+        &0,
+    )));
+    let const_it: Value<RefcountMapIter<i32, i32>> = Rc::new(RefCell::new((*it0.borrow()).clone()));
+    let r: Value<i32> = Rc::new(RefCell::new(
+        if (*const_it.borrow()) == (*end.borrow()).clone() {
+            0
+        } else {
+            1
+        },
     ));
-    return if (*const_it.borrow()) == (*end.borrow()) {
+    (*r.borrow_mut()) += ({
+        let _it: RefcountMapIter<i32, i32> = (*it0.borrow()).clone();
+        sink_0(_it)
+    });
+    (*r.borrow_mut()) += if (*end.borrow()) == (*end.borrow()) {
         0
     } else {
         1
     };
+    return (*r.borrow());
 }

--- a/tests/unit/out/refcount/redundant_copy_in_conversion.rs
+++ b/tests/unit/out/refcount/redundant_copy_in_conversion.rs
@@ -6,54 +6,27 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-#[derive(Default)]
-pub struct iter {
-    pub p: Value<Ptr<i32>>,
-}
-impl Clone for iter {
-    fn clone(&self) -> Self {
-        let mut this = Self {
-            p: Rc::new(RefCell::new((*self.p.borrow()).clone())),
-        };
-        this
-    }
-}
-impl ByteRepr for iter {}
-#[derive(Default)]
-pub struct const_iter {
-    pub p: Value<Ptr<i32>>,
-}
-impl const_iter {
-    pub fn const_iter(o: Ptr<iter>) -> Self {
-        let mut this = Self {
-            p: Rc::new(RefCell::new((*(*o.upgrade().deref()).p.borrow()).clone())),
-        };
-        this
-    }
-}
-impl Clone for const_iter {
-    fn clone(&self) -> Self {
-        let mut this = Self {
-            p: Rc::new(RefCell::new(Ptr::<i32>::null())),
-        };
-        this
-    }
-}
-impl ByteRepr for const_iter {}
-pub fn sink_0(i: const_iter) {
-    let i: Value<const_iter> = Rc::new(RefCell::new(i));
-}
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    let buf: Value<Box<[i32]>> = Rc::new(RefCell::new(Box::new([0, 0])));
-    let it: Value<iter> = Rc::new(RefCell::new(iter {
-        p: Rc::new(RefCell::new((buf.as_pointer() as Ptr<i32>))),
-    }));
-    ({
-        let _i: const_iter = const_iter::const_iter(it.as_pointer());
-        sink_0(_i)
-    });
-    return 0;
+    let m: Value<BTreeMap<i32, Value<i32>>> = Rc::new(RefCell::new(BTreeMap::new()));
+    (m.as_pointer() as Ptr<BTreeMap<i32, Value<i32>>>)
+        .with_mut(|__v: &mut BTreeMap<i32, Value<i32>>| {
+            __v.entry(0.clone())
+                .or_insert_with(|| Rc::new(RefCell::new(<i32>::default())))
+                .as_pointer()
+        })
+        .write(1);
+    let end: Value<RefcountMapIter<i32, i32>> = Rc::new(RefCell::new(RefcountMapIter::end(
+        (m.as_pointer() as Ptr<BTreeMap<i32, Value<i32>>>),
+    )));
+    let const_it: Value<RefcountMapIter<i32, i32>> = Rc::new(RefCell::new(
+        RefcountMapIter::find_key((m.as_pointer() as Ptr<BTreeMap<i32, Value<i32>>>), &0),
+    ));
+    return if (*const_it.borrow()) == (*end.borrow()) {
+        0
+    } else {
+        1
+    };
 }

--- a/tests/unit/out/unsafe/initializer_list.rs
+++ b/tests/unit/out/unsafe/initializer_list.rs
@@ -7,7 +7,7 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn f_0(mut bytes: Vec<i32>) -> u64 {
-    let mut buf: *mut Vec<i32> = (Box::leak(Box::new(bytes)) as *mut Vec<i32>);
+    let mut buf: *mut Vec<i32> = (Box::leak(Box::new(bytes.clone())) as *mut Vec<i32>);
     let mut n: u64 = bytes.len() as u64;
     ::std::mem::drop(Box::from_raw(buf));
     return n;

--- a/tests/unit/out/unsafe/initializer_list.rs
+++ b/tests/unit/out/unsafe/initializer_list.rs
@@ -1,0 +1,28 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn f_0(mut bytes: Vec<i32>) -> u64 {
+    let mut buf: *mut Vec<i32> = (Box::leak(Box::new(bytes)) as *mut Vec<i32>);
+    let mut n: u64 = bytes.len() as u64;
+    ::std::mem::drop(Box::from_raw(buf));
+    return n;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe {
+            let _bytes: Vec<i32> = vec![1, 2, 3];
+            f_0(_bytes)
+        }) == (3_u64))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/map.rs
+++ b/tests/unit/out/unsafe/map.rs
@@ -91,7 +91,7 @@ unsafe fn main_0() -> i32 {
         UnsafeMapIterator::find_key(&m as *const BTreeMap<i16, Box<u32>>, &4_i16)
             != UnsafeMapIterator::end(&m as *const BTreeMap<i16, Box<u32>>)
     );
-    UnsafeMapIterator::erase(&(*r) as *const BTreeMap<i16, Box<u32>>, &it4);
+    UnsafeMapIterator::erase(&(*r) as *const BTreeMap<i16, Box<u32>>, &it4.clone());
     assert!((((*r).len() as u64) == (3_u64)));
     assert!(
         UnsafeMapIterator::find_key(&m as *const BTreeMap<i16, Box<u32>>, &4_i16)

--- a/tests/unit/out/unsafe/map.rs
+++ b/tests/unit/out/unsafe/map.rs
@@ -50,10 +50,10 @@ unsafe fn main_0() -> i32 {
     let mut it: UnsafeMapIterator<i16, u32> =
         UnsafeMapIterator::find_key(&m as *const BTreeMap<i16, Box<u32>>, &1_i16);
     let mut const_it: UnsafeMapIterator<i16, u32> =
-        UnsafeMapIterator::find_key(&m as *const BTreeMap<i16, Box<u32>>, &10_i16);
+        UnsafeMapIterator::find_key(&m as *const BTreeMap<i16, Box<u32>>, &10_i16).clone();
     let mut x1: u32 = if it == end { 0_u32 } else { *it.second() };
     assert!(((x1) == (4_u32)));
-    let mut x2: u32 = if const_it == end {
+    let mut x2: u32 = if const_it == end.clone() {
         0_u32
     } else {
         *const_it.second()
@@ -65,11 +65,12 @@ unsafe fn main_0() -> i32 {
         *it.second()
     };
     assert!(((x3) == (4_u32)));
-    let mut x4: u32 = if const_it == UnsafeMapIterator::end(&m as *const BTreeMap<i16, Box<u32>>) {
-        0_u32
-    } else {
-        *const_it.second()
-    };
+    let mut x4: u32 =
+        if const_it == UnsafeMapIterator::end(&m as *const BTreeMap<i16, Box<u32>>).clone() {
+            0_u32
+        } else {
+            *const_it.second()
+        };
     assert!(((x4) == (0_u32)));
     (*m.entry(4_i16).or_default().as_mut()) = 5_u32;
     let mut it4: UnsafeMapIterator<i16, u32> =

--- a/tests/unit/out/unsafe/map.rs
+++ b/tests/unit/out/unsafe/map.rs
@@ -91,7 +91,7 @@ unsafe fn main_0() -> i32 {
         UnsafeMapIterator::find_key(&m as *const BTreeMap<i16, Box<u32>>, &4_i16)
             != UnsafeMapIterator::end(&m as *const BTreeMap<i16, Box<u32>>)
     );
-    UnsafeMapIterator::erase(&(*r) as *const BTreeMap<i16, Box<u32>>, &it4.clone());
+    UnsafeMapIterator::erase(&(*r) as *const BTreeMap<i16, Box<u32>>, &it4);
     assert!((((*r).len() as u64) == (3_u64)));
     assert!(
         UnsafeMapIterator::find_key(&m as *const BTreeMap<i16, Box<u32>>, &4_i16)

--- a/tests/unit/out/unsafe/redundant_copy_in_conversion.rs
+++ b/tests/unit/out/unsafe/redundant_copy_in_conversion.rs
@@ -1,0 +1,43 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct iter {
+    pub p: *mut i32,
+}
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct const_iter {
+    pub p: *const i32,
+}
+impl const_iter {
+    pub unsafe fn const_iter(o: *const iter) -> Self {
+        let mut this = Self {
+            p: (*o).p.cast_const(),
+        };
+        this
+    }
+}
+pub unsafe fn sink_0(mut i: const_iter) {}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut buf: [i32; 2] = [0, 0];
+    let mut it: iter = iter {
+        p: buf.as_mut_ptr(),
+    };
+    (unsafe {
+        let _i: const_iter = const_iter::const_iter(&it as *const iter);
+        sink_0(_i)
+    });
+    return 0;
+}

--- a/tests/unit/out/unsafe/redundant_copy_in_conversion.rs
+++ b/tests/unit/out/unsafe/redundant_copy_in_conversion.rs
@@ -6,6 +6,10 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
+pub unsafe fn sink_0(mut it: UnsafeMapIterator<i32, i32>) -> i32 {
+    let mut cit: UnsafeMapIterator<i32, i32> = it.clone();
+    return if cit == it.clone() { *it.second() } else { 0 };
+}
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
@@ -16,7 +20,14 @@ unsafe fn main_0() -> i32 {
     (*m.entry(0).or_default().as_mut()) = 1;
     let mut end: UnsafeMapIterator<i32, i32> =
         UnsafeMapIterator::end(&m as *const BTreeMap<i32, Box<i32>>);
-    let mut const_it: UnsafeMapIterator<i32, i32> =
+    let mut it0: UnsafeMapIterator<i32, i32> =
         UnsafeMapIterator::find_key(&m as *const BTreeMap<i32, Box<i32>>, &0);
-    return if const_it == end { 0 } else { 1 };
+    let mut const_it: UnsafeMapIterator<i32, i32> = it0.clone();
+    let mut r: i32 = if const_it == end.clone() { 0 } else { 1 };
+    r += (unsafe {
+        let _it: UnsafeMapIterator<i32, i32> = it0.clone();
+        sink_0(_it)
+    });
+    r += if end == end { 0 } else { 1 };
+    return r;
 }

--- a/tests/unit/out/unsafe/redundant_copy_in_conversion.rs
+++ b/tests/unit/out/unsafe/redundant_copy_in_conversion.rs
@@ -6,38 +6,17 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-#[repr(C)]
-#[derive(Copy, Clone, Default)]
-pub struct iter {
-    pub p: *mut i32,
-}
-#[repr(C)]
-#[derive(Copy, Clone, Default)]
-pub struct const_iter {
-    pub p: *const i32,
-}
-impl const_iter {
-    pub unsafe fn const_iter(o: *const iter) -> Self {
-        let mut this = Self {
-            p: (*o).p.cast_const(),
-        };
-        this
-    }
-}
-pub unsafe fn sink_0(mut i: const_iter) {}
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut buf: [i32; 2] = [0, 0];
-    let mut it: iter = iter {
-        p: buf.as_mut_ptr(),
-    };
-    (unsafe {
-        let _i: const_iter = const_iter::const_iter(&it as *const iter);
-        sink_0(_i)
-    });
-    return 0;
+    let mut m: BTreeMap<i32, Box<i32>> = BTreeMap::new();
+    (*m.entry(0).or_default().as_mut()) = 1;
+    let mut end: UnsafeMapIterator<i32, i32> =
+        UnsafeMapIterator::end(&m as *const BTreeMap<i32, Box<i32>>);
+    let mut const_it: UnsafeMapIterator<i32, i32> =
+        UnsafeMapIterator::find_key(&m as *const BTreeMap<i32, Box<i32>>, &0);
+    return if const_it == end { 0 } else { 1 };
 }

--- a/tests/unit/redundant_copy_in_conversion.cpp
+++ b/tests/unit/redundant_copy_in_conversion.cpp
@@ -1,10 +1,16 @@
 #include <map>
 
+static int sink(std::map<int, int>::iterator it) {
+  std::map<int, int>::const_iterator cit(it);
+  return cit == it ? it->second : 0;
+}
+
 int main() {
   std::map<int, int> m;
   m[0] = 1;
   std::map<int, int>::iterator end = m.end();
-  std::map<int, int>::const_iterator const_it = m.find(0);
+  std::map<int, int>::iterator it0 = m.find(0);
+  std::map<int, int>::const_iterator const_it = it0;
   // Comparing const_iterator with iterator forces an implicit conversion of
   // `end` to const_iterator. The AST shape differs between platforms:
   //
@@ -13,5 +19,8 @@ int main() {
   //
   // The extra inner CopyCtor on macOS would emit a redundant .clone() in the
   // generated Rust. cpp2rust suppresses it so the output matches Linux.
-  return const_it == end ? 0 : 1;
+  int r = const_it == end ? 0 : 1;
+  r += sink(it0);
+  r += end == end ? 0 : 1;
+  return r;
 }

--- a/tests/unit/redundant_copy_in_conversion.cpp
+++ b/tests/unit/redundant_copy_in_conversion.cpp
@@ -1,0 +1,20 @@
+struct iter {
+  using iterator_category = int;
+  int *p;
+};
+
+struct const_iter {
+  using iterator_category = int;
+  const int *p;
+  const_iter(const iter &o) : p(o.p) {}
+  const_iter(const const_iter &) = default;
+};
+
+static void sink(const_iter i) {}
+
+int main() {
+  int buf[2] = {0, 0};
+  iter it{buf};
+  sink(it);
+  return 0;
+}

--- a/tests/unit/redundant_copy_in_conversion.cpp
+++ b/tests/unit/redundant_copy_in_conversion.cpp
@@ -5,5 +5,13 @@ int main() {
   m[0] = 1;
   std::map<int, int>::iterator end = m.end();
   std::map<int, int>::const_iterator const_it = m.find(0);
+  // Comparing const_iterator with iterator forces an implicit conversion of
+  // `end` to const_iterator. The AST shape differs between platforms:
+  //
+  //   Linux: const_it == ConvertingCtor(end)
+  //   macOS: const_it == ConvertingCtor(CopyCtor(end))
+  //
+  // The extra inner CopyCtor on macOS would emit a redundant .clone() in the
+  // generated Rust. cpp2rust suppresses it so the output matches Linux.
   return const_it == end ? 0 : 1;
 }

--- a/tests/unit/redundant_copy_in_conversion.cpp
+++ b/tests/unit/redundant_copy_in_conversion.cpp
@@ -1,20 +1,9 @@
-struct iter {
-  using iterator_category = int;
-  int *p;
-};
-
-struct const_iter {
-  using iterator_category = int;
-  const int *p;
-  const_iter(const iter &o) : p(o.p) {}
-  const_iter(const const_iter &) = default;
-};
-
-static void sink(const_iter i) {}
+#include <map>
 
 int main() {
-  int buf[2] = {0, 0};
-  iter it{buf};
-  sink(it);
-  return 0;
+  std::map<int, int> m;
+  m[0] = 1;
+  std::map<int, int>::iterator end = m.end();
+  std::map<int, int>::const_iterator const_it = m.find(0);
+  return const_it == end ? 0 : 1;
 }


### PR DESCRIPTION
From, tests/unit/redundant_copy_in_conversion:

```cpp
  // Comparing const_iterator with iterator forces an implicit conversion of
  // `end` to const_iterator. The AST shape differs between platforms:
  //
  //   Linux: const_it == ConvertingCtor(end)
  //   macOS: const_it == ConvertingCtor(CopyCtor(end))
  //
  // The extra inner CopyCtor on macOS would emit a redundant .clone() in the
  // generated Rust. cpp2rust suppresses it so the output matches Linux.
  const_it == end ? 0 : 1;
```

This only happens on iterator types because the distinction between iterator and const_iterator. Other containers don't have this issue.