### PR TITLE
[unsafe] Replace fs::File with libc::FILE

### DIFF
--- a/libcc2rs/Cargo.toml
+++ b/libcc2rs/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2024"
 
 [dependencies]
 libcc2rs-macros = { path = "../libcc2rs-macros", version = "0.1.0" }
+libc = "0.2"

--- a/libcc2rs/src/io.rs
+++ b/libcc2rs/src/io.rs
@@ -165,95 +165,70 @@ pub fn fwrite_refcount(a0: AnyPtr, a1: u64, a2: u64, a3: Ptr<::std::fs::File>) -
     (written_bytes / a1 as usize) as u64
 }
 
-/// # Safety
-///
-/// `a0` must point to a readable buffer of at least `a1 * a2` bytes, and `a3`
-/// must point to a valid, open `std::fs::File`.
-pub unsafe fn fwrite_unsafe(
-    a0: *const ::std::ffi::c_void,
-    a1: u64,
-    a2: u64,
-    a3: *mut ::std::fs::File,
-) -> u64 {
-    let total = a1.saturating_mul(a2) as usize;
-    let mut src = a0 as *const u8;
+unsafe extern "C" {
+    #[cfg(target_os = "linux")]
+    #[link_name = "stdin"]
+    static mut LIBC_STDIN: *mut libc::FILE;
+    #[cfg(target_os = "linux")]
+    #[link_name = "stdout"]
+    static mut LIBC_STDOUT: *mut libc::FILE;
+    #[cfg(target_os = "linux")]
+    #[link_name = "stderr"]
+    static mut LIBC_STDERR: *mut libc::FILE;
 
-    let f = unsafe { (*a3).try_clone().expect("try_clone failed") };
-    let mut writer = std::io::BufWriter::with_capacity(64 * 1024, f);
-
-    let mut written_bytes: usize = 0;
-    let mut buffer: [u8; 8192] = [0; 8192];
-
-    while written_bytes < total {
-        let remaining = total - written_bytes;
-        let to_fill = std::cmp::min(buffer.len(), remaining);
-
-        for b in buffer.iter_mut().take(to_fill) {
-            unsafe {
-                *b = *src;
-                src = src.offset(1);
-            }
-        }
-
-        let mut off = 0;
-        while off < to_fill {
-            match std::io::Write::write(&mut writer, &buffer[off..to_fill]) {
-                Ok(0) => break,
-                Ok(n) => off += n,
-                Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
-                Err(e) => panic!("Unhandled error in fwrite: {e}"),
-            }
-        }
-
-        if off == 0 {
-            break;
-        }
-
-        written_bytes += off;
-    }
-
-    (written_bytes / a1 as usize) as u64
+    #[cfg(target_os = "macos")]
+    #[link_name = "__stdinp"]
+    static mut LIBC_STDIN: *mut libc::FILE;
+    #[cfg(target_os = "macos")]
+    #[link_name = "__stdoutp"]
+    static mut LIBC_STDOUT: *mut libc::FILE;
+    #[cfg(target_os = "macos")]
+    #[link_name = "__stderrp"]
+    static mut LIBC_STDERR: *mut libc::FILE;
 }
 
 /// # Safety
 ///
-/// `a0` must point to a writable buffer of at least `a1 * a2` bytes, and `a3`
-/// must point to a valid, open `std::fs::File`.
+/// Returns the libc `stdin` handle. The pointer is valid for the process
+/// lifetime.
+pub unsafe fn stdin_unsafe() -> *mut libc::FILE {
+    unsafe { LIBC_STDIN }
+}
+
+/// # Safety
+///
+/// Returns the libc `stdout` handle.
+pub unsafe fn stdout_unsafe() -> *mut libc::FILE {
+    unsafe { LIBC_STDOUT }
+}
+
+/// # Safety
+///
+/// Returns the libc `stderr` handle.
+pub unsafe fn stderr_unsafe() -> *mut libc::FILE {
+    unsafe { LIBC_STDERR }
+}
+
+/// # Safety
+///
+/// Same contract as C's `fwrite`.
+pub unsafe fn fwrite_unsafe(
+    a0: *const ::std::ffi::c_void,
+    a1: u64,
+    a2: u64,
+    a3: *mut libc::FILE,
+) -> u64 {
+    unsafe { libc::fwrite(a0, a1 as libc::size_t, a2 as libc::size_t, a3) as u64 }
+}
+
+/// # Safety
+///
+/// Same contract as C's `fread`.
 pub unsafe fn fread_unsafe(
     a0: *mut ::std::ffi::c_void,
     a1: u64,
     a2: u64,
-    a3: *mut ::std::fs::File,
+    a3: *mut libc::FILE,
 ) -> u64 {
-    let total = a1.saturating_mul(a2) as usize;
-    let mut dst = a0 as *mut u8;
-
-    let f = unsafe { (*a3).try_clone().expect("try_clone failed") };
-    let mut reader = std::io::BufReader::with_capacity(64 * 1024, f);
-
-    let mut read_bytes: usize = 0;
-    let mut buffer: [u8; 8192] = [0; 8192];
-
-    while read_bytes < total {
-        let remaining = total - read_bytes;
-        let to_read = std::cmp::min(buffer.len(), remaining);
-
-        let n = match std::io::Read::read(&mut reader, &mut buffer[..to_read]) {
-            Ok(0) => break,
-            Ok(n) => n,
-            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
-            Err(e) => panic!("Unhandled error in fread: {e}"),
-        };
-
-        for &byte in &buffer[..n] {
-            unsafe {
-                *dst = byte;
-                dst = dst.offset(1);
-            }
-        }
-
-        read_bytes += n;
-    }
-
-    (read_bytes / a1 as usize) as u64
+    unsafe { libc::fread(a0, a1 as libc::size_t, a2 as libc::size_t, a3) as u64 }
 }

--- a/rules/stdio/ir_unsafe.json
+++ b/rules/stdio/ir_unsafe.json
@@ -2,307 +2,7 @@
   "f1": {
     "body": [
       {
-        "text": "match "
-      },
-      {
-        "method_call": {
-          "receiver": [
-            {
-              "method_call": {
-                "receiver": [
-                  {
-                    "text": "std::ffi::CStr::from_ptr("
-                  },
-                  {
-                    "placeholder": {
-                      "arg": 1,
-                      "access": "read"
-                    }
-                  },
-                  {
-                    "text": " as *const i8)"
-                  }
-                ],
-                "body": [
-                  {
-                    "text": ".to_str()"
-                  }
-                ]
-              }
-            }
-          ],
-          "body": [
-            {
-              "text": ".expect(\"invalid c-string\")"
-            }
-          ]
-        }
-      },
-      {
-        "text": "\n    {\n        v if v == \"rb\" => "
-      },
-      {
-        "method_call": {
-          "receiver": [
-            {
-              "method_call": {
-                "receiver": [
-                  {
-                    "method_call": {
-                      "receiver": [
-                        {
-                          "method_call": {
-                            "receiver": [
-                              {
-                                "text": "std::fs::OpenOptions::new()"
-                              }
-                            ],
-                            "body": [
-                              {
-                                "text": ".read(true)"
-                              }
-                            ]
-                          }
-                        }
-                      ],
-                      "body": [
-                        {
-                          "text": ".open(\n                "
-                        },
-                        {
-                          "method_call": {
-                            "receiver": [
-                              {
-                                "method_call": {
-                                  "receiver": [
-                                    {
-                                      "text": "std::ffi::CStr::from_ptr("
-                                    },
-                                    {
-                                      "placeholder": {
-                                        "arg": 0,
-                                        "access": "read"
-                                      }
-                                    },
-                                    {
-                                      "text": " as *const i8)"
-                                    }
-                                  ],
-                                  "body": [
-                                    {
-                                      "text": ".to_str()"
-                                    }
-                                  ]
-                                }
-                              }
-                            ],
-                            "body": [
-                              {
-                                "text": ".expect(\"invalid c-string\")"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "text": ",\n            )"
-                        }
-                      ]
-                    }
-                  }
-                ],
-                "body": [
-                  {
-                    "text": ".ok()"
-                  }
-                ]
-              }
-            }
-          ],
-          "body": [
-            {
-              "text": ".map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f)))"
-            }
-          ]
-        }
-      },
-      {
-        "text": ",\n        v if v == \"wb\" => "
-      },
-      {
-        "method_call": {
-          "receiver": [
-            {
-              "method_call": {
-                "receiver": [
-                  {
-                    "method_call": {
-                      "receiver": [
-                        {
-                          "method_call": {
-                            "receiver": [
-                              {
-                                "method_call": {
-                                  "receiver": [
-                                    {
-                                      "method_call": {
-                                        "receiver": [
-                                          {
-                                            "text": "std::fs::OpenOptions::new()"
-                                          }
-                                        ],
-                                        "body": [
-                                          {
-                                            "text": ".write(true)"
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  ],
-                                  "body": [
-                                    {
-                                      "text": ".create(true)"
-                                    }
-                                  ]
-                                }
-                              }
-                            ],
-                            "body": [
-                              {
-                                "text": ".truncate(true)"
-                              }
-                            ]
-                          }
-                        }
-                      ],
-                      "body": [
-                        {
-                          "text": ".open(\n                "
-                        },
-                        {
-                          "method_call": {
-                            "receiver": [
-                              {
-                                "method_call": {
-                                  "receiver": [
-                                    {
-                                      "text": "std::ffi::CStr::from_ptr("
-                                    },
-                                    {
-                                      "placeholder": {
-                                        "arg": 0,
-                                        "access": "read"
-                                      }
-                                    },
-                                    {
-                                      "text": " as *const i8)"
-                                    }
-                                  ],
-                                  "body": [
-                                    {
-                                      "text": ".to_str()"
-                                    }
-                                  ]
-                                }
-                              }
-                            ],
-                            "body": [
-                              {
-                                "text": ".expect(\"invalid c-string\")"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "text": ",\n            )"
-                        }
-                      ]
-                    }
-                  }
-                ],
-                "body": [
-                  {
-                    "text": ".ok()"
-                  }
-                ]
-              }
-            }
-          ],
-          "body": [
-            {
-              "text": ".map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f)))"
-            }
-          ]
-        }
-      },
-      {
-        "text": ",\n        _ => panic!(\"unsupported mode\"),\n    }"
-      }
-    ],
-    "params": {
-      "a0": {
-        "type": "*const i8",
-        "is_unsafe_pointer": true
-      },
-      "a1": {
-        "type": "*const i8",
-        "is_unsafe_pointer": true
-      }
-    },
-    "return_type": {
-      "type": "*mut ::std::fs::File",
-      "is_unsafe_pointer": true
-    }
-  },
-  "f10": {
-    "body": [
-      {
-        "text": "libcc2rs::cin_unsafe()"
-      }
-    ],
-    "return_type": {
-      "type": "*mut ::std::fs::File",
-      "is_unsafe_pointer": true
-    }
-  },
-  "f11": {
-    "body": [
-      {
-        "text": "match "
-      },
-      {
-        "method_call": {
-          "receiver": [
-            {
-              "text": "(*"
-            },
-            {
-              "placeholder": {
-                "arg": 1,
-                "access": "write"
-              }
-            },
-            {
-              "text": ")"
-            }
-          ],
-          "body": [
-            {
-              "text": ".write_all(&["
-            },
-            {
-              "placeholder": {
-                "arg": 0,
-                "access": "read"
-              }
-            },
-            {
-              "text": " as u8])"
-            }
-          ]
-        }
-      },
-      {
-        "text": " {\n        Ok(()) => "
+        "text": "libc::fopen("
       },
       {
         "placeholder": {
@@ -311,7 +11,66 @@
         }
       },
       {
-        "text": " & 0xff,\n        Err(_) => -1,\n    }"
+        "text": " as *const i8, "
+      },
+      {
+        "placeholder": {
+          "arg": 1,
+          "access": "read"
+        }
+      },
+      {
+        "text": " as *const i8)"
+      }
+    ],
+    "params": {
+      "a0": {
+        "type": "*const u8",
+        "is_unsafe_pointer": true
+      },
+      "a1": {
+        "type": "*const u8",
+        "is_unsafe_pointer": true
+      }
+    },
+    "return_type": {
+      "type": "*mut ::libc::FILE",
+      "is_unsafe_pointer": true
+    }
+  },
+  "f10": {
+    "body": [
+      {
+        "text": "libcc2rs::stdin_unsafe()"
+      }
+    ],
+    "return_type": {
+      "type": "*mut ::libc::FILE",
+      "is_unsafe_pointer": true
+    }
+  },
+  "f11": {
+    "body": [
+      {
+        "text": "libc::fputc("
+      },
+      {
+        "placeholder": {
+          "arg": 0,
+          "access": "read"
+        }
+      },
+      {
+        "text": ", "
+      },
+      {
+        "placeholder": {
+          "arg": 1,
+          "access": "read"
+        }
+      },
+      {
+        "text": ")"
       }
     ],
     "params": {
@@ -319,7 +78,7 @@
         "type": "i32"
       },
       "a1": {
-        "type": "*mut ::std::fs::File",
+        "type": "*mut ::libc::FILE",
         "is_unsafe_pointer": true
       }
     },
@@ -330,69 +89,34 @@
   "f12": {
     "body": [
       {
-        "text": "let bytes = "
+        "text": "libc::fputs("
       },
       {
-        "method_call": {
-          "receiver": [
-            {
-              "text": "std::ffi::CStr::from_ptr("
-            },
-            {
-              "placeholder": {
-                "arg": 0,
-                "access": "read"
-              }
-            },
-            {
-              "text": " as *const i8)"
-            }
-          ],
-          "body": [
-            {
-              "text": ".to_bytes()"
-            }
-          ]
+        "placeholder": {
+          "arg": 0,
+          "access": "read"
         }
       },
       {
-        "text": ";\n    match "
+        "text": " as *const i8, "
       },
       {
-        "method_call": {
-          "receiver": [
-            {
-              "text": "(*"
-            },
-            {
-              "placeholder": {
-                "arg": 1,
-                "access": "write"
-              }
-            },
-            {
-              "text": ")"
-            }
-          ],
-          "body": [
-            {
-              "text": ".write_all(bytes)"
-            }
-          ]
+        "placeholder": {
+          "arg": 1,
+          "access": "read"
         }
       },
       {
-        "text": " {\n        Ok(()) => 0,\n        Err(_) => -1,\n    }"
+        "text": ")"
       }
     ],
-    "multi_statement": true,
     "params": {
       "a0": {
         "type": "*const u8",
         "is_unsafe_pointer": true
       },
       "a1": {
-        "type": "*mut ::std::fs::File",
+        "type": "*mut ::libc::FILE",
         "is_unsafe_pointer": true
       }
     },
@@ -403,104 +127,18 @@
   "f13": {
     "body": [
       {
-        "text": "let bytes = "
+        "text": "libc::puts("
       },
       {
-        "method_call": {
-          "receiver": [
-            {
-              "text": "std::ffi::CStr::from_ptr("
-            },
-            {
-              "placeholder": {
-                "arg": 0,
-                "access": "read"
-              }
-            },
-            {
-              "text": " as *const i8)"
-            }
-          ],
-          "body": [
-            {
-              "text": ".to_bytes()"
-            }
-          ]
+        "placeholder": {
+          "arg": 0,
+          "access": "read"
         }
       },
       {
-        "text": ";\n    let stdout = libcc2rs::cout_unsafe();\n    let r1 = "
-      },
-      {
-        "method_call": {
-          "receiver": [
-            {
-              "text": "(*stdout)"
-            }
-          ],
-          "body": [
-            {
-              "text": ".write_all(bytes)"
-            }
-          ]
-        }
-      },
-      {
-        "text": ";\n    let r2 = "
-      },
-      {
-        "method_call": {
-          "receiver": [
-            {
-              "text": "(*stdout)"
-            }
-          ],
-          "body": [
-            {
-              "text": ".write_all(b\"\\n\")"
-            }
-          ]
-        }
-      },
-      {
-        "text": ";\n    if "
-      },
-      {
-        "method_call": {
-          "receiver": [
-            {
-              "text": "r1"
-            }
-          ],
-          "body": [
-            {
-              "text": ".is_ok()"
-            }
-          ]
-        }
-      },
-      {
-        "text": " && "
-      },
-      {
-        "method_call": {
-          "receiver": [
-            {
-              "text": "r2"
-            }
-          ],
-          "body": [
-            {
-              "text": ".is_ok()"
-            }
-          ]
-        }
-      },
-      {
-        "text": " { 0 } else { -1 }"
+        "text": " as *const i8)"
       }
     ],
-    "multi_statement": true,
     "params": {
       "a0": {
         "type": "*const u8",
@@ -514,7 +152,7 @@
   "f14": {
     "body": [
       {
-        "text": "if "
+        "text": "libc::fileno("
       },
       {
         "placeholder": {
@@ -523,40 +161,215 @@
         }
       },
       {
-        "text": " == libcc2rs::cin_unsafe() {\n        0\n    } else if "
-      },
-      {
-        "placeholder": {
-          "arg": 0,
-          "access": "read"
-        }
-      },
-      {
-        "text": " == libcc2rs::cout_unsafe() {\n        1\n    } else if "
-      },
-      {
-        "placeholder": {
-          "arg": 0,
-          "access": "read"
-        }
-      },
-      {
-        "text": " == libcc2rs::cerr_unsafe() {\n        2\n    } else {\n        ::std::os::fd::AsRawFd::as_raw_fd(&*"
-      },
-      {
-        "placeholder": {
-          "arg": 0,
-          "access": "read"
-        }
-      },
-      {
-        "text": ")\n    }"
+        "text": ")"
       }
     ],
     "params": {
       "a0": {
-        "type": "*mut ::std::fs::File",
+        "type": "*mut ::libc::FILE",
         "is_unsafe_pointer": true
+      }
+    },
+    "return_type": {
+      "type": "i32"
+    }
+  },
+  "f15": {
+    "body": [
+      {
+        "text": "libc::ferror("
+      },
+      {
+        "placeholder": {
+          "arg": 0,
+          "access": "read"
+        }
+      },
+      {
+        "text": ")"
+      }
+    ],
+    "params": {
+      "a0": {
+        "type": "*mut ::libc::FILE",
+        "is_unsafe_pointer": true
+      }
+    },
+    "return_type": {
+      "type": "i32"
+    }
+  },
+  "f16": {
+    "body": [
+      {
+        "text": "libc::feof("
+      },
+      {
+        "placeholder": {
+          "arg": 0,
+          "access": "read"
+        }
+      },
+      {
+        "text": ")"
+      }
+    ],
+    "params": {
+      "a0": {
+        "type": "*mut ::libc::FILE",
+        "is_unsafe_pointer": true
+      }
+    },
+    "return_type": {
+      "type": "i32"
+    }
+  },
+  "f17": {
+    "body": [
+      {
+        "text": "libc::fgets("
+      },
+      {
+        "placeholder": {
+          "arg": 0,
+          "access": "read"
+        }
+      },
+      {
+        "text": " as *mut i8, "
+      },
+      {
+        "placeholder": {
+          "arg": 1,
+          "access": "read"
+        }
+      },
+      {
+        "text": ", "
+      },
+      {
+        "placeholder": {
+          "arg": 2,
+          "access": "read"
+        }
+      },
+      {
+        "text": ") as *mut u8"
+      }
+    ],
+    "params": {
+      "a0": {
+        "type": "*mut u8",
+        "is_unsafe_pointer": true
+      },
+      "a1": {
+        "type": "i32"
+      },
+      "a2": {
+        "type": "*mut ::libc::FILE",
+        "is_unsafe_pointer": true
+      }
+    },
+    "return_type": {
+      "type": "*mut u8",
+      "is_unsafe_pointer": true
+    }
+  },
+  "f18": {
+    "body": [
+      {
+        "text": "libc::freopen("
+      },
+      {
+        "placeholder": {
+          "arg": 0,
+          "access": "read"
+        }
+      },
+      {
+        "text": " as *const i8, "
+      },
+      {
+        "placeholder": {
+          "arg": 1,
+          "access": "read"
+        }
+      },
+      {
+        "text": " as *const i8, "
+      },
+      {
+        "placeholder": {
+          "arg": 2,
+          "access": "read"
+        }
+      },
+      {
+        "text": ")"
+      }
+    ],
+    "params": {
+      "a0": {
+        "type": "*const u8",
+        "is_unsafe_pointer": true
+      },
+      "a1": {
+        "type": "*const u8",
+        "is_unsafe_pointer": true
+      },
+      "a2": {
+        "type": "*mut ::libc::FILE",
+        "is_unsafe_pointer": true
+      }
+    },
+    "return_type": {
+      "type": "*mut ::libc::FILE",
+      "is_unsafe_pointer": true
+    }
+  },
+  "f19": {
+    "body": [
+      {
+        "text": "libc::fseeko("
+      },
+      {
+        "placeholder": {
+          "arg": 0,
+          "access": "read"
+        }
+      },
+      {
+        "text": ", "
+      },
+      {
+        "placeholder": {
+          "arg": 1,
+          "access": "read"
+        }
+      },
+      {
+        "text": " as ::libc::off_t, "
+      },
+      {
+        "placeholder": {
+          "arg": 2,
+          "access": "read"
+        }
+      },
+      {
+        "text": ")"
+      }
+    ],
+    "params": {
+      "a0": {
+        "type": "*mut ::libc::FILE",
+        "is_unsafe_pointer": true
+      },
+      "a1": {
+        "type": "i64"
+      },
+      "a2": {
+        "type": "i32"
       }
     },
     "return_type": {
@@ -566,7 +379,7 @@
   "f2": {
     "body": [
       {
-        "text": "Box::from_raw("
+        "text": "libc::fclose("
       },
       {
         "placeholder": {
@@ -575,13 +388,12 @@
         }
       },
       {
-        "text": ");\n    0"
+        "text": ")"
       }
     ],
-    "multi_statement": true,
     "params": {
       "a0": {
-        "type": "*mut ::std::fs::File",
+        "type": "*mut ::libc::FILE",
         "is_unsafe_pointer": true
       }
     },
@@ -589,41 +401,62 @@
       "type": "i32"
     }
   },
-  "f3": {
+  "f20": {
     "body": [
       {
-        "text": "match "
+        "text": "libc::fdopen("
       },
       {
-        "method_call": {
-          "receiver": [
-            {
-              "text": "(*"
-            },
-            {
-              "placeholder": {
-                "arg": 0,
-                "access": "write"
-              }
-            },
-            {
-              "text": ")"
-            }
-          ],
-          "body": [
-            {
-              "text": ".stream_position()"
-            }
-          ]
+        "placeholder": {
+          "arg": 0,
+          "access": "read"
         }
       },
       {
-        "text": " {\n        Ok(pos) => pos as i64,\n        Err(_) => -1,\n    }"
+        "text": ", "
+      },
+      {
+        "placeholder": {
+          "arg": 1,
+          "access": "read"
+        }
+      },
+      {
+        "text": " as *const i8)"
       }
     ],
     "params": {
       "a0": {
-        "type": "*mut ::std::fs::File",
+        "type": "i32"
+      },
+      "a1": {
+        "type": "*const u8",
+        "is_unsafe_pointer": true
+      }
+    },
+    "return_type": {
+      "type": "*mut ::libc::FILE",
+      "is_unsafe_pointer": true
+    }
+  },
+  "f3": {
+    "body": [
+      {
+        "text": "libc::ftell("
+      },
+      {
+        "placeholder": {
+          "arg": 0,
+          "access": "read"
+        }
+      },
+      {
+        "text": ") as i64"
+      }
+    ],
+    "params": {
+      "a0": {
+        "type": "*mut ::libc::FILE",
         "is_unsafe_pointer": true
       }
     },
@@ -634,143 +467,39 @@
   "f4": {
     "body": [
       {
-        "text": "if "
+        "text": "libc::fseek("
       },
       {
-        "method_call": {
-          "receiver": [
-            {
-              "text": "(match "
-            },
-            {
-              "placeholder": {
-                "arg": 2,
-                "access": "read"
-              }
-            },
-            {
-              "text": " {\n        0 => "
-            },
-            {
-              "method_call": {
-                "receiver": [
-                  {
-                    "text": "(*"
-                  },
-                  {
-                    "placeholder": {
-                      "arg": 0,
-                      "access": "write"
-                    }
-                  },
-                  {
-                    "text": ")"
-                  }
-                ],
-                "body": [
-                  {
-                    "text": ".seek(std::io::SeekFrom::Start("
-                  },
-                  {
-                    "placeholder": {
-                      "arg": 1,
-                      "access": "read"
-                    }
-                  },
-                  {
-                    "text": " as u64))"
-                  }
-                ]
-              }
-            },
-            {
-              "text": ",\n        1 => "
-            },
-            {
-              "method_call": {
-                "receiver": [
-                  {
-                    "text": "(*"
-                  },
-                  {
-                    "placeholder": {
-                      "arg": 0,
-                      "access": "write"
-                    }
-                  },
-                  {
-                    "text": ")"
-                  }
-                ],
-                "body": [
-                  {
-                    "text": ".seek(std::io::SeekFrom::Current("
-                  },
-                  {
-                    "placeholder": {
-                      "arg": 1,
-                      "access": "read"
-                    }
-                  },
-                  {
-                    "text": "))"
-                  }
-                ]
-              }
-            },
-            {
-              "text": ",\n        2 => "
-            },
-            {
-              "method_call": {
-                "receiver": [
-                  {
-                    "text": "(*"
-                  },
-                  {
-                    "placeholder": {
-                      "arg": 0,
-                      "access": "write"
-                    }
-                  },
-                  {
-                    "text": ")"
-                  }
-                ],
-                "body": [
-                  {
-                    "text": ".seek(std::io::SeekFrom::End("
-                  },
-                  {
-                    "placeholder": {
-                      "arg": 1,
-                      "access": "read"
-                    }
-                  },
-                  {
-                    "text": "))"
-                  }
-                ]
-              }
-            },
-            {
-              "text": ",\n        _ => Err(std::io::Error::other(\"unsupported whence for fseek.\")),\n    })"
-            }
-          ],
-          "body": [
-            {
-              "text": ".is_ok()"
-            }
-          ]
+        "placeholder": {
+          "arg": 0,
+          "access": "read"
         }
       },
       {
-        "text": "\n    {\n        0\n    } else {\n        -1\n    }"
+        "text": ", "
+      },
+      {
+        "placeholder": {
+          "arg": 1,
+          "access": "read"
+        }
+      },
+      {
+        "text": " as ::libc::c_long, "
+      },
+      {
+        "placeholder": {
+          "arg": 2,
+          "access": "read"
+        }
+      },
+      {
+        "text": ")"
       }
     ],
     "params": {
       "a0": {
-        "type": "*mut ::std::fs::File",
+        "type": "*mut ::libc::FILE",
         "is_unsafe_pointer": true
       },
       "a1": {
@@ -787,7 +516,7 @@
   "f5": {
     "body": [
       {
-        "text": "let __a0 = "
+        "text": "libcc2rs::fread_unsafe("
       },
       {
         "placeholder": {
@@ -796,7 +525,7 @@
         }
       },
       {
-        "text": " as *mut ::std::ffi::c_void;\n    let __a1 = "
+        "text": ", "
       },
       {
         "placeholder": {
@@ -805,7 +534,7 @@
         }
       },
       {
-        "text": ";\n    let __a2 = "
+        "text": ", "
       },
       {
         "placeholder": {
@@ -814,7 +543,7 @@
         }
       },
       {
-        "text": ";\n    let __a3 = "
+        "text": ", "
       },
       {
         "placeholder": {
@@ -823,10 +552,9 @@
         }
       },
       {
-        "text": ";\n    libcc2rs::fread_unsafe(__a0, __a1, __a2, __a3)"
+        "text": ")"
       }
     ],
-    "multi_statement": true,
     "params": {
       "a0": {
         "type": "*mut ::libc::c_void",
@@ -839,7 +567,7 @@
         "type": "u64"
       },
       "a3": {
-        "type": "*mut ::std::fs::File",
+        "type": "*mut ::libc::FILE",
         "is_unsafe_pointer": true
       }
     },
@@ -850,7 +578,7 @@
   "f6": {
     "body": [
       {
-        "text": "let __a0 = "
+        "text": "libcc2rs::fwrite_unsafe("
       },
       {
         "placeholder": {
@@ -859,7 +587,7 @@
         }
       },
       {
-        "text": " as *const ::std::ffi::c_void;\n    let __a1 = "
+        "text": ", "
       },
       {
         "placeholder": {
@@ -868,7 +596,7 @@
         }
       },
       {
-        "text": ";\n    let __a2 = "
+        "text": ", "
       },
       {
         "placeholder": {
@@ -877,7 +605,7 @@
         }
       },
       {
-        "text": ";\n    let __a3 = "
+        "text": ", "
       },
       {
         "placeholder": {
@@ -886,10 +614,9 @@
         }
       },
       {
-        "text": ";\n    libcc2rs::fwrite_unsafe(__a0, __a1, __a2, __a3)"
+        "text": ")"
       }
     ],
-    "multi_statement": true,
     "params": {
       "a0": {
         "type": "*const ::libc::c_void",
@@ -902,7 +629,7 @@
         "type": "u64"
       },
       "a3": {
-        "type": "*mut ::std::fs::File",
+        "type": "*mut ::libc::FILE",
         "is_unsafe_pointer": true
       }
     },
@@ -913,120 +640,21 @@
   "f7": {
     "body": [
       {
-        "text": "if !"
+        "text": "libc::fflush("
       },
       {
-        "method_call": {
-          "receiver": [
-            {
-              "text": "("
-            },
-            {
-              "placeholder": {
-                "arg": 0,
-                "access": "write"
-              }
-            },
-            {
-              "text": ")"
-            }
-          ],
-          "body": [
-            {
-              "text": ".is_null()"
-            }
-          ]
+        "placeholder": {
+          "arg": 0,
+          "access": "read"
         }
       },
       {
-        "text": " {\n        match "
-      },
-      {
-        "method_call": {
-          "receiver": [
-            {
-              "text": "(*"
-            },
-            {
-              "placeholder": {
-                "arg": 0,
-                "access": "read"
-              }
-            },
-            {
-              "text": ")"
-            }
-          ],
-          "body": [
-            {
-              "text": ".sync_all()"
-            }
-          ]
-        }
-      },
-      {
-        "text": " {\n            Ok(_) => 0,\n            Err(_) => -1,\n        }\n    } else {\n        "
-      },
-      {
-        "method_call": {
-          "receiver": [
-            {
-              "method_call": {
-                "receiver": [
-                  {
-                    "text": "::std::io::stdout()"
-                  }
-                ],
-                "body": [
-                  {
-                    "text": ".flush()"
-                  }
-                ]
-              }
-            }
-          ],
-          "body": [
-            {
-              "text": ".unwrap()"
-            }
-          ]
-        }
-      },
-      {
-        "text": ";\n        "
-      },
-      {
-        "method_call": {
-          "receiver": [
-            {
-              "method_call": {
-                "receiver": [
-                  {
-                    "text": "::std::io::stderr()"
-                  }
-                ],
-                "body": [
-                  {
-                    "text": ".flush()"
-                  }
-                ]
-              }
-            }
-          ],
-          "body": [
-            {
-              "text": ".unwrap()"
-            }
-          ]
-        }
-      },
-      {
-        "text": ";\n        0\n    }"
+        "text": ")"
       }
     ],
     "params": {
       "a0": {
-        "type": "*mut ::std::fs::File",
+        "type": "*mut ::libc::FILE",
         "is_unsafe_pointer": true
       }
     },
@@ -1037,28 +665,28 @@
   "f8": {
     "body": [
       {
-        "text": "libcc2rs::cout_unsafe()"
+        "text": "libcc2rs::stdout_unsafe()"
       }
     ],
     "return_type": {
-      "type": "*mut ::std::fs::File",
+      "type": "*mut ::libc::FILE",
       "is_unsafe_pointer": true
     }
   },
   "f9": {
     "body": [
       {
-        "text": "libcc2rs::cerr_unsafe()"
+        "text": "libcc2rs::stderr_unsafe()"
       }
     ],
     "return_type": {
-      "type": "*mut ::std::fs::File",
+      "type": "*mut ::libc::FILE",
       "is_unsafe_pointer": true
     }
   },
   "t1": {
     "init": "std::ptr::null_mut()",
-    "type": "*mut ::std::fs::File",
+    "type": "*mut ::libc::FILE",
     "is_unsafe_pointer": true
   }
 }

--- a/rules/stdio/src.cpp
+++ b/rules/stdio/src.cpp
@@ -40,3 +40,19 @@ int f12(const char *s, FILE *stream) { return fputs(s, stream); }
 int f13(const char *s) { return puts(s); }
 
 int f14(FILE *stream) { return fileno(stream); }
+
+int f15(FILE *stream) { return ferror(stream); }
+
+int f16(FILE *stream) { return feof(stream); }
+
+char *f17(char *s, int n, FILE *stream) { return fgets(s, n, stream); }
+
+FILE *f18(const char *pathname, const char *mode, FILE *stream) {
+  return freopen(pathname, mode, stream);
+}
+
+int f19(FILE *stream, off_t offset, int whence) {
+  return fseeko(stream, offset, whence);
+}
+
+FILE *f20(int fd, const char *mode) { return fdopen(fd, mode); }

--- a/rules/stdio/tgt_unsafe.rs
+++ b/rules/stdio/tgt_unsafe.rs
@@ -1,142 +1,87 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-use libcc2rs::*;
-use std::io::prelude::*;
-
 fn types() -> Result<(), Box<dyn std::error::Error>> {
-    let t1: *mut ::std::fs::File = std::ptr::null_mut();
+    let t1: *mut ::libc::FILE = std::ptr::null_mut();
     Ok(())
 }
 
-unsafe fn f1(a0: *const i8, a1: *const i8) -> *mut ::std::fs::File {
-    match std::ffi::CStr::from_ptr(a1 as *const i8)
-        .to_str()
-        .expect("invalid c-string")
-    {
-        v if v == "rb" => std::fs::OpenOptions::new()
-            .read(true)
-            .open(
-                std::ffi::CStr::from_ptr(a0 as *const i8)
-                    .to_str()
-                    .expect("invalid c-string"),
-            )
-            .ok()
-            .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-        v if v == "wb" => std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(
-                std::ffi::CStr::from_ptr(a0 as *const i8)
-                    .to_str()
-                    .expect("invalid c-string"),
-            )
-            .ok()
-            .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-        _ => panic!("unsupported mode"),
-    }
+unsafe fn f1(a0: *const u8, a1: *const u8) -> *mut ::libc::FILE {
+    libc::fopen(a0 as *const i8, a1 as *const i8)
 }
 
-unsafe fn f2(a0: *mut ::std::fs::File) -> i32 {
-    Box::from_raw(a0);
-    0
+unsafe fn f2(a0: *mut ::libc::FILE) -> i32 {
+    libc::fclose(a0)
 }
 
-unsafe fn f3(a0: *mut ::std::fs::File) -> i64 {
-    match (*a0).stream_position() {
-        Ok(pos) => pos as i64,
-        Err(_) => -1,
-    }
+unsafe fn f3(a0: *mut ::libc::FILE) -> i64 {
+    libc::ftell(a0) as i64
 }
 
-unsafe fn f4(a0: *mut ::std::fs::File, a1: i64, a2: i32) -> i32 {
-    if (match a2 {
-        0 => (*a0).seek(std::io::SeekFrom::Start(a1 as u64)),
-        1 => (*a0).seek(std::io::SeekFrom::Current(a1)),
-        2 => (*a0).seek(std::io::SeekFrom::End(a1)),
-        _ => Err(std::io::Error::other("unsupported whence for fseek.")),
-    })
-    .is_ok()
-    {
-        0
-    } else {
-        -1
-    }
+unsafe fn f4(a0: *mut ::libc::FILE, a1: i64, a2: i32) -> i32 {
+    libc::fseek(a0, a1 as ::libc::c_long, a2)
 }
 
-unsafe fn f5(a0: *mut ::libc::c_void, a1: u64, a2: u64, a3: *mut ::std::fs::File) -> u64 {
-    let __a0 = a0 as *mut ::std::ffi::c_void;
-    let __a1 = a1;
-    let __a2 = a2;
-    let __a3 = a3;
-    libcc2rs::fread_unsafe(__a0, __a1, __a2, __a3)
+unsafe fn f5(a0: *mut ::libc::c_void, a1: u64, a2: u64, a3: *mut ::libc::FILE) -> u64 {
+    libcc2rs::fread_unsafe(a0, a1, a2, a3)
 }
 
-unsafe fn f6(a0: *const ::libc::c_void, a1: u64, a2: u64, a3: *mut ::std::fs::File) -> u64 {
-    let __a0 = a0 as *const ::std::ffi::c_void;
-    let __a1 = a1;
-    let __a2 = a2;
-    let __a3 = a3;
-    libcc2rs::fwrite_unsafe(__a0, __a1, __a2, __a3)
+unsafe fn f6(a0: *const ::libc::c_void, a1: u64, a2: u64, a3: *mut ::libc::FILE) -> u64 {
+    libcc2rs::fwrite_unsafe(a0, a1, a2, a3)
 }
 
-unsafe fn f7(a0: *mut ::std::fs::File) -> i32 {
-    if !(a0).is_null() {
-        match (*a0).sync_all() {
-            Ok(_) => 0,
-            Err(_) => -1,
-        }
-    } else {
-        ::std::io::stdout().flush().unwrap();
-        ::std::io::stderr().flush().unwrap();
-        0
-    }
+unsafe fn f7(a0: *mut ::libc::FILE) -> i32 {
+    libc::fflush(a0)
 }
 
-unsafe fn f8() -> *mut ::std::fs::File {
-    libcc2rs::cout_unsafe()
+unsafe fn f8() -> *mut ::libc::FILE {
+    libcc2rs::stdout_unsafe()
 }
 
-unsafe fn f9() -> *mut ::std::fs::File {
-    libcc2rs::cerr_unsafe()
+unsafe fn f9() -> *mut ::libc::FILE {
+    libcc2rs::stderr_unsafe()
 }
 
-unsafe fn f10() -> *mut ::std::fs::File {
-    libcc2rs::cin_unsafe()
+unsafe fn f10() -> *mut ::libc::FILE {
+    libcc2rs::stdin_unsafe()
 }
 
-unsafe fn f11(a0: i32, a1: *mut ::std::fs::File) -> i32 {
-    match (*a1).write_all(&[a0 as u8]) {
-        Ok(()) => a0 & 0xff,
-        Err(_) => -1,
-    }
+unsafe fn f11(a0: i32, a1: *mut ::libc::FILE) -> i32 {
+    libc::fputc(a0, a1)
 }
 
-unsafe fn f12(a0: *const u8, a1: *mut ::std::fs::File) -> i32 {
-    let bytes = std::ffi::CStr::from_ptr(a0 as *const i8).to_bytes();
-    match (*a1).write_all(bytes) {
-        Ok(()) => 0,
-        Err(_) => -1,
-    }
+unsafe fn f12(a0: *const u8, a1: *mut ::libc::FILE) -> i32 {
+    libc::fputs(a0 as *const i8, a1)
 }
 
 unsafe fn f13(a0: *const u8) -> i32 {
-    let bytes = std::ffi::CStr::from_ptr(a0 as *const i8).to_bytes();
-    let stdout = libcc2rs::cout_unsafe();
-    let r1 = (*stdout).write_all(bytes);
-    let r2 = (*stdout).write_all(b"\n");
-    if r1.is_ok() && r2.is_ok() { 0 } else { -1 }
+    libc::puts(a0 as *const i8)
 }
 
-unsafe fn f14(a0: *mut ::std::fs::File) -> i32 {
-    if a0 == libcc2rs::cin_unsafe() {
-        0
-    } else if a0 == libcc2rs::cout_unsafe() {
-        1
-    } else if a0 == libcc2rs::cerr_unsafe() {
-        2
-    } else {
-        ::std::os::fd::AsRawFd::as_raw_fd(&*a0)
-    }
+unsafe fn f14(a0: *mut ::libc::FILE) -> i32 {
+    libc::fileno(a0)
+}
+
+unsafe fn f15(a0: *mut ::libc::FILE) -> i32 {
+    libc::ferror(a0)
+}
+
+unsafe fn f16(a0: *mut ::libc::FILE) -> i32 {
+    libc::feof(a0)
+}
+
+unsafe fn f17(a0: *mut u8, a1: i32, a2: *mut ::libc::FILE) -> *mut u8 {
+    libc::fgets(a0 as *mut i8, a1, a2) as *mut u8
+}
+
+unsafe fn f18(a0: *const u8, a1: *const u8, a2: *mut ::libc::FILE) -> *mut ::libc::FILE {
+    libc::freopen(a0 as *const i8, a1 as *const i8, a2)
+}
+
+unsafe fn f19(a0: *mut ::libc::FILE, a1: i64, a2: i32) -> i32 {
+    libc::fseeko(a0, a1 as ::libc::off_t, a2)
+}
+
+unsafe fn f20(a0: i32, a1: *const u8) -> *mut ::libc::FILE {
+    libc::fdopen(a0, a1 as *const i8)
 }

--- a/tests/unit/out/unsafe/errno.rs
+++ b/tests/unit/out/unsafe/errno.rs
@@ -17,10 +17,11 @@ pub unsafe fn test_errno_0() {
 }
 pub unsafe fn test_errno_preserved_across_strdup_1() {
     (*libcc2rs::cpp2rust_errno()) = 99;
-    let mut d: *mut u8 = libcc2rs::strdup_unsafe((b"hello\0".as_ptr().cast_mut()).cast_const());
+    let mut d: *mut u8 =
+        libc::strdup((b"hello\0".as_ptr().cast_mut()).cast_const() as *const i8) as *mut u8;
     assert!((((!((d).is_null())) as i32) != 0));
     assert!(((((*libcc2rs::cpp2rust_errno()) == (99)) as i32) != 0));
-    libcc2rs::free_unsafe((d as *mut u8 as *mut ::libc::c_void));
+    libc::free((d as *mut u8 as *mut ::libc::c_void));
     (*libcc2rs::cpp2rust_errno()) = 0;
 }
 pub unsafe fn test_errno_from_fseek_2() {

--- a/tests/unit/out/unsafe/errno.rs
+++ b/tests/unit/out/unsafe/errno.rs
@@ -17,27 +17,15 @@ pub unsafe fn test_errno_0() {
 }
 pub unsafe fn test_errno_preserved_across_strdup_1() {
     (*libcc2rs::cpp2rust_errno()) = 99;
-    let mut d: *mut u8 =
-        libc::strdup((b"hello\0".as_ptr().cast_mut()).cast_const() as *const i8) as *mut u8;
+    let mut d: *mut u8 = libcc2rs::strdup_unsafe((b"hello\0".as_ptr().cast_mut()).cast_const());
     assert!((((!((d).is_null())) as i32) != 0));
     assert!(((((*libcc2rs::cpp2rust_errno()) == (99)) as i32) != 0));
-    libc::free((d as *mut u8 as *mut ::libc::c_void));
+    libcc2rs::free_unsafe((d as *mut u8 as *mut ::libc::c_void));
     (*libcc2rs::cpp2rust_errno()) = 0;
 }
 pub unsafe fn test_errno_from_fseek_2() {
     (*libcc2rs::cpp2rust_errno()) = 0;
-    let mut r: i32 = if (match 0 {
-        0 => (*libcc2rs::cin_unsafe()).seek(std::io::SeekFrom::Start(0_i64 as u64)),
-        1 => (*libcc2rs::cin_unsafe()).seek(std::io::SeekFrom::Current(0_i64)),
-        2 => (*libcc2rs::cin_unsafe()).seek(std::io::SeekFrom::End(0_i64)),
-        _ => Err(std::io::Error::other("unsupported whence for fseek.")),
-    })
-    .is_ok()
-    {
-        0
-    } else {
-        -1
-    };
+    let mut r: i32 = libc::fseek(libcc2rs::stdin_unsafe(), 0_i64 as ::libc::c_long, 0);
     assert!(((((r) == (-1_i32)) as i32) != 0));
     assert!(((((*libcc2rs::cpp2rust_errno()) == (29)) as i32) != 0));
     (*libcc2rs::cpp2rust_errno()) = 0;

--- a/tests/unit/out/unsafe/fflush_null.rs
+++ b/tests/unit/out/unsafe/fflush_null.rs
@@ -12,15 +12,6 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut file_ptr: *mut ::std::fs::File = std::ptr::null_mut();
-    return if !(file_ptr).is_null() {
-        match (*file_ptr).sync_all() {
-            Ok(_) => 0,
-            Err(_) => -1,
-        }
-    } else {
-        ::std::io::stdout().flush().unwrap();
-        ::std::io::stderr().flush().unwrap();
-        0
-    };
+    let mut file_ptr: *mut ::libc::FILE = std::ptr::null_mut();
+    return libc::fflush(file_ptr);
 }

--- a/tests/unit/out/unsafe/fn_ptr_stdlib_compare.rs
+++ b/tests/unit/out/unsafe/fn_ptr_stdlib_compare.rs
@@ -28,64 +28,41 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut fn1: Option<unsafe fn(*mut ::libc::c_void, u64, u64, *mut ::std::fs::File) -> u64> =
+    let mut fn1: Option<unsafe fn(*mut ::libc::c_void, u64, u64, *mut ::libc::FILE) -> u64> =
         Some(libcc2rs::fread_unsafe);
     assert!(((fn1) == (Some(libcc2rs::fread_unsafe))));
     assert!(!((fn1).is_none()));
     let mut fn2: Option<unsafe fn(*mut u8, u64, u64, *mut ::libc::c_void) -> u64> =
         std::mem::transmute::<
-            Option<unsafe fn(*mut ::libc::c_void, u64, u64, *mut ::std::fs::File) -> u64>,
+            Option<unsafe fn(*mut ::libc::c_void, u64, u64, *mut ::libc::FILE) -> u64>,
             Option<unsafe fn(*mut u8, u64, u64, *mut ::libc::c_void) -> u64>,
         >(Some(libcc2rs::fread_unsafe));
     assert!(
         ((fn1)
             == (std::mem::transmute::<
                 Option<unsafe fn(*mut u8, u64, u64, *mut ::libc::c_void) -> u64>,
-                Option<unsafe fn(*mut ::libc::c_void, u64, u64, *mut ::std::fs::File) -> u64>,
+                Option<unsafe fn(*mut ::libc::c_void, u64, u64, *mut ::libc::FILE) -> u64>,
             >(fn2)))
     );
-    let mut f3: Option<unsafe fn(*mut ::libc::c_void, u64, u64, *mut ::std::fs::File) -> u64> =
+    let mut f3: Option<unsafe fn(*mut ::libc::c_void, u64, u64, *mut ::libc::FILE) -> u64> =
         std::mem::transmute::<
             Option<unsafe fn(*mut u8, u64, u64, *mut ::libc::c_void) -> u64>,
-            Option<unsafe fn(*mut ::libc::c_void, u64, u64, *mut ::std::fs::File) -> u64>,
+            Option<unsafe fn(*mut ::libc::c_void, u64, u64, *mut ::libc::FILE) -> u64>,
         >(Some(my_alternative_fread_0));
     assert!(
         ((unsafe {
             let _arg0: *mut ::libc::c_void = std::ptr::null_mut();
             let _arg1: u64 = 0_u64;
             let _arg2: u64 = 0_u64;
-            let _arg3: *mut ::std::fs::File = std::ptr::null_mut();
+            let _arg3: *mut ::libc::FILE = std::ptr::null_mut();
             (f3).unwrap()(_arg0, _arg1, _arg2, _arg3)
         }) == (22_u64))
     );
     'loop_: loop {
-        let mut stream: *mut ::std::fs::File =
-            match std::ffi::CStr::from_ptr(b"rb\0".as_ptr() as *const i8)
-                .to_str()
-                .expect("invalid c-string")
-            {
-                v if v == "rb" => std::fs::OpenOptions::new()
-                    .read(true)
-                    .open(
-                        std::ffi::CStr::from_ptr(b"/dev/zero\0".as_ptr() as *const i8)
-                            .to_str()
-                            .expect("invalid c-string"),
-                    )
-                    .ok()
-                    .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-                v if v == "wb" => std::fs::OpenOptions::new()
-                    .write(true)
-                    .create(true)
-                    .truncate(true)
-                    .open(
-                        std::ffi::CStr::from_ptr(b"/dev/zero\0".as_ptr() as *const i8)
-                            .to_str()
-                            .expect("invalid c-string"),
-                    )
-                    .ok()
-                    .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-                _ => panic!("unsupported mode"),
-            };
+        let mut stream: *mut ::libc::FILE = libc::fopen(
+            b"/dev/zero\0".as_ptr() as *const i8,
+            b"rb\0".as_ptr() as *const i8,
+        );
         assert!(!((stream).is_null()));
         let mut buf: [u8; 16] = [0_u8; 16];
         {
@@ -95,14 +72,12 @@ unsafe fn main_0() -> i32 {
             }
             (buf.as_mut_ptr() as *mut u8 as *mut ::libc::c_void)
         };
-        let mut n: u64 = {
-            let __a0 =
-                (buf.as_mut_ptr() as *mut u8 as *mut ::libc::c_void) as *mut ::std::ffi::c_void;
-            let __a1 = 1_u64;
-            let __a2 = 10_u64;
-            let __a3 = stream;
-            libcc2rs::fread_unsafe(__a0, __a1, __a2, __a3)
-        };
+        let mut n: u64 = libcc2rs::fread_unsafe(
+            (buf.as_mut_ptr() as *mut u8 as *mut ::libc::c_void),
+            1_u64,
+            10_u64,
+            stream,
+        );
         assert!(((n) == (10_u64)));
         let mut i: i32 = 0;
         'loop_: while ((i) < (10)) {
@@ -114,42 +89,16 @@ unsafe fn main_0() -> i32 {
             assert!(((buf[(i) as usize] as i32) == (('X' as u8) as i32)));
             i.prefix_inc();
         }
-        {
-            Box::from_raw(stream);
-            0
-        };
+        libc::fclose(stream);
         if !(0 != 0) {
             break;
         }
     }
     'loop_: loop {
-        let mut stream: *mut ::std::fs::File =
-            match std::ffi::CStr::from_ptr(b"rb\0".as_ptr() as *const i8)
-                .to_str()
-                .expect("invalid c-string")
-            {
-                v if v == "rb" => std::fs::OpenOptions::new()
-                    .read(true)
-                    .open(
-                        std::ffi::CStr::from_ptr(b"/dev/zero\0".as_ptr() as *const i8)
-                            .to_str()
-                            .expect("invalid c-string"),
-                    )
-                    .ok()
-                    .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-                v if v == "wb" => std::fs::OpenOptions::new()
-                    .write(true)
-                    .create(true)
-                    .truncate(true)
-                    .open(
-                        std::ffi::CStr::from_ptr(b"/dev/zero\0".as_ptr() as *const i8)
-                            .to_str()
-                            .expect("invalid c-string"),
-                    )
-                    .ok()
-                    .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-                _ => panic!("unsupported mode"),
-            };
+        let mut stream: *mut ::libc::FILE = libc::fopen(
+            b"/dev/zero\0".as_ptr() as *const i8,
+            b"rb\0".as_ptr() as *const i8,
+        );
         assert!(!((stream).is_null()));
         let mut buf: [u8; 16] = [0_u8; 16];
         {
@@ -163,7 +112,7 @@ unsafe fn main_0() -> i32 {
             let _arg0: *mut ::libc::c_void = (buf.as_mut_ptr() as *mut u8 as *mut ::libc::c_void);
             let _arg1: u64 = 1_u64;
             let _arg2: u64 = 10_u64;
-            let _arg3: *mut ::std::fs::File = stream;
+            let _arg3: *mut ::libc::FILE = stream;
             (fn1).unwrap()(_arg0, _arg1, _arg2, _arg3)
         });
         assert!(((n) == (10_u64)));
@@ -177,72 +126,46 @@ unsafe fn main_0() -> i32 {
             assert!(((buf[(i) as usize] as i32) == (('X' as u8) as i32)));
             i.prefix_inc();
         }
-        {
-            Box::from_raw(stream);
-            0
-        };
+        libc::fclose(stream);
         if !(0 != 0) {
             break;
         }
     }
-    let mut gn1: Option<unsafe fn(*const ::libc::c_void, u64, u64, *mut ::std::fs::File) -> u64> =
+    let mut gn1: Option<unsafe fn(*const ::libc::c_void, u64, u64, *mut ::libc::FILE) -> u64> =
         Some(libcc2rs::fwrite_unsafe);
     assert!(((gn1) == (Some(libcc2rs::fwrite_unsafe))));
     assert!(!((gn1).is_none()));
     let mut gn2: Option<unsafe fn(*const u8, u64, u64, *mut ::libc::c_void) -> u64> =
         std::mem::transmute::<
-            Option<unsafe fn(*const ::libc::c_void, u64, u64, *mut ::std::fs::File) -> u64>,
+            Option<unsafe fn(*const ::libc::c_void, u64, u64, *mut ::libc::FILE) -> u64>,
             Option<unsafe fn(*const u8, u64, u64, *mut ::libc::c_void) -> u64>,
         >(Some(libcc2rs::fwrite_unsafe));
     assert!(
         ((gn1)
             == (std::mem::transmute::<
                 Option<unsafe fn(*const u8, u64, u64, *mut ::libc::c_void) -> u64>,
-                Option<unsafe fn(*const ::libc::c_void, u64, u64, *mut ::std::fs::File) -> u64>,
+                Option<unsafe fn(*const ::libc::c_void, u64, u64, *mut ::libc::FILE) -> u64>,
             >(gn2)))
     );
-    let mut g3: Option<unsafe fn(*const ::libc::c_void, u64, u64, *mut ::std::fs::File) -> u64> =
+    let mut g3: Option<unsafe fn(*const ::libc::c_void, u64, u64, *mut ::libc::FILE) -> u64> =
         std::mem::transmute::<
             Option<unsafe fn(*const u8, u64, u64, *mut ::libc::c_void) -> u64>,
-            Option<unsafe fn(*const ::libc::c_void, u64, u64, *mut ::std::fs::File) -> u64>,
+            Option<unsafe fn(*const ::libc::c_void, u64, u64, *mut ::libc::FILE) -> u64>,
         >(Some(my_alternative_fwrite_1));
     assert!(
         ((unsafe {
             let _arg0: *const ::libc::c_void = std::ptr::null();
             let _arg1: u64 = 0_u64;
             let _arg2: u64 = 0_u64;
-            let _arg3: *mut ::std::fs::File = std::ptr::null_mut();
+            let _arg3: *mut ::libc::FILE = std::ptr::null_mut();
             (g3).unwrap()(_arg0, _arg1, _arg2, _arg3)
         }) == (33_u64))
     );
     'loop_: loop {
-        let mut stream: *mut ::std::fs::File =
-            match std::ffi::CStr::from_ptr(b"wb\0".as_ptr() as *const i8)
-                .to_str()
-                .expect("invalid c-string")
-            {
-                v if v == "rb" => std::fs::OpenOptions::new()
-                    .read(true)
-                    .open(
-                        std::ffi::CStr::from_ptr(b"/dev/null\0".as_ptr() as *const i8)
-                            .to_str()
-                            .expect("invalid c-string"),
-                    )
-                    .ok()
-                    .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-                v if v == "wb" => std::fs::OpenOptions::new()
-                    .write(true)
-                    .create(true)
-                    .truncate(true)
-                    .open(
-                        std::ffi::CStr::from_ptr(b"/dev/null\0".as_ptr() as *const i8)
-                            .to_str()
-                            .expect("invalid c-string"),
-                    )
-                    .ok()
-                    .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-                _ => panic!("unsupported mode"),
-            };
+        let mut stream: *mut ::libc::FILE = libc::fopen(
+            b"/dev/null\0".as_ptr() as *const i8,
+            b"wb\0".as_ptr() as *const i8,
+        );
         assert!(!((stream).is_null()));
         let mut buf: [u8; 10] = [0_u8; 10];
         {
@@ -252,51 +175,23 @@ unsafe fn main_0() -> i32 {
             }
             (buf.as_mut_ptr() as *mut u8 as *mut ::libc::c_void)
         };
-        let mut n: u64 = {
-            let __a0 = (buf.as_mut_ptr() as *const u8 as *const ::libc::c_void)
-                as *const ::std::ffi::c_void;
-            let __a1 = 1_u64;
-            let __a2 = 10_u64;
-            let __a3 = stream;
-            libcc2rs::fwrite_unsafe(__a0, __a1, __a2, __a3)
-        };
+        let mut n: u64 = libcc2rs::fwrite_unsafe(
+            (buf.as_mut_ptr() as *const u8 as *const ::libc::c_void),
+            1_u64,
+            10_u64,
+            stream,
+        );
         assert!(((n) == (10_u64)));
-        {
-            Box::from_raw(stream);
-            0
-        };
+        libc::fclose(stream);
         if !(0 != 0) {
             break;
         }
     }
     'loop_: loop {
-        let mut stream: *mut ::std::fs::File =
-            match std::ffi::CStr::from_ptr(b"wb\0".as_ptr() as *const i8)
-                .to_str()
-                .expect("invalid c-string")
-            {
-                v if v == "rb" => std::fs::OpenOptions::new()
-                    .read(true)
-                    .open(
-                        std::ffi::CStr::from_ptr(b"/dev/null\0".as_ptr() as *const i8)
-                            .to_str()
-                            .expect("invalid c-string"),
-                    )
-                    .ok()
-                    .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-                v if v == "wb" => std::fs::OpenOptions::new()
-                    .write(true)
-                    .create(true)
-                    .truncate(true)
-                    .open(
-                        std::ffi::CStr::from_ptr(b"/dev/null\0".as_ptr() as *const i8)
-                            .to_str()
-                            .expect("invalid c-string"),
-                    )
-                    .ok()
-                    .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-                _ => panic!("unsupported mode"),
-            };
+        let mut stream: *mut ::libc::FILE = libc::fopen(
+            b"/dev/null\0".as_ptr() as *const i8,
+            b"wb\0".as_ptr() as *const i8,
+        );
         assert!(!((stream).is_null()));
         let mut buf: [u8; 10] = [0_u8; 10];
         {
@@ -311,14 +206,11 @@ unsafe fn main_0() -> i32 {
                 (buf.as_mut_ptr() as *const u8 as *const ::libc::c_void);
             let _arg1: u64 = 1_u64;
             let _arg2: u64 = 10_u64;
-            let _arg3: *mut ::std::fs::File = stream;
+            let _arg3: *mut ::libc::FILE = stream;
             (gn1).unwrap()(_arg0, _arg1, _arg2, _arg3)
         });
         assert!(((n) == (10_u64)));
-        {
-            Box::from_raw(stream);
-            0
-        };
+        libc::fclose(stream);
         if !(0 != 0) {
             break;
         }

--- a/tests/unit/out/unsafe/fopen.rs
+++ b/tests/unit/out/unsafe/fopen.rs
@@ -14,31 +14,6 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut fname: *const u8 = b"testfile.txt\0".as_ptr();
     let mut mode: *const u8 = b"rb\0".as_ptr();
-    let mut file_ptr: *mut ::std::fs::File = match std::ffi::CStr::from_ptr(mode as *const i8)
-        .to_str()
-        .expect("invalid c-string")
-    {
-        v if v == "rb" => std::fs::OpenOptions::new()
-            .read(true)
-            .open(
-                std::ffi::CStr::from_ptr(fname as *const i8)
-                    .to_str()
-                    .expect("invalid c-string"),
-            )
-            .ok()
-            .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-        v if v == "wb" => std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(
-                std::ffi::CStr::from_ptr(fname as *const i8)
-                    .to_str()
-                    .expect("invalid c-string"),
-            )
-            .ok()
-            .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-        _ => panic!("unsupported mode"),
-    };
+    let mut file_ptr: *mut ::libc::FILE = libc::fopen(fname as *const i8, mode as *const i8);
     return 0;
 }

--- a/tests/unit/out/unsafe/global_without_initializer.rs
+++ b/tests/unit/out/unsafe/global_without_initializer.rs
@@ -12,7 +12,7 @@ pub struct S {
     pub a: i32,
 }
 pub static mut s: *mut S = unsafe { std::ptr::null_mut() };
-pub static mut file: *mut ::std::fs::File = unsafe { std::ptr::null_mut() };
+pub static mut file: *mut ::libc::FILE = unsafe { std::ptr::null_mut() };
 pub static mut size: u64 = unsafe { 0_u64 };
 pub fn main() {
     unsafe {

--- a/tests/unit/out/unsafe/printfs.rs
+++ b/tests/unit/out/unsafe/printfs.rs
@@ -34,7 +34,7 @@ unsafe fn main_0() -> i32 {
     );
     printf(b"%d %u %ld\n\0".as_ptr() as *const i8, 1, 2_u32, 3_i64);
     printf(b"hello world\0".as_ptr() as *const i8);
-    let mut in_: *mut ::std::fs::File = libcc2rs::cin_unsafe();
+    let mut in_: *mut ::libc::FILE = libcc2rs::stdin_unsafe();
     assert!(!((in_).is_null()));
     printf(b"%s\n\0".as_ptr() as *const i8, b"printf\0".as_ptr());
     printf(b"hello world\0".as_ptr() as *const i8);

--- a/tests/unit/out/unsafe/stdio.rs
+++ b/tests/unit/out/unsafe/stdio.rs
@@ -7,174 +7,48 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn test_fputc_0() {
-    match (*libcc2rs::cout_unsafe()).write_all(&[('H' as i32) as u8]) {
-        Ok(()) => ('H' as i32) & 0xff,
-        Err(_) => -1,
-    };
-    match (*libcc2rs::cout_unsafe()).write_all(&[('i' as i32) as u8]) {
-        Ok(()) => ('i' as i32) & 0xff,
-        Err(_) => -1,
-    };
-    match (*libcc2rs::cout_unsafe()).write_all(&[('\n' as i32) as u8]) {
-        Ok(()) => ('\n' as i32) & 0xff,
-        Err(_) => -1,
-    };
+    libc::fputc(('H' as i32), libcc2rs::stdout_unsafe());
+    libc::fputc(('i' as i32), libcc2rs::stdout_unsafe());
+    libc::fputc(('\n' as i32), libcc2rs::stdout_unsafe());
 }
 pub unsafe fn test_fputs_1() {
-    {
-        let bytes =
-            std::ffi::CStr::from_ptr((b"hello\0".as_ptr().cast_mut()).cast_const() as *const i8)
-                .to_bytes();
-        match (*libcc2rs::cout_unsafe()).write_all(bytes) {
-            Ok(()) => 0,
-            Err(_) => -1,
-        }
-    };
-    match (*libcc2rs::cout_unsafe()).write_all(&[('\n' as i32) as u8]) {
-        Ok(()) => ('\n' as i32) & 0xff,
-        Err(_) => -1,
-    };
+    libc::fputs(
+        (b"hello\0".as_ptr().cast_mut()).cast_const() as *const i8,
+        libcc2rs::stdout_unsafe(),
+    );
+    libc::fputc(('\n' as i32), libcc2rs::stdout_unsafe());
     let mut s: *const u8 = (b"from variable\0".as_ptr().cast_mut()).cast_const();
-    {
-        let bytes = std::ffi::CStr::from_ptr(s as *const i8).to_bytes();
-        match (*libcc2rs::cout_unsafe()).write_all(bytes) {
-            Ok(()) => 0,
-            Err(_) => -1,
-        }
-    };
-    match (*libcc2rs::cout_unsafe()).write_all(&[('\n' as i32) as u8]) {
-        Ok(()) => ('\n' as i32) & 0xff,
-        Err(_) => -1,
-    };
+    libc::fputs(s as *const i8, libcc2rs::stdout_unsafe());
+    libc::fputc(('\n' as i32), libcc2rs::stdout_unsafe());
     let mut buf: [u8; 4] = [
         (('b' as i32) as u8),
         (('u' as i32) as u8),
         (('f' as i32) as u8),
         (('\0' as i32) as u8),
     ];
-    {
-        let bytes =
-            std::ffi::CStr::from_ptr((buf.as_mut_ptr()).cast_const() as *const i8).to_bytes();
-        match (*libcc2rs::cout_unsafe()).write_all(bytes) {
-            Ok(()) => 0,
-            Err(_) => -1,
-        }
-    };
-    match (*libcc2rs::cout_unsafe()).write_all(&[('\n' as i32) as u8]) {
-        Ok(()) => ('\n' as i32) & 0xff,
-        Err(_) => -1,
-    };
+    libc::fputs(
+        (buf.as_mut_ptr()).cast_const() as *const i8,
+        libcc2rs::stdout_unsafe(),
+    );
+    libc::fputc(('\n' as i32), libcc2rs::stdout_unsafe());
 }
 pub unsafe fn test_puts_2() {
-    {
-        let bytes = std::ffi::CStr::from_ptr(
-            (b"puts hello\0".as_ptr().cast_mut()).cast_const() as *const i8
-        )
-        .to_bytes();
-        let stdout = libcc2rs::cout_unsafe();
-        let r1 = (*stdout).write_all(bytes);
-        let r2 = (*stdout).write_all(b"\n");
-        if r1.is_ok() && r2.is_ok() {
-            0
-        } else {
-            -1
-        }
-    };
+    libc::puts((b"puts hello\0".as_ptr().cast_mut()).cast_const() as *const i8);
     let mut s: *const u8 = (b"puts variable\0".as_ptr().cast_mut()).cast_const();
-    {
-        let bytes = std::ffi::CStr::from_ptr(s as *const i8).to_bytes();
-        let stdout = libcc2rs::cout_unsafe();
-        let r1 = (*stdout).write_all(bytes);
-        let r2 = (*stdout).write_all(b"\n");
-        if r1.is_ok() && r2.is_ok() {
-            0
-        } else {
-            -1
-        }
-    };
+    libc::puts(s as *const i8);
 }
 pub unsafe fn test_fileno_3() {
-    assert!(
-        ((((if libcc2rs::cin_unsafe() == libcc2rs::cin_unsafe() {
-            0
-        } else if libcc2rs::cin_unsafe() == libcc2rs::cout_unsafe() {
-            1
-        } else if libcc2rs::cin_unsafe() == libcc2rs::cerr_unsafe() {
-            2
-        } else {
-            ::std::os::fd::AsRawFd::as_raw_fd(&*libcc2rs::cin_unsafe())
-        }) == (0)) as i32)
-            != 0)
-    );
-    assert!(
-        ((((if libcc2rs::cout_unsafe() == libcc2rs::cin_unsafe() {
-            0
-        } else if libcc2rs::cout_unsafe() == libcc2rs::cout_unsafe() {
-            1
-        } else if libcc2rs::cout_unsafe() == libcc2rs::cerr_unsafe() {
-            2
-        } else {
-            ::std::os::fd::AsRawFd::as_raw_fd(&*libcc2rs::cout_unsafe())
-        }) == (1)) as i32)
-            != 0)
-    );
-    assert!(
-        ((((if libcc2rs::cerr_unsafe() == libcc2rs::cin_unsafe() {
-            0
-        } else if libcc2rs::cerr_unsafe() == libcc2rs::cout_unsafe() {
-            1
-        } else if libcc2rs::cerr_unsafe() == libcc2rs::cerr_unsafe() {
-            2
-        } else {
-            ::std::os::fd::AsRawFd::as_raw_fd(&*libcc2rs::cerr_unsafe())
-        }) == (2)) as i32)
-            != 0)
-    );
+    assert!(((((libc::fileno(libcc2rs::stdin_unsafe())) == (0)) as i32) != 0));
+    assert!(((((libc::fileno(libcc2rs::stdout_unsafe())) == (1)) as i32) != 0));
+    assert!(((((libc::fileno(libcc2rs::stderr_unsafe())) == (2)) as i32) != 0));
     let mut file: *const u8 = (b"/tmp/cpp2rust_fileno_test.tmp\0".as_ptr().cast_mut()).cast_const();
-    let mut fp: *mut ::std::fs::File =
-        match std::ffi::CStr::from_ptr((b"wb\0".as_ptr().cast_mut()).cast_const() as *const i8)
-            .to_str()
-            .expect("invalid c-string")
-        {
-            v if v == "rb" => std::fs::OpenOptions::new()
-                .read(true)
-                .open(
-                    std::ffi::CStr::from_ptr(file as *const i8)
-                        .to_str()
-                        .expect("invalid c-string"),
-                )
-                .ok()
-                .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-            v if v == "wb" => std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(
-                    std::ffi::CStr::from_ptr(file as *const i8)
-                        .to_str()
-                        .expect("invalid c-string"),
-                )
-                .ok()
-                .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-            _ => panic!("unsupported mode"),
-        };
-    assert!((((!((fp).is_null())) as i32) != 0));
-    assert!(
-        ((((if fp == libcc2rs::cin_unsafe() {
-            0
-        } else if fp == libcc2rs::cout_unsafe() {
-            1
-        } else if fp == libcc2rs::cerr_unsafe() {
-            2
-        } else {
-            ::std::os::fd::AsRawFd::as_raw_fd(&*fp)
-        }) > (2)) as i32)
-            != 0)
+    let mut fp: *mut ::libc::FILE = libc::fopen(
+        file as *const i8,
+        (b"wb\0".as_ptr().cast_mut()).cast_const() as *const i8,
     );
-    {
-        Box::from_raw(fp);
-        0
-    };
+    assert!((((!((fp).is_null())) as i32) != 0));
+    assert!(((((libc::fileno(fp)) > (2)) as i32) != 0));
+    libc::fclose(fp);
     assert!(((((libc::unlink(file as *const i8)) == (0)) as i32) != 0));
 }
 pub fn main() {

--- a/tests/unit/out/unsafe/unistd.rs
+++ b/tests/unit/out/unsafe/unistd.rs
@@ -24,87 +24,22 @@ pub unsafe fn test_close_0() {
 }
 pub unsafe fn test_lseek_1() {
     let mut path: *const u8 = (b"/tmp/cpp2rust_lseek_test.tmp\0".as_ptr().cast_mut()).cast_const();
-    let mut fp: *mut ::std::fs::File =
-        match std::ffi::CStr::from_ptr((b"wb\0".as_ptr().cast_mut()).cast_const() as *const i8)
-            .to_str()
-            .expect("invalid c-string")
-        {
-            v if v == "rb" => std::fs::OpenOptions::new()
-                .read(true)
-                .open(
-                    std::ffi::CStr::from_ptr(path as *const i8)
-                        .to_str()
-                        .expect("invalid c-string"),
-                )
-                .ok()
-                .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-            v if v == "wb" => std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(
-                    std::ffi::CStr::from_ptr(path as *const i8)
-                        .to_str()
-                        .expect("invalid c-string"),
-                )
-                .ok()
-                .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-            _ => panic!("unsupported mode"),
-        };
-    assert!((((!((fp).is_null())) as i32) != 0));
-    {
-        let bytes = std::ffi::CStr::from_ptr(
-            (b"hello world\0".as_ptr().cast_mut()).cast_const() as *const i8
-        )
-        .to_bytes();
-        match (*fp).write_all(bytes) {
-            Ok(()) => 0,
-            Err(_) => -1,
-        }
-    };
-    assert!(
-        (((({
-            Box::from_raw(fp);
-            0
-        }) == (0)) as i32)
-            != 0)
+    let mut fp: *mut ::libc::FILE = libc::fopen(
+        path as *const i8,
+        (b"wb\0".as_ptr().cast_mut()).cast_const() as *const i8,
     );
-    fp = match std::ffi::CStr::from_ptr((b"rb\0".as_ptr().cast_mut()).cast_const() as *const i8)
-        .to_str()
-        .expect("invalid c-string")
-    {
-        v if v == "rb" => std::fs::OpenOptions::new()
-            .read(true)
-            .open(
-                std::ffi::CStr::from_ptr(path as *const i8)
-                    .to_str()
-                    .expect("invalid c-string"),
-            )
-            .ok()
-            .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-        v if v == "wb" => std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(
-                std::ffi::CStr::from_ptr(path as *const i8)
-                    .to_str()
-                    .expect("invalid c-string"),
-            )
-            .ok()
-            .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-        _ => panic!("unsupported mode"),
-    };
     assert!((((!((fp).is_null())) as i32) != 0));
-    let mut fd: i32 = if fp == libcc2rs::cin_unsafe() {
-        0
-    } else if fp == libcc2rs::cout_unsafe() {
-        1
-    } else if fp == libcc2rs::cerr_unsafe() {
-        2
-    } else {
-        ::std::os::fd::AsRawFd::as_raw_fd(&*fp)
-    };
+    libc::fputs(
+        (b"hello world\0".as_ptr().cast_mut()).cast_const() as *const i8,
+        fp,
+    );
+    assert!(((((libc::fclose(fp)) == (0)) as i32) != 0));
+    fp = libc::fopen(
+        path as *const i8,
+        (b"rb\0".as_ptr().cast_mut()).cast_const() as *const i8,
+    );
+    assert!((((!((fp).is_null())) as i32) != 0));
+    let mut fd: i32 = libc::fileno(fp);
     assert!(((((libc::lseek(fd, 0_i64, 2)) == (11_i64)) as i32) != 0));
     assert!(((((libc::lseek(fd, 6_i64, 0)) == (6_i64)) as i32) != 0));
     let mut buf: [u8; 8] = [0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8];
@@ -138,98 +73,27 @@ pub unsafe fn test_lseek_1() {
         }) == (0)) as i32)
             != 0)
     );
-    assert!(
-        (((({
-            Box::from_raw(fp);
-            0
-        }) == (0)) as i32)
-            != 0)
-    );
+    assert!(((((libc::fclose(fp)) == (0)) as i32) != 0));
     libc::unlink(path as *const i8);
 }
 pub unsafe fn test_read_2() {
     let mut path: *const u8 = (b"/tmp/cpp2rust_read_test.tmp\0".as_ptr().cast_mut()).cast_const();
-    let mut fp: *mut ::std::fs::File =
-        match std::ffi::CStr::from_ptr((b"wb\0".as_ptr().cast_mut()).cast_const() as *const i8)
-            .to_str()
-            .expect("invalid c-string")
-        {
-            v if v == "rb" => std::fs::OpenOptions::new()
-                .read(true)
-                .open(
-                    std::ffi::CStr::from_ptr(path as *const i8)
-                        .to_str()
-                        .expect("invalid c-string"),
-                )
-                .ok()
-                .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-            v if v == "wb" => std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(
-                    std::ffi::CStr::from_ptr(path as *const i8)
-                        .to_str()
-                        .expect("invalid c-string"),
-                )
-                .ok()
-                .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-            _ => panic!("unsupported mode"),
-        };
-    assert!((((!((fp).is_null())) as i32) != 0));
-    {
-        let bytes = std::ffi::CStr::from_ptr(
-            (b"hello world\0".as_ptr().cast_mut()).cast_const() as *const i8
-        )
-        .to_bytes();
-        match (*fp).write_all(bytes) {
-            Ok(()) => 0,
-            Err(_) => -1,
-        }
-    };
-    assert!(
-        (((({
-            Box::from_raw(fp);
-            0
-        }) == (0)) as i32)
-            != 0)
+    let mut fp: *mut ::libc::FILE = libc::fopen(
+        path as *const i8,
+        (b"wb\0".as_ptr().cast_mut()).cast_const() as *const i8,
     );
-    fp = match std::ffi::CStr::from_ptr((b"rb\0".as_ptr().cast_mut()).cast_const() as *const i8)
-        .to_str()
-        .expect("invalid c-string")
-    {
-        v if v == "rb" => std::fs::OpenOptions::new()
-            .read(true)
-            .open(
-                std::ffi::CStr::from_ptr(path as *const i8)
-                    .to_str()
-                    .expect("invalid c-string"),
-            )
-            .ok()
-            .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-        v if v == "wb" => std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(
-                std::ffi::CStr::from_ptr(path as *const i8)
-                    .to_str()
-                    .expect("invalid c-string"),
-            )
-            .ok()
-            .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-        _ => panic!("unsupported mode"),
-    };
     assert!((((!((fp).is_null())) as i32) != 0));
-    let mut fd: i32 = if fp == libcc2rs::cin_unsafe() {
-        0
-    } else if fp == libcc2rs::cout_unsafe() {
-        1
-    } else if fp == libcc2rs::cerr_unsafe() {
-        2
-    } else {
-        ::std::os::fd::AsRawFd::as_raw_fd(&*fp)
-    };
+    libc::fputs(
+        (b"hello world\0".as_ptr().cast_mut()).cast_const() as *const i8,
+        fp,
+    );
+    assert!(((((libc::fclose(fp)) == (0)) as i32) != 0));
+    fp = libc::fopen(
+        path as *const i8,
+        (b"rb\0".as_ptr().cast_mut()).cast_const() as *const i8,
+    );
+    assert!((((!((fp).is_null())) as i32) != 0));
+    let mut fd: i32 = libc::fileno(fp);
     let mut buf: [u8; 16] = [
         0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8,
         0_u8,
@@ -265,52 +129,17 @@ pub unsafe fn test_read_2() {
         }) == (0)) as i32)
             != 0)
     );
-    assert!(
-        (((({
-            Box::from_raw(fp);
-            0
-        }) == (0)) as i32)
-            != 0)
-    );
+    assert!(((((libc::fclose(fp)) == (0)) as i32) != 0));
     libc::unlink(path as *const i8);
 }
 pub unsafe fn test_unlink_3() {
     let mut path: *const u8 = (b"/tmp/cpp2rust_unlink_test.tmp\0".as_ptr().cast_mut()).cast_const();
-    let mut fp: *mut ::std::fs::File =
-        match std::ffi::CStr::from_ptr((b"wb\0".as_ptr().cast_mut()).cast_const() as *const i8)
-            .to_str()
-            .expect("invalid c-string")
-        {
-            v if v == "rb" => std::fs::OpenOptions::new()
-                .read(true)
-                .open(
-                    std::ffi::CStr::from_ptr(path as *const i8)
-                        .to_str()
-                        .expect("invalid c-string"),
-                )
-                .ok()
-                .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-            v if v == "wb" => std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(
-                    std::ffi::CStr::from_ptr(path as *const i8)
-                        .to_str()
-                        .expect("invalid c-string"),
-                )
-                .ok()
-                .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-            _ => panic!("unsupported mode"),
-        };
-    assert!((((!((fp).is_null())) as i32) != 0));
-    assert!(
-        (((({
-            Box::from_raw(fp);
-            0
-        }) == (0)) as i32)
-            != 0)
+    let mut fp: *mut ::libc::FILE = libc::fopen(
+        path as *const i8,
+        (b"wb\0".as_ptr().cast_mut()).cast_const() as *const i8,
     );
+    assert!((((!((fp).is_null())) as i32) != 0));
+    assert!(((((libc::fclose(fp)) == (0)) as i32) != 0));
     assert!(((((libc::unlink(path as *const i8)) == (0)) as i32) != 0));
     assert!(((((libc::unlink(path as *const i8)) == (-1_i32)) as i32) != 0));
 }
@@ -373,116 +202,27 @@ pub unsafe fn test_pipe_4() {
 pub unsafe fn test_ftruncate_5() {
     let mut path: *const u8 =
         (b"/tmp/cpp2rust_ftruncate_test.tmp\0".as_ptr().cast_mut()).cast_const();
-    let mut fp: *mut ::std::fs::File =
-        match std::ffi::CStr::from_ptr((b"wb\0".as_ptr().cast_mut()).cast_const() as *const i8)
-            .to_str()
-            .expect("invalid c-string")
-        {
-            v if v == "rb" => std::fs::OpenOptions::new()
-                .read(true)
-                .open(
-                    std::ffi::CStr::from_ptr(path as *const i8)
-                        .to_str()
-                        .expect("invalid c-string"),
-                )
-                .ok()
-                .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-            v if v == "wb" => std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(
-                    std::ffi::CStr::from_ptr(path as *const i8)
-                        .to_str()
-                        .expect("invalid c-string"),
-                )
-                .ok()
-                .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-            _ => panic!("unsupported mode"),
-        };
+    let mut fp: *mut ::libc::FILE = libc::fopen(
+        path as *const i8,
+        (b"wb\0".as_ptr().cast_mut()).cast_const() as *const i8,
+    );
     assert!((((!((fp).is_null())) as i32) != 0));
-    {
-        let bytes = std::ffi::CStr::from_ptr(
-            (b"hello world\0".as_ptr().cast_mut()).cast_const() as *const i8
-        )
-        .to_bytes();
-        match (*fp).write_all(bytes) {
-            Ok(()) => 0,
-            Err(_) => -1,
-        }
-    };
-    if !(fp).is_null() {
-        match (*fp).sync_all() {
-            Ok(_) => 0,
-            Err(_) => -1,
-        }
-    } else {
-        ::std::io::stdout().flush().unwrap();
-        ::std::io::stderr().flush().unwrap();
-        0
-    };
-    let mut fd: i32 = if fp == libcc2rs::cin_unsafe() {
-        0
-    } else if fp == libcc2rs::cout_unsafe() {
-        1
-    } else if fp == libcc2rs::cerr_unsafe() {
-        2
-    } else {
-        ::std::os::fd::AsRawFd::as_raw_fd(&*fp)
-    };
+    libc::fputs(
+        (b"hello world\0".as_ptr().cast_mut()).cast_const() as *const i8,
+        fp,
+    );
+    libc::fflush(fp);
+    let mut fd: i32 = libc::fileno(fp);
     assert!(((((libc::ftruncate(fd, 5_i64)) == (0)) as i32) != 0));
-    assert!(
-        (((({
-            Box::from_raw(fp);
-            0
-        }) == (0)) as i32)
-            != 0)
+    assert!(((((libc::fclose(fp)) == (0)) as i32) != 0));
+    fp = libc::fopen(
+        path as *const i8,
+        (b"rb\0".as_ptr().cast_mut()).cast_const() as *const i8,
     );
-    fp = match std::ffi::CStr::from_ptr((b"rb\0".as_ptr().cast_mut()).cast_const() as *const i8)
-        .to_str()
-        .expect("invalid c-string")
-    {
-        v if v == "rb" => std::fs::OpenOptions::new()
-            .read(true)
-            .open(
-                std::ffi::CStr::from_ptr(path as *const i8)
-                    .to_str()
-                    .expect("invalid c-string"),
-            )
-            .ok()
-            .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-        v if v == "wb" => std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(
-                std::ffi::CStr::from_ptr(path as *const i8)
-                    .to_str()
-                    .expect("invalid c-string"),
-            )
-            .ok()
-            .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-        _ => panic!("unsupported mode"),
-    };
     assert!((((!((fp).is_null())) as i32) != 0));
-    fd = (if fp == libcc2rs::cin_unsafe() {
-        0
-    } else if fp == libcc2rs::cout_unsafe() {
-        1
-    } else if fp == libcc2rs::cerr_unsafe() {
-        2
-    } else {
-        ::std::os::fd::AsRawFd::as_raw_fd(&*fp)
-    })
-    .clone();
+    fd = (libc::fileno(fp)).clone();
     assert!(((((libc::lseek(fd, 0_i64, 2)) == (5_i64)) as i32) != 0));
-    assert!(
-        (((({
-            Box::from_raw(fp);
-            0
-        }) == (0)) as i32)
-            != 0)
-    );
+    assert!(((((libc::fclose(fp)) == (0)) as i32) != 0));
     libc::unlink(path as *const i8);
 }
 pub unsafe fn test_isatty_6() {

--- a/tests/unit/out/unsafe/user_defined_same_as_libc.rs
+++ b/tests/unit/out/unsafe/user_defined_same_as_libc.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-pub unsafe fn fopen_0(mut path: *const u8, mut mode: *const u8) -> *mut ::std::fs::File {
+pub unsafe fn fopen_0(mut path: *const u8, mut mode: *const u8) -> *mut ::libc::FILE {
     &(path);
     &(mode);
     return std::ptr::null_mut();
@@ -17,7 +17,7 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut fp: *mut ::std::fs::File = (unsafe {
+    let mut fp: *mut ::libc::FILE = (unsafe {
         let _path: *const u8 = (b"/tmp/irrelevant-file\0".as_ptr().cast_mut()).cast_const();
         let _mode: *const u8 = (b"r\0".as_ptr().cast_mut()).cast_const();
         fopen_0(_path, _mode)

--- a/tests/unit/out/unsafe/va_arg_non_primitive_ptrs.rs
+++ b/tests/unit/out/unsafe/va_arg_non_primitive_ptrs.rs
@@ -45,7 +45,7 @@ pub unsafe fn dispatch_0(mut option: i32, __args: &[VaArg]) -> i32 {
                 break 'switch;
             }
             v if v == (opt::OPT_FILE as i32) => {
-                let mut f: *mut ::std::fs::File = ap.arg::<*mut ::std::fs::File>();
+                let mut f: *mut ::libc::FILE = ap.arg::<*mut ::libc::FILE>();
                 result = ((!((f).is_null())) as i32).clone();
                 break 'switch;
             }
@@ -83,7 +83,7 @@ unsafe fn main_0() -> i32 {
     assert!(
         ((((unsafe {
             let _option: i32 = (opt::OPT_FILE as i32);
-            dispatch_0(_option, &[libcc2rs::cout_unsafe().into()])
+            dispatch_0(_option, &[libcc2rs::stdout_unsafe().into()])
         }) == (1)) as i32)
             != 0)
     );
@@ -92,7 +92,7 @@ unsafe fn main_0() -> i32 {
             let _option: i32 = (opt::OPT_FILE as i32);
             dispatch_0(
                 _option,
-                &[((0 as *mut ::libc::c_void) as *mut ::std::fs::File).into()],
+                &[((0 as *mut ::libc::c_void) as *mut ::libc::FILE).into()],
             )
         }) == (0)) as i32)
             != 0)


### PR DESCRIPTION
Currently we translate `FILE*` as `*mut std::fs:FILE`. This makes it difficult to translate functions such as feof and ferrror.

feof and ferror both peek the internal state of the FILE object. std::fs::File doet not keep an internal state, it propagates the error right at the point of the usage, for example when performing a read or a write. On the other side, `*mut libc::FILE`, which is the direct FFI equivalent of `FILE*`, keeps the internal state, making the translation of feof and ferror easy.

Another advantage of switching to `*mut libc::FILE` is that it simplifies all stdio.h rules. For example fwrites becomes a simple call to `libc::fwrite`, instead of the hand-rolled implementation that we have now for writing a buffer into `std::fs::File`.