### PR TITLE
Don't map user-defined expressions

### DIFF
--- a/cpp2rust/compat/platform_flags.h
+++ b/cpp2rust/compat/platform_flags.h
@@ -9,7 +9,7 @@
 static inline std::vector<std::string> getPlatformClangBeginFlags() {
   std::vector<std::string> flags = {
       "-resource-dir=" CLANG_RESOURCE_DIR,
-      "-I" COMPAT_INCLUDE_DIR,
+      "-isystem" COMPAT_INCLUDE_DIR,
       "-D_FORTIFY_SOURCE=0",
   };
 #ifdef MACOS_SDK_PATH

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -276,7 +276,7 @@ bool Converter::Convert(clang::Decl *decl) { return TraverseDecl(decl); }
 
 bool Converter::VisitTranslationUnitDecl(clang::TranslationUnitDecl *decl) {
   for (auto *child : decl->decls()) {
-    if (IsConvertibleDecl(child) &&
+    if (IsUserDefinedDecl(child) &&
         (IsInMainFile(child) || !decl_ids_.contains(GetID(child)))) {
       Convert(child);
     }

--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -129,13 +129,28 @@ bool IsInMainFile(const clang::Decl *decl) {
   return src_mgr.isInMainFile(src_mgr.getExpansionLoc(loc));
 }
 
-bool IsConvertibleDecl(const clang::Decl *decl) {
+bool IsUserDefinedDecl(const clang::Decl *decl) {
   const auto &ctx = decl->getASTContext();
   const auto &src_mgr = ctx.getSourceManager();
   const auto src_loc = decl->getLocation();
   return !decl->getBeginLoc().isInvalid() && !decl->isImplicit() &&
          !src_mgr.isInSystemHeader(src_loc) &&
          !src_mgr.isInSystemMacro(src_loc);
+}
+
+bool RefersToUserDefinedDecl(const clang::Expr *expr) {
+  expr = expr->IgnoreParenImpCasts();
+  const clang::Decl *decl = nullptr;
+  if (const auto *call = llvm::dyn_cast<clang::CallExpr>(expr)) {
+    decl = call->getDirectCallee();
+  } else if (const auto *ref = llvm::dyn_cast<clang::DeclRefExpr>(expr)) {
+    decl = ref->getDecl();
+  } else if (const auto *member = llvm::dyn_cast<clang::MemberExpr>(expr)) {
+    decl = member->getMemberDecl();
+  } else if (const auto *ctor = llvm::dyn_cast<clang::CXXConstructExpr>(expr)) {
+    decl = ctor->getConstructor();
+  }
+  return decl && IsUserDefinedDecl(decl);
 }
 
 bool IsUnsignedArithOp(const clang::BinaryOperator *expr) {

--- a/cpp2rust/converter/converter_lib.h
+++ b/cpp2rust/converter/converter_lib.h
@@ -39,7 +39,9 @@ bool IsComparisonWithNullOp(const clang::BinaryOperator *expr);
 
 bool IsInMainFile(const clang::Decl *decl);
 
-bool IsConvertibleDecl(const clang::Decl *decl);
+bool IsUserDefinedDecl(const clang::Decl *decl);
+
+bool RefersToUserDefinedDecl(const clang::Expr *expr);
 
 bool IsUnsignedArithOp(const clang::BinaryOperator *expr);
 

--- a/cpp2rust/converter/mapper.cpp
+++ b/cpp2rust/converter/mapper.cpp
@@ -385,6 +385,9 @@ search(std::unordered_multimap<std::string, T> &map, const std::string &txt,
 }
 
 TranslationRule::ExprRule *search(const clang::Expr *expr) {
+  if (RefersToUserDefinedDecl(expr)) {
+    return nullptr;
+  }
   auto qualified_name = ToString(expr);
   auto [rule, subs] =
       search(exprs_, qualified_name, GetExprMapKey(qualified_name));
@@ -598,7 +601,8 @@ const TranslationRule::ExprRule *GetExprRule(const clang::Expr *expr) {
 
 std::string MapFunctionName(const clang::FunctionDecl *decl) {
   assert(decl);
-  if (exprs_.contains(GetExprMapKey(ToString(decl)))) {
+  if (!IsUserDefinedDecl(decl) &&
+      exprs_.contains(GetExprMapKey(ToString(decl)))) {
     return std::format("libcc2rs::{}_{}", decl->getNameAsString(),
                        model_ == Model::kRefCount ? "refcount" : "unsafe");
   }

--- a/tests/unit/out/refcount/user_defined_same_as_libc.rs
+++ b/tests/unit/out/refcount/user_defined_same_as_libc.rs
@@ -19,7 +19,7 @@ pub fn main() {
 fn main_0() -> i32 {
     let fp: Value<Ptr<::std::fs::File>> = Rc::new(RefCell::new(
         ({
-            let _path: Ptr<u8> = Ptr::from_string_literal("/etc/passwd");
+            let _path: Ptr<u8> = Ptr::from_string_literal("/tmp/irrelevant-file");
             let _mode: Ptr<u8> = Ptr::from_string_literal("r");
             fopen_0(_path, _mode)
         }),

--- a/tests/unit/out/refcount/user_defined_same_as_libc.rs
+++ b/tests/unit/out/refcount/user_defined_same_as_libc.rs
@@ -6,22 +6,24 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-pub fn strchr_0(s: Ptr<u8>, c: i32) -> Ptr<u8> {
-    let s: Value<Ptr<u8>> = Rc::new(RefCell::new(s));
-    let c: Value<i32> = Rc::new(RefCell::new(c));
-    return Ptr::<u8>::null();
+pub fn fopen_0(path: Ptr<u8>, mode: Ptr<u8>) -> Ptr<::std::fs::File> {
+    let path: Value<Ptr<u8>> = Rc::new(RefCell::new(path));
+    let mode: Value<Ptr<u8>> = Rc::new(RefCell::new(mode));
+    (*path.borrow()).clone();
+    (*mode.borrow()).clone();
+    return Ptr::null();
 }
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    let p: Value<Ptr<u8>> = Rc::new(RefCell::new(
+    let fp: Value<Ptr<::std::fs::File>> = Rc::new(RefCell::new(
         ({
-            let _s: Ptr<u8> = Ptr::from_string_literal("hello");
-            let _c: i32 = ('l' as i32);
-            strchr_0(_s, _c)
+            let _path: Ptr<u8> = Ptr::from_string_literal("/etc/passwd");
+            let _mode: Ptr<u8> = Ptr::from_string_literal("r");
+            fopen_0(_path, _mode)
         }),
     ));
-    assert!(((((*p.borrow()).is_null()) as i32) != 0));
+    assert!(((((*fp.borrow()).is_null()) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/refcount/user_defined_same_as_libc.rs
+++ b/tests/unit/out/refcount/user_defined_same_as_libc.rs
@@ -1,0 +1,27 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn strchr_0(s: Ptr<u8>, c: i32) -> Ptr<u8> {
+    let s: Value<Ptr<u8>> = Rc::new(RefCell::new(s));
+    let c: Value<i32> = Rc::new(RefCell::new(c));
+    return Ptr::<u8>::null();
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let p: Value<Ptr<u8>> = Rc::new(RefCell::new(
+        ({
+            let _s: Ptr<u8> = Ptr::from_string_literal("hello");
+            let _c: i32 = ('l' as i32);
+            strchr_0(_s, _c)
+        }),
+    ));
+    assert!(((((*p.borrow()).is_null()) as i32) != 0));
+    return 0;
+}

--- a/tests/unit/out/unsafe/user_defined_same_as_libc.rs
+++ b/tests/unit/out/unsafe/user_defined_same_as_libc.rs
@@ -18,8 +18,8 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut fp: *mut ::std::fs::File = (unsafe {
-        let _path: *const u8 = b"/etc/passwd\0".as_ptr().cast_mut().cast_const();
-        let _mode: *const u8 = b"r\0".as_ptr().cast_mut().cast_const();
+        let _path: *const u8 = (b"/etc/passwd\0".as_ptr().cast_mut()).cast_const();
+        let _mode: *const u8 = (b"r\0".as_ptr().cast_mut()).cast_const();
         fopen_0(_path, _mode)
     });
     assert!(((((fp).is_null()) as i32) != 0));

--- a/tests/unit/out/unsafe/user_defined_same_as_libc.rs
+++ b/tests/unit/out/unsafe/user_defined_same_as_libc.rs
@@ -18,7 +18,7 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut fp: *mut ::std::fs::File = (unsafe {
-        let _path: *const u8 = (b"/etc/passwd\0".as_ptr().cast_mut()).cast_const();
+        let _path: *const u8 = (b"/tmp/irrelevant-file\0".as_ptr().cast_mut()).cast_const();
         let _mode: *const u8 = (b"r\0".as_ptr().cast_mut()).cast_const();
         fopen_0(_path, _mode)
     });

--- a/tests/unit/out/unsafe/user_defined_same_as_libc.rs
+++ b/tests/unit/out/unsafe/user_defined_same_as_libc.rs
@@ -6,7 +6,9 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-pub unsafe fn strchr_0(mut s: *const u8, mut c: i32) -> *mut u8 {
+pub unsafe fn fopen_0(mut path: *const u8, mut mode: *const u8) -> *mut ::std::fs::File {
+    &(path);
+    &(mode);
     return std::ptr::null_mut();
 }
 pub fn main() {
@@ -15,12 +17,11 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut p: *const u8 = (unsafe {
-        let _s: *const u8 = b"hello\0".as_ptr().cast_mut().cast_const();
-        let _c: i32 = ('l' as i32);
-        strchr_0(_s, _c)
-    })
-    .cast_const();
-    assert!(((((p).is_null()) as i32) != 0));
+    let mut fp: *mut ::std::fs::File = (unsafe {
+        let _path: *const u8 = b"/etc/passwd\0".as_ptr().cast_mut().cast_const();
+        let _mode: *const u8 = b"r\0".as_ptr().cast_mut().cast_const();
+        fopen_0(_path, _mode)
+    });
+    assert!(((((fp).is_null()) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/user_defined_same_as_libc.rs
+++ b/tests/unit/out/unsafe/user_defined_same_as_libc.rs
@@ -1,0 +1,26 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn strchr_0(mut s: *const u8, mut c: i32) -> *mut u8 {
+    return std::ptr::null_mut();
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut p: *const u8 = (unsafe {
+        let _s: *const u8 = b"hello\0".as_ptr().cast_mut().cast_const();
+        let _c: i32 = ('l' as i32);
+        strchr_0(_s, _c)
+    })
+    .cast_const();
+    assert!(((((p).is_null()) as i32) != 0));
+    return 0;
+}

--- a/tests/unit/user_defined_same_as_libc.c
+++ b/tests/unit/user_defined_same_as_libc.c
@@ -1,10 +1,14 @@
 #include <assert.h>
-#include <stddef.h>
+#include <stdio.h>
 
-char *strchr(const char *s, int c) { return NULL; }
+FILE *fopen(const char *path, const char *mode) {
+  (void)path;
+  (void)mode;
+  return NULL;
+}
 
 int main() {
-  const char *p = strchr("hello", 'l');
-  assert(p == NULL);
+  FILE *fp = fopen("/etc/passwd", "r");
+  assert(fp == NULL);
   return 0;
 }

--- a/tests/unit/user_defined_same_as_libc.c
+++ b/tests/unit/user_defined_same_as_libc.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+#include <stddef.h>
+
+char *strchr(const char *s, int c) { return NULL; }
+
+int main() {
+  const char *p = strchr("hello", 'l');
+  assert(p == NULL);
+  return 0;
+}

--- a/tests/unit/user_defined_same_as_libc.c
+++ b/tests/unit/user_defined_same_as_libc.c
@@ -8,7 +8,7 @@ FILE *fopen(const char *path, const char *mode) {
 }
 
 int main() {
-  FILE *fp = fopen("/etc/passwd", "r");
+  FILE *fp = fopen("/tmp/irrelevant-file", "r");
   assert(fp == NULL);
   return 0;
 }


### PR DESCRIPTION
If the user code redefines strchr, don't apply the translation rules on the user-defined strchr, instead call the user-defined strchr.