### PR TITLE
Add paren around cast'ed expression

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -1856,21 +1856,28 @@ bool Converter::VisitImplicitCastExpr(clang::ImplicitCastExpr *expr) {
     break;
   }
   case clang::CastKind::CK_NoOp: {
-    Convert(sub_expr);
+    const char *suffix = nullptr;
     if (expr->getType()->isPointerType() &&
         sub_expr->getType()->isPointerType() &&
         !clang::isa<clang::CXXThisExpr>(expr->IgnoreImplicit())) {
       switch (GetConstCastType(expr->getType()->getPointeeType(),
                                sub_expr->getType()->getPointeeType())) {
       case ConstCastType::MutableToConst:
-        StrCat(".cast_const()");
+        suffix = ".cast_const()";
         break;
       case ConstCastType::ConstToMutable:
-        StrCat(".cast_mut()");
+        suffix = ".cast_mut()";
         break;
       default:
         break;
       }
+    }
+    {
+      PushParen paren(*this, suffix);
+      Convert(sub_expr);
+    }
+    if (suffix) {
+      StrCat(suffix);
     }
     break;
   }

--- a/tests/unit/out/unsafe/bool_condition_logical_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical_c.rs
@@ -128,7 +128,7 @@ unsafe fn main_0() -> i32 {
     if (((((((n) != (0)) as i32) != 0) || (((bits) & (256_i64)) != 0)) as i32) != 0) {
         assert!((1 != 0));
     }
-    let mut cp: *const u8 = b"hi\0".as_ptr().cast_mut().cast_const();
+    let mut cp: *const u8 = (b"hi\0".as_ptr().cast_mut()).cast_const();
     let mut cnp: *const u8 = std::ptr::null();
     if (((((((x) > (y)) as i32) != 0) && (!(cp).is_null())) as i32) != 0) {
         assert!((1 != 0));

--- a/tests/unit/out/unsafe/enum_int_interop_c.rs
+++ b/tests/unit/out/unsafe/enum_int_interop_c.rs
@@ -72,17 +72,17 @@ pub static mut global_tag: Tag = unsafe { Tag::TAG_TWO };
 pub static mut entries: [Entry; 3] = unsafe {
     [
         Entry {
-            name: b"first\0".as_ptr().cast_mut().cast_const(),
+            name: (b"first\0".as_ptr().cast_mut()).cast_const(),
             color: Color::RED,
             opt: Option::OPT_NONE,
         },
         Entry {
-            name: b"second\0".as_ptr().cast_mut().cast_const(),
+            name: (b"second\0".as_ptr().cast_mut()).cast_const(),
             color: Color::GREEN,
             opt: Option::OPT_A,
         },
         Entry {
-            name: b"third\0".as_ptr().cast_mut().cast_const(),
+            name: (b"third\0".as_ptr().cast_mut()).cast_const(),
             color: Color::BLUE,
             opt: Option::OPT_C,
         },

--- a/tests/unit/out/unsafe/expr_as_bool_c.rs
+++ b/tests/unit/out/unsafe/expr_as_bool_c.rs
@@ -66,7 +66,7 @@ unsafe fn main_0() -> i32 {
     assert!(((((eq) == (1)) as i32) != 0));
     assert!(((((lt) == (0)) as i32) != 0));
     assert!(((((neq) == (0)) as i32) != 0));
-    let mut p1: *const u8 = b"hi\0".as_ptr().cast_mut().cast_const();
+    let mut p1: *const u8 = (b"hi\0".as_ptr().cast_mut()).cast_const();
     let mut p2: *const u8 = std::ptr::null();
     let mut either: i32 = (((!(p1).is_null()) || (!(p2).is_null())) as i32);
     let mut both: i32 = (((!(p1).is_null()) && (!(p2).is_null())) as i32);

--- a/tests/unit/out/unsafe/huffman.rs
+++ b/tests/unit/out/unsafe/huffman.rs
@@ -240,7 +240,7 @@ pub unsafe fn CollectCodes_4(
             CollectCodes_4(_root, _arr, _top, _out, _next)
         });
     }
-    if (unsafe { (*root.cast_const()).IsLeaf() }) {
+    if (unsafe { (*(root).cast_const()).IsLeaf() }) {
         (unsafe {
             let _arr: *mut Option<Box<[i32]>> = arr;
             let _top: i32 = top;

--- a/tests/unit/out/unsafe/pointer_usize_arith.rs
+++ b/tests/unit/out/unsafe/pointer_usize_arith.rs
@@ -63,7 +63,7 @@ unsafe fn main_0() -> i32 {
     assert!((((*bq) as i32) == (4)));
     let mut bdiff: i64 = ((bq as usize - bp as usize) / ::std::mem::size_of::<u8>()) as i64;
     assert!(((bdiff) == (4_i64)));
-    let mut cp: *const i32 = arr.as_mut_ptr().cast_const();
+    let mut cp: *const i32 = (arr.as_mut_ptr()).cast_const();
     let mut cq: *const i32 = cp.offset((2) as isize);
     assert!(((*cq) == (12)));
     let mut cdiff: i64 = ((cq as usize - cp as usize) / ::std::mem::size_of::<i32>()) as i64;

--- a/tests/unit/out/unsafe/polymorphism.rs
+++ b/tests/unit/out/unsafe/polymorphism.rs
@@ -38,9 +38,9 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut dog: Dog = <Dog>::default();
     let mut animal: *mut dyn Animal = (&mut dog as *mut Dog);
-    let mut eat1: bool = (unsafe { (*animal.cast_const()).bark() });
+    let mut eat1: bool = (unsafe { (*(animal).cast_const()).bark() });
     let mut cat: Cat = <Cat>::default();
     animal = (&mut cat as *mut Cat);
-    let mut eat2: bool = (unsafe { (*animal.cast_const()).bark() });
+    let mut eat2: bool = (unsafe { (*(animal).cast_const()).bark() });
     return (((eat1) && (!eat2)) as i32);
 }

--- a/tests/unit/out/unsafe/strchr_c.rs
+++ b/tests/unit/out/unsafe/strchr_c.rs
@@ -12,8 +12,8 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut s: *const u8 = b"hello world\0".as_ptr().cast_mut().cast_const();
-    let mut r: *mut u8 = libc::strchr(s as *const i8, ('w' as i32)) as *mut u8;
+    let mut s: *const u8 = (b"hello world\0".as_ptr().cast_mut()).cast_const();
+    let mut r: *const u8 = (libc::strchr(s as *const i8, ('w' as i32)) as *mut u8).cast_const();
     assert!((((!((r).is_null())) as i32) != 0));
     assert!((((((*r) as i32) == ('w' as i32)) as i32) != 0));
     assert!(((((libc::strchr(s as *const i8, ('z' as i32)) as *mut u8).is_null()) as i32) != 0));

--- a/tests/unit/out/unsafe/string.rs
+++ b/tests/unit/out/unsafe/string.rs
@@ -30,7 +30,7 @@ unsafe fn main_0() -> i32 {
                 .to_vec()
         }
     );
-    let mut p1: *const u8 = s1.as_mut_ptr().cast_const();
+    let mut p1: *const u8 = (s1.as_mut_ptr()).cast_const();
     assert!((((*p1.offset((0) as isize)) as i32) == (('h' as u8) as i32)));
     assert!((((*p1.offset((1) as isize)) as i32) == (('e' as u8) as i32)));
     assert!((((*p1.offset((2) as isize)) as i32) == (('l' as u8) as i32)));
@@ -41,7 +41,7 @@ unsafe fn main_0() -> i32 {
         .cloned()
         .chain(std::iter::once(0))
         .collect();
-    let mut p2: *const u8 = s2.as_mut_ptr().cast_const();
+    let mut p2: *const u8 = (s2.as_mut_ptr()).cast_const();
     let mut i: u32 = 0_u32;
     'loop_: while ((i as u64) < ((s2.len() - 1) as u64)) {
         assert!(
@@ -72,7 +72,7 @@ unsafe fn main_0() -> i32 {
     };
     assert!((((s3.len() - 1) as u64) == (5_u64)));
     assert!((((s3.len() - 1) as u64) == ((s3.len() - 1) as u64)));
-    let mut p3: *const u8 = s3.as_mut_ptr().cast_const();
+    let mut p3: *const u8 = (s3.as_mut_ptr()).cast_const();
     let mut i: u32 = 0_u32;
     'loop_: while ((i as u64) < ((s3.len() - 1) as u64)) {
         assert!((((*p3.offset((i) as isize)) as i32) == (s3[(i as u64) as usize] as i32)));
@@ -99,7 +99,7 @@ unsafe fn main_0() -> i32 {
     };
     assert!((((s4.len() - 1) as u64) == (3_u64)));
     assert!((((s4.len() - 1) as u64) == ((s4.len() - 1) as u64)));
-    let mut p4: *const u8 = s4.as_mut_ptr().cast_const();
+    let mut p4: *const u8 = (s4.as_mut_ptr()).cast_const();
     let mut i: u32 = 0_u32;
     'loop_: while ((i as u64) < ((s4.len() - 1) as u64)) {
         assert!((((*p4.offset((i) as isize)) as i32) == (s4[(i as u64) as usize] as i32)));
@@ -118,7 +118,7 @@ unsafe fn main_0() -> i32 {
     };
     assert!((((s5.len() - 1) as u64) == (12_u64)));
     assert!((((s5.len() - 1) as u64) == ((s5.len() - 1) as u64)));
-    let mut p5: *const u8 = s5.as_mut_ptr().cast_const();
+    let mut p5: *const u8 = (s5.as_mut_ptr()).cast_const();
     let mut i: u32 = 0_u32;
     'loop_: while ((i as u64) < ((s5.len() - 1) as u64)) {
         assert!((((*p5.offset((i) as isize)) as i32) == (s5[(i as u64) as usize] as i32)));
@@ -134,7 +134,7 @@ unsafe fn main_0() -> i32 {
         ('o' as u8),
     ];
     let mut string: Vec<u8> =
-        std::slice::from_raw_parts(arr.as_mut_ptr().cast_const(), 3_u64 as usize)
+        std::slice::from_raw_parts((arr.as_mut_ptr()).cast_const(), 3_u64 as usize)
             .to_vec()
             .iter()
             .copied()

--- a/tests/unit/out/unsafe/string_literals_c.rs
+++ b/tests/unit/out/unsafe/string_literals_c.rs
@@ -20,16 +20,16 @@ unsafe fn main_0() -> i32 {
         b"c\0".as_ptr().cast_mut(),
     ];
     let mut immutable_strings: [*const u8; 3] = [
-        b"a\0".as_ptr().cast_mut().cast_const(),
-        b"b\0".as_ptr().cast_mut().cast_const(),
-        b"c\0".as_ptr().cast_mut().cast_const(),
+        (b"a\0".as_ptr().cast_mut()).cast_const(),
+        (b"b\0".as_ptr().cast_mut()).cast_const(),
+        (b"c\0".as_ptr().cast_mut()).cast_const(),
     ];
     let mut mutable_string: *mut u8 = b"hello\0".as_ptr().cast_mut();
-    let mut immutable_string: *const u8 = b"hello\0".as_ptr().cast_mut().cast_const();
+    let mut immutable_string: *const u8 = (b"hello\0".as_ptr().cast_mut()).cast_const();
     let mut mutable_string_arr: [u8; 9] = *b"papanasi\0";
     let immutable_string_arr: [u8; 9] = *b"papanasi\0";
     let mut mutable_empty: *mut u8 = b"\0".as_ptr().cast_mut();
-    let mut immutable_empty: *const u8 = b"\0".as_ptr().cast_mut().cast_const();
+    let mut immutable_empty: *const u8 = (b"\0".as_ptr().cast_mut()).cast_const();
     let mut mutable_empty_arr: [u8; 1] = [0u8; 1];
     let immutable_empty_arr: [u8; 1] = [0u8; 1];
     (unsafe {
@@ -45,11 +45,11 @@ unsafe fn main_0() -> i32 {
         foo_mut_0(_str)
     });
     (unsafe {
-        let _str: *const u8 = b"world\0".as_ptr().cast_mut().cast_const();
+        let _str: *const u8 = (b"world\0".as_ptr().cast_mut()).cast_const();
         foo_const_1(_str)
     });
     (unsafe {
-        let _str: *const u8 = mutable_string.cast_const();
+        let _str: *const u8 = (mutable_string).cast_const();
         foo_const_1(_str)
     });
     (unsafe {
@@ -57,7 +57,7 @@ unsafe fn main_0() -> i32 {
         foo_const_1(_str)
     });
     (unsafe {
-        let _str: *const u8 = mutable_string_arr.as_mut_ptr().cast_const();
+        let _str: *const u8 = (mutable_string_arr.as_mut_ptr()).cast_const();
         foo_const_1(_str)
     });
     (unsafe {
@@ -65,11 +65,11 @@ unsafe fn main_0() -> i32 {
         foo_const_1(_str)
     });
     (unsafe {
-        let _str: *const u8 = b"\0".as_ptr().cast_mut().cast_const();
+        let _str: *const u8 = (b"\0".as_ptr().cast_mut()).cast_const();
         foo_const_1(_str)
     });
     (unsafe {
-        let _str: *const u8 = mutable_empty.cast_const();
+        let _str: *const u8 = (mutable_empty).cast_const();
         foo_const_1(_str)
     });
     (unsafe {
@@ -77,7 +77,7 @@ unsafe fn main_0() -> i32 {
         foo_const_1(_str)
     });
     (unsafe {
-        let _str: *const u8 = mutable_empty_arr.as_mut_ptr().cast_const();
+        let _str: *const u8 = (mutable_empty_arr.as_mut_ptr()).cast_const();
         foo_const_1(_str)
     });
     (unsafe {

--- a/tests/unit/out/unsafe/string_literals_concat_c.rs
+++ b/tests/unit/out/unsafe/string_literals_concat_c.rs
@@ -17,7 +17,7 @@ unsafe fn main_0() -> i32 {
     assert!(((((arr[(3) as usize] as i32) == ('b' as i32)) as i32) != 0));
     assert!(((((arr[(5) as usize] as i32) == ('r' as i32)) as i32) != 0));
     assert!(((((arr[(6) as usize] as i32) == ('\0' as i32)) as i32) != 0));
-    let mut split_pieces: *const u8 = b"abcdefghi\0".as_ptr().cast_mut().cast_const();
+    let mut split_pieces: *const u8 = (b"abcdefghi\0".as_ptr().cast_mut()).cast_const();
     assert!((((((*split_pieces.offset((0) as isize)) as i32) == ('a' as i32)) as i32) != 0));
     assert!((((((*split_pieces.offset((3) as isize)) as i32) == ('d' as i32)) as i32) != 0));
     assert!((((((*split_pieces.offset((6) as isize)) as i32) == ('g' as i32)) as i32) != 0));

--- a/tests/unit/out/unsafe/string_literals_return_c.rs
+++ b/tests/unit/out/unsafe/string_literals_return_c.rs
@@ -7,16 +7,16 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn get_greeting_0() -> *const u8 {
-    return b"hello\0".as_ptr().cast_mut().cast_const();
+    return (b"hello\0".as_ptr().cast_mut()).cast_const();
 }
 pub unsafe fn get_empty_1() -> *const u8 {
-    return b"\0".as_ptr().cast_mut().cast_const();
+    return (b"\0".as_ptr().cast_mut()).cast_const();
 }
 pub unsafe fn get_branch_2(mut x: i32) -> *const u8 {
     if ((((x) > (0)) as i32) != 0) {
-        return b"positive\0".as_ptr().cast_mut().cast_const();
+        return (b"positive\0".as_ptr().cast_mut()).cast_const();
     }
-    return b"non-positive\0".as_ptr().cast_mut().cast_const();
+    return (b"non-positive\0".as_ptr().cast_mut()).cast_const();
 }
 pub fn main() {
     unsafe {

--- a/tests/unit/out/unsafe/union_tagged_many_arms.rs
+++ b/tests/unit/out/unsafe/union_tagged_many_arms.rs
@@ -63,7 +63,7 @@ unsafe fn main_0() -> i32 {
     assert!(((((b.payload.unsigned_n) == (3735928559_u64)) as i32) != 0));
     let mut c: Slot = <Slot>::default();
     c.tag = Tag::T_TEXT;
-    c.payload.text = b"hello\0".as_ptr().cast_mut().cast_const();
+    c.payload.text = (b"hello\0".as_ptr().cast_mut()).cast_const();
     assert!((((((*c.payload.text.offset((0) as isize)) as i32) == ('h' as i32)) as i32) != 0));
     let mut d: Slot = <Slot>::default();
     d.tag = Tag::T_FLOAT;

--- a/tests/unit/out/unsafe/va_arg_conditional.rs
+++ b/tests/unit/out/unsafe/va_arg_conditional.rs
@@ -24,7 +24,7 @@ unsafe fn main_0() -> i32 {
     assert!(
         ((((unsafe {
             let _verbose: i32 = 1;
-            let _fmt: *const u8 = b"%d\0".as_ptr().cast_mut().cast_const();
+            let _fmt: *const u8 = (b"%d\0".as_ptr().cast_mut()).cast_const();
             conditional_log_0(_verbose, _fmt, &[42.into()])
         }) == (42)) as i32)
             != 0)
@@ -32,7 +32,7 @@ unsafe fn main_0() -> i32 {
     assert!(
         ((((unsafe {
             let _verbose: i32 = 0;
-            let _fmt: *const u8 = b"%d\0".as_ptr().cast_mut().cast_const();
+            let _fmt: *const u8 = (b"%d\0".as_ptr().cast_mut()).cast_const();
             conditional_log_0(_verbose, _fmt, &[99.into()])
         }) == (-1_i32)) as i32)
             != 0)

--- a/tests/unit/out/unsafe/va_arg_non_primitive_ptrs.rs
+++ b/tests/unit/out/unsafe/va_arg_non_primitive_ptrs.rs
@@ -40,7 +40,7 @@ pub unsafe fn dispatch_0(mut option: i32, __args: &[VaArg]) -> i32 {
         match __match_cond {
             v if v == (opt::OPT_STRING_OUT as i32) => {
                 let mut out: *mut *const u8 = ap.arg::<*mut *const u8>();
-                (*out) = b"hello\0".as_ptr().cast_mut().cast_const();
+                (*out) = (b"hello\0".as_ptr().cast_mut()).cast_const();
                 result = 1;
                 break 'switch;
             }

--- a/tests/unit/out/unsafe/va_arg_printf.rs
+++ b/tests/unit/out/unsafe/va_arg_printf.rs
@@ -28,14 +28,14 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     assert!(
         ((((unsafe {
-            let _fmt: *const u8 = b"hello %d %d\0".as_ptr().cast_mut().cast_const();
+            let _fmt: *const u8 = (b"hello %d %d\0".as_ptr().cast_mut()).cast_const();
             logf_1(_fmt, &[10.into(), 32.into()])
         }) == (42)) as i32)
             != 0)
     );
     assert!(
         ((((unsafe {
-            let _fmt: *const u8 = b"x %d %d\0".as_ptr().cast_mut().cast_const();
+            let _fmt: *const u8 = (b"x %d %d\0".as_ptr().cast_mut()).cast_const();
             logf_1(_fmt, &[1.into(), 2.into()])
         }) == (3)) as i32)
             != 0)

--- a/tests/unit/out/unsafe/va_arg_snprintf.rs
+++ b/tests/unit/out/unsafe/va_arg_snprintf.rs
@@ -29,7 +29,7 @@ unsafe fn main_0() -> i32 {
         ((((unsafe {
             let _buf: *mut u8 = buf.as_mut_ptr();
             let _size: i32 = 1;
-            let _fmt: *const u8 = b"%d\0".as_ptr().cast_mut().cast_const();
+            let _fmt: *const u8 = (b"%d\0".as_ptr().cast_mut()).cast_const();
             extract_first_0(_buf, _size, _fmt, &[42.into()])
         }) == (42)) as i32)
             != 0)
@@ -39,7 +39,7 @@ unsafe fn main_0() -> i32 {
         ((((unsafe {
             let _buf: *mut u8 = buf.as_mut_ptr();
             let _size: i32 = 1;
-            let _fmt: *const u8 = b"%d\0".as_ptr().cast_mut().cast_const();
+            let _fmt: *const u8 = (b"%d\0".as_ptr().cast_mut()).cast_const();
             extract_first_0(_buf, _size, _fmt, &[65.into()])
         }) == (65)) as i32)
             != 0)

--- a/tests/unit/out/unsafe/va_arg_struct_ctx.rs
+++ b/tests/unit/out/unsafe/va_arg_struct_ctx.rs
@@ -30,14 +30,14 @@ unsafe fn main_0() -> i32 {
     ctx.last_error = 0;
     (unsafe {
         let _ctx: *mut context = (&mut ctx as *mut context);
-        let _fmt: *const u8 = b"error %d\0".as_ptr().cast_mut().cast_const();
+        let _fmt: *const u8 = (b"error %d\0".as_ptr().cast_mut()).cast_const();
         set_error_0(_ctx, _fmt, &[42.into()])
     });
     assert!(((((ctx.last_error) == (42)) as i32) != 0));
     ctx.verbose = 0;
     (unsafe {
         let _ctx: *mut context = (&mut ctx as *mut context);
-        let _fmt: *const u8 = b"error %d\0".as_ptr().cast_mut().cast_const();
+        let _fmt: *const u8 = (b"error %d\0".as_ptr().cast_mut()).cast_const();
         set_error_0(_ctx, _fmt, &[99.into()])
     });
     assert!(((((ctx.last_error) == (42)) as i32) != 0));

--- a/tests/unit/out/unsafe/vector.rs
+++ b/tests/unit/out/unsafe/vector.rs
@@ -99,7 +99,7 @@ unsafe fn main_0() -> i32 {
         assert!(((v7[(i as u64) as usize].0).is_null()) && ((v7[(i as u64) as usize].1) == (0)));
         i.prefix_inc();
     }
-    let mut p1: *const f64 = v6.as_mut_ptr().cast_const();
+    let mut p1: *const f64 = (v6.as_mut_ptr()).cast_const();
     assert!(((*p1) == (2.0E+0)));
     let mut p2: *mut i32 = v3.as_mut_ptr();
     assert!(((*p2) == (1)));

--- a/tests/unit/out/unsafe/vector_addr_of_back.rs
+++ b/tests/unit/out/unsafe/vector_addr_of_back.rs
@@ -16,9 +16,9 @@ unsafe fn main_0() -> i32 {
     let mut inner: Vec<i32> = Vec::new();
     outer.push(inner.clone());
     let mut sink: *mut Vec<i32> = ((outer).last_mut().unwrap());
-    assert!((((*sink.cast_const()).len() as u64) == (0_u64)));
+    assert!((((*(sink).cast_const()).len() as u64) == (0_u64)));
     let mut p: *mut Vec<Vec<i32>> = (&mut outer as *mut Vec<Vec<i32>>);
     sink = ((*p).last_mut().unwrap());
-    assert!((((*sink.cast_const()).len() as u64) == (0_u64)));
+    assert!((((*(sink).cast_const()).len() as u64) == (0_u64)));
     return 0;
 }

--- a/tests/unit/out/unsafe/vector_iter_range_ctor.rs
+++ b/tests/unit/out/unsafe/vector_iter_range_ctor.rs
@@ -61,7 +61,7 @@ unsafe fn main_0() -> i32 {
             && ((v4[(2_u64) as usize]) == (3_u32))
     );
     let mut buf: [u8; 5] = [10_u8, 20_u8, 30_u8, 40_u8, 50_u8];
-    let mut start: *const u8 = buf.as_mut_ptr().cast_const();
+    let mut start: *const u8 = (buf.as_mut_ptr()).cast_const();
     let mut len: u64 = 5_u64;
     let mut v5: Vec<u8> = core::slice::from_raw_parts(
         start,

--- a/tests/unit/strchr_c.c
+++ b/tests/unit/strchr_c.c
@@ -4,7 +4,7 @@
 
 int main() {
   const char *s = "hello world";
-  char *r = strchr(s, 'w');
+  const char *r = strchr(s, 'w');
   assert(r != NULL);
   assert(*r == 'w');
   assert(strchr(s, 'z') == NULL);


### PR DESCRIPTION
This avoids compilation errors in the generated code.