### PR TITLE
Receive &Ptr instead of Ptr in PtrValueIter::new

### DIFF
--- a/libcc2rs/src/rc.rs
+++ b/libcc2rs/src/rc.rs
@@ -640,7 +640,10 @@ pub struct PtrValueIter<T> {
 
 impl<T> PtrValueIter<T> {
     pub fn new(ptr: &Ptr<T>, n: usize) -> Self {
-        Self { ptr: ptr.clone() , n }
+        Self {
+            ptr: ptr.clone(),
+            n,
+        }
     }
 }
 

--- a/libcc2rs/src/rc.rs
+++ b/libcc2rs/src/rc.rs
@@ -639,8 +639,8 @@ pub struct PtrValueIter<T> {
 }
 
 impl<T> PtrValueIter<T> {
-    pub fn new(ptr: Ptr<T>, n: usize) -> Self {
-        Self { ptr, n }
+    pub fn new(ptr: &Ptr<T>, n: usize) -> Self {
+        Self { ptr: ptr.clone() , n }
     }
 }
 

--- a/rules/algorithm/ir_refcount.json
+++ b/rules/algorithm/ir_refcount.json
@@ -127,7 +127,7 @@
         }
       },
       {
-        "text": ";\n        let mut iter = PtrValueIter::new("
+        "text": ";\n        let mut iter = PtrValueIter::new(&"
       },
       {
         "placeholder": {
@@ -975,7 +975,7 @@
         }
       },
       {
-        "text": ";\n    for value in PtrValueIter::new("
+        "text": ";\n    for value in PtrValueIter::new(&"
       },
       {
         "placeholder": {
@@ -1430,23 +1430,12 @@
                           "method_call": {
                             "receiver": [
                               {
-                                "text": "PtrValueIter::new("
+                                "text": "PtrValueIter::new(&"
                               },
                               {
-                                "method_call": {
-                                  "receiver": [
-                                    {
-                                      "placeholder": {
-                                        "arg": 0,
-                                        "access": "read"
-                                      }
-                                    }
-                                  ],
-                                  "body": [
-                                    {
-                                      "text": ".clone()"
-                                    }
-                                  ]
+                                "placeholder": {
+                                  "arg": 0,
+                                  "access": "read"
                                 }
                               },
                               {

--- a/rules/algorithm/tgt_refcount.rs
+++ b/rules/algorithm/tgt_refcount.rs
@@ -17,7 +17,7 @@ fn f2<T1: Clone + PartialOrd + ByteRepr, T2: Clone + From<T1> + ByteRepr>(
 ) -> Ptr<T2> {
     let count = a1.get_offset() - a0.get_offset();
     let mut outptr = a2.clone();
-    for value in PtrValueIter::new(a0, count) {
+    for value in PtrValueIter::new(&a0, count) {
         outptr.write(value.into());
         outptr += 1;
     }
@@ -52,7 +52,7 @@ where
 
 fn f8<T1: PartialOrd + Clone + ByteRepr>(a0: Ptr<T1>, a1: Ptr<T1>) -> Ptr<T1> {
     let count = a1.get_offset() - a0.get_offset();
-    let max_index = PtrValueIter::new(a0.clone(), count)
+    let max_index = PtrValueIter::new(&a0, count)
         .enumerate()
         .max_by(|(_, val_a), (_, val_b)| {
             val_a
@@ -76,7 +76,7 @@ fn f10<T1: PartialEq + Clone + ByteRepr>(a0: Ptr<T1>, a1: Ptr<T1>) -> Ptr<T1> {
         a1
     } else {
         let mut write_ptr = a0.clone();
-        let mut iter = PtrValueIter::new(a0, count);
+        let mut iter = PtrValueIter::new(&a0, count);
         let mut last_unique = iter.next().unwrap();
 
         // the first unique value is already in place

--- a/rules/vector/ir_refcount.json
+++ b/rules/vector/ir_refcount.json
@@ -1071,7 +1071,7 @@
         "method_call": {
           "receiver": [
             {
-              "text": "PtrValueIter::new("
+              "text": "PtrValueIter::new(&"
             },
             {
               "placeholder": {
@@ -1164,23 +1164,12 @@
               "method_call": {
                 "receiver": [
                   {
-                    "text": "PtrValueIter::new("
+                    "text": "PtrValueIter::new(&"
                   },
                   {
-                    "method_call": {
-                      "receiver": [
-                        {
-                          "placeholder": {
-                            "arg": 0,
-                            "access": "read"
-                          }
-                        }
-                      ],
-                      "body": [
-                        {
-                          "text": ".clone()"
-                        }
-                      ]
+                    "placeholder": {
+                      "arg": 0,
+                      "access": "read"
                     }
                   },
                   {
@@ -1318,27 +1307,7 @@
   "f42": {
     "body": [
       {
-        "text": "let __a0 = "
-      },
-      {
-        "method_call": {
-          "receiver": [
-            {
-              "placeholder": {
-                "arg": 0,
-                "access": "read"
-              }
-            }
-          ],
-          "body": [
-            {
-              "text": ".clone()"
-            }
-          ]
-        }
-      },
-      {
-        "text": ";\n    let __count = "
+        "text": "let __count = "
       },
       {
         "method_call": {
@@ -1364,7 +1333,10 @@
         "method_call": {
           "receiver": [
             {
-              "text": "__a0"
+              "placeholder": {
+                "arg": 0,
+                "access": "read"
+              }
             }
           ],
           "body": [
@@ -1390,7 +1362,16 @@
                           "method_call": {
                             "receiver": [
                               {
-                                "text": "PtrValueIter::new(__a0, __count)"
+                                "text": "PtrValueIter::new(&"
+                              },
+                              {
+                                "placeholder": {
+                                  "arg": 0,
+                                  "access": "read"
+                                }
+                              },
+                              {
+                                "text": ", __count)"
                               }
                             ],
                             "body": [
@@ -1809,7 +1790,7 @@
         "method_call": {
           "receiver": [
             {
-              "text": "PtrValueIter::new("
+              "text": "PtrValueIter::new(&"
             },
             {
               "placeholder": {

--- a/rules/vector/tgt_refcount.rs
+++ b/rules/vector/tgt_refcount.rs
@@ -114,12 +114,12 @@ fn f34<T1>(a0: &mut Ptr<T1>) -> Ptr<T1> {
 
 fn f35<T1: Clone + ByteRepr>(a0: Ptr<T1>, a1: Ptr<T1>) -> Vec<T1> {
     let __count = a1.get_offset() - a0.get_offset();
-    PtrValueIter::new(a0, __count).collect::<Vec<_>>()
+    PtrValueIter::new(&a0, __count).collect::<Vec<_>>()
 }
 
 fn f37<T1: TryFrom<T2>, T2: Clone + ByteRepr>(a0: Ptr<T2>, a1: Ptr<T2>) -> Vec<T1> {
     let __count = a1.get_offset() - a0.get_offset();
-    PtrValueIter::new(a0.clone(), __count)
+    PtrValueIter::new(&a0, __count)
         .map(|item| T1::try_from(item).ok().unwrap())
         .collect::<Vec<_>>()
 }
@@ -133,9 +133,8 @@ fn f41<T1>(a0: Ptr<T1>) -> Ptr<T1> {
 }
 
 fn f42(a0: Ptr<u8>, a1: Ptr<u8>) -> Ptr<u8> {
-    let __a0 = a0.clone();
-    let __count = a1.get_offset() - __a0.get_offset();
-    let max_index = PtrValueIter::new(__a0, __count)
+    let __count = a1.get_offset() - a0.get_offset();
+    let max_index = PtrValueIter::new(&a0, __count)
         .enumerate()
         .max_by_key(|&(_, val)| val)
         .map(|(idx, _)| idx)
@@ -176,7 +175,7 @@ fn f53<T1: Clone + ByteRepr>(
 ) -> Ptr<Vec<T1>> {
     let start_idx = a1.get_offset();
     let count = a3.get_offset() - a2.get_offset();
-    let temp_vec: Vec<T1> = PtrValueIter::new(a2, count).collect();
+    let temp_vec: Vec<T1> = PtrValueIter::new(&a2, count).collect();
     a0.with_mut(|v: &mut Vec<T1>| {
         v.splice(start_idx..start_idx, temp_vec);
     });

--- a/tests/unit/out/refcount/push_emplace_back.rs
+++ b/tests/unit/out/refcount/push_emplace_back.rs
@@ -84,7 +84,7 @@ pub fn push_local_from_field_1(jpg: Ptr<JPEGData>, cond: bool) {
                         .offset((3) as isize)
                         .get_offset()
                         - (head.as_pointer() as Ptr<u8>).get_offset();
-                    PtrValueIter::new((head.as_pointer() as Ptr<u8>).clone(), __count)
+                    PtrValueIter::new(&(head.as_pointer() as Ptr<u8>), __count)
                         .map(|item| u8::try_from(item).ok().unwrap())
                         .collect::<Vec<_>>()
                 }
@@ -125,7 +125,7 @@ pub fn emplace_local_from_field_4(jpg: Ptr<JPEGData>, cond: bool) {
                     .offset((3) as isize)
                     .get_offset()
                     - (head.as_pointer() as Ptr<u8>).get_offset();
-                PtrValueIter::new((head.as_pointer() as Ptr<u8>).clone(), __count)
+                PtrValueIter::new(&(head.as_pointer() as Ptr<u8>), __count)
                     .map(|item| u8::try_from(item).ok().unwrap())
                     .collect::<Vec<_>>()
             })))

--- a/tests/unit/out/refcount/stdcopy.rs
+++ b/tests/unit/out/refcount/stdcopy.rs
@@ -20,7 +20,7 @@ fn main_0() -> i32 {
             .get_offset()
             - (input.as_pointer() as Ptr<i32>).get_offset();
         let mut outptr = (output.as_pointer() as Ptr<i32>).clone();
-        for value in PtrValueIter::new((input.as_pointer() as Ptr<i32>), count) {
+        for value in PtrValueIter::new(&(input.as_pointer() as Ptr<i32>), count) {
             outptr.write(value.into());
             outptr += 1;
         }

--- a/tests/unit/out/refcount/vector_iter_range_ctor.rs
+++ b/tests/unit/out/refcount/vector_iter_range_ctor.rs
@@ -16,7 +16,7 @@ fn main_0() -> i32 {
             .offset((3) as isize)
             .get_offset()
             - (src.as_pointer() as Ptr<u32>).get_offset();
-        PtrValueIter::new((src.as_pointer() as Ptr<u32>).clone(), __count)
+        PtrValueIter::new(&(src.as_pointer() as Ptr<u32>), __count)
             .map(|item| u32::try_from(item).ok().unwrap())
             .collect::<Vec<_>>()
     }));
@@ -31,7 +31,7 @@ fn main_0() -> i32 {
             .offset((3) as isize)
             .get_offset()
             - (src.as_pointer() as Ptr<u32>).get_offset();
-        PtrValueIter::new((src.as_pointer() as Ptr<u32>).clone(), __count)
+        PtrValueIter::new(&(src.as_pointer() as Ptr<u32>), __count)
             .map(|item| u64::try_from(item).ok().unwrap())
             .collect::<Vec<_>>()
     }));
@@ -46,7 +46,7 @@ fn main_0() -> i32 {
             .offset((3) as isize)
             .get_offset()
             - (src.as_pointer() as Ptr<u32>).get_offset();
-        PtrValueIter::new((src.as_pointer() as Ptr<u32>).clone(), __count)
+        PtrValueIter::new(&(src.as_pointer() as Ptr<u32>), __count)
             .map(|item| i32::try_from(item).ok().unwrap())
             .collect::<Vec<_>>()
     }));
@@ -60,13 +60,29 @@ fn main_0() -> i32 {
     let v4: Value<Vec<u32>> = Rc::new(RefCell::new({
         let __count = (src1.as_pointer() as Ptr<u32>).to_end().get_offset()
             - (src1.as_pointer() as Ptr<u32>).get_offset();
-        PtrValueIter::new((src1.as_pointer() as Ptr<u32>), __count).collect::<Vec<_>>()
+        PtrValueIter::new(&(src1.as_pointer() as Ptr<u32>), __count).collect::<Vec<_>>()
     }));
     assert!(((*v4.borrow()).len() as u64 == 3_u64));
     assert!(
         ((((v4.as_pointer() as Ptr<u32>).offset(0_u64 as isize).read()) == 1_u32)
             && (((v4.as_pointer() as Ptr<u32>).offset(1_u64 as isize).read()) == 2_u32))
             && (((v4.as_pointer() as Ptr<u32>).offset(2_u64 as isize).read()) == 3_u32)
+    );
+    let buf: Value<Box<[u8]>> =
+        Rc::new(RefCell::new(Box::new([10_u8, 20_u8, 30_u8, 40_u8, 50_u8])));
+    let start: Value<Ptr<u8>> = Rc::new(RefCell::new((buf.as_pointer() as Ptr<u8>)));
+    let len: Value<u64> = Rc::new(RefCell::new(5_u64));
+    let v5: Value<Vec<u8>> = Rc::new(RefCell::new({
+        let __count = (*start.borrow())
+            .offset((*len.borrow()) as isize)
+            .get_offset()
+            - (*start.borrow()).get_offset();
+        PtrValueIter::new(&(*start.borrow()), __count).collect::<Vec<_>>()
+    }));
+    assert!(((*v5.borrow()).len() as u64 == 5_u64));
+    assert!(
+        ((((v5.as_pointer() as Ptr<u8>).offset(0_u64 as isize).read()) as i32) == 10)
+            && ((((v5.as_pointer() as Ptr<u8>).offset(4_u64 as isize).read()) as i32) == 50)
     );
     return 0;
 }

--- a/tests/unit/out/unsafe/vector_iter_range_ctor.rs
+++ b/tests/unit/out/unsafe/vector_iter_range_ctor.rs
@@ -60,5 +60,15 @@ unsafe fn main_0() -> i32 {
         (((v4[(0_u64) as usize]) == (1_u32)) && ((v4[(1_u64) as usize]) == (2_u32)))
             && ((v4[(2_u64) as usize]) == (3_u32))
     );
+    let mut buf: [u8; 5] = [10_u8, 20_u8, 30_u8, 40_u8, 50_u8];
+    let mut start: *const u8 = buf.as_mut_ptr().cast_const();
+    let mut len: u64 = 5_u64;
+    let mut v5: Vec<u8> = core::slice::from_raw_parts(
+        start,
+        (start.offset((len) as isize)).offset_from(start) as usize,
+    )
+    .to_vec();
+    assert!(((v5.len() as u64) == (5_u64)));
+    assert!(((v5[(0_u64) as usize] as i32) == (10)) && ((v5[(4_u64) as usize] as i32) == (50)));
     return 0;
 }

--- a/tests/unit/vector_iter_range_ctor.cpp
+++ b/tests/unit/vector_iter_range_ctor.cpp
@@ -26,5 +26,12 @@ int main() {
   assert(v4.size() == 3);
   assert(v4[0] == 1 && v4[1] == 2 && v4[2] == 3);
 
+  uint8_t buf[5] = {10, 20, 30, 40, 50};
+  const uint8_t *start = buf;
+  size_t len = 5;
+  std::vector<uint8_t> v5(start, start + len);
+  assert(v5.size() == 5);
+  assert(v5[0] == 10 && v5[4] == 50);
+
   return 0;
 }


### PR DESCRIPTION
```rs
let start: Value<Ptr<u8>> = ...;
PtrValueIter::new((*start.borrow()), __count).collect::<Vec<_>>()
```

tries to move out of `(*start.borrow())` which does not implement the Copy trait because Ptr does not implement Copy.

To avoid the move, change the `ptr` argument of `PtrValueIter::new` to `&Ptr<T>` instead of `Ptr<T>`
```rs
pub fn new(ptr: &Ptr<T>, n: usize) -> Self 
                ^
```

This pattern is not new, it's also used in `Ptr::memcpy, Ptr::memset, Ptr::slice_until`.