### PR TITLE
Use ConvertPointeeType instead of Convert(t->getPointeeType())

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -86,6 +86,19 @@ bool Converter::ConvertMappedType(clang::QualType qual_type) {
   return true;
 }
 
+std::string Converter::ConvertPointeeType(clang::QualType ptr_type) {
+  assert(!ptr_type.isNull() && ptr_type->isPointerType());
+  auto pointee = ptr_type->getPointeeType();
+  if (!pointee->isRecordType()) {
+    return ToString(pointee);
+  }
+
+  auto str = ToString(ptr_type);
+  Unwrap(str, "*mut ", "");
+  Unwrap(str, "*const ", "");
+  return str;
+}
+
 bool Converter::VisitBuiltinType(clang::BuiltinType *type) {
   switch (type->getKind()) {
   case clang::BuiltinType::Bool:
@@ -216,9 +229,8 @@ bool Converter::VisitIncompleteArrayType(clang::IncompleteArrayType *type) {
 }
 
 bool Converter::VisitLValueReferenceType(clang::LValueReferenceType *type) {
-  StrCat(token::kStar);
   auto pointee_type = type->getPointeeType();
-  StrCat(pointee_type.isConstQualified() ? keyword::kConst : keyword_mut_);
+  StrCat(pointee_type.isConstQualified() ? "*const" : "*mut");
   return Convert(pointee_type);
 }
 
@@ -250,9 +262,8 @@ bool Converter::VisitPointerType(clang::PointerType *type) {
     return false;
   }
 
-  StrCat(token::kStar);
   auto pointee_type = type->getPointeeType();
-  StrCat(pointee_type.isConstQualified() ? keyword::kConst : keyword_mut_);
+  StrCat(pointee_type.isConstQualified() ? "*const" : "*mut");
   if (pointee_type->isRecordType() &&
       abstract_structs_.contains(GetID(pointee_type->getAsRecordDecl()))) {
     StrCat(keyword::kDyn);
@@ -1850,7 +1861,7 @@ bool Converter::VisitImplicitCastExpr(clang::ImplicitCastExpr *expr) {
     if (type->isVoidPointerType()) {
       StrCat(keyword::kAs,
              type->getPointeeType().isConstQualified() ? "*const" : "*mut");
-      Convert(sub_expr->getType()->getPointeeType());
+      StrCat(ConvertPointeeType(sub_expr->getType()));
     }
     ConvertCast(type);
     break;
@@ -2109,7 +2120,7 @@ void Converter::ConvertBinaryOperator(clang::BinaryOperator *expr) {
         StrCat(keyword::kAs, "usize");
       }
       StrCat(token::kDiv);
-      auto pointee_type_as_string = ToString(lhs_type->getPointeeType());
+      auto pointee_type_as_string = ConvertPointeeType(lhs_type);
       auto size_of_as_string =
           std::format("::std::mem::size_of::<{}>()", pointee_type_as_string);
       StrCat(size_of_as_string);

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -398,6 +398,8 @@ protected:
   virtual bool Convert(clang::QualType qual_type);
   virtual bool ConvertMappedType(clang::QualType qual_type);
 
+  virtual std::string ConvertPointeeType(clang::QualType ptr_type);
+
   virtual bool Convert(clang::Decl *decl);
   virtual bool Convert(clang::Stmt *stmt);
   virtual bool Convert(clang::Expr *expr);

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -1080,9 +1080,9 @@ bool ConverterRefCount::VisitImplicitCastExpr(clang::ImplicitCastExpr *expr) {
 
       if (pointee_type && abstract_structs_.contains(GetID(pointee_type))) {
         PushConversionKind push(*this, ConversionKind::Unboxed);
-        StrCat(std::format("({}.to_strong() as Value<dyn {}>).as_pointer_dyn()",
+        StrCat(std::format("({}.to_strong() as Value<{}>).as_pointer_dyn()",
                            ToString(sub_expr->IgnoreCasts()),
-                           ToString(expr->getType()->getPointeeType())));
+                           ConvertPointeeType(expr->getType())));
         computed_expr_type_ = ComputedExprType::FreshPointer;
         return false;
       }
@@ -1222,6 +1222,12 @@ bool ConverterRefCount::VisitExplicitCastExpr(clang::ExplicitCastExpr *expr) {
       PushConversionKind push(*this, ConversionKind::Unboxed);
       StrCat(std::format(".cast::<{}>().expect(\"ub:wrong type\")",
                          ConvertPointeeType(expr->getType())));
+      return false;
+    } else if (expr->getType()->isVoidPointerType() &&
+               expr->getSubExpr()->getType()->isPointerType()) {
+      StrCat(
+          std::format("{}.to_any()", ConvertFreshPointer(expr->getSubExpr())));
+      computed_expr_type_ = ComputedExprType::FreshPointer;
       return false;
     } else if (expr->getSubExpr()->getType()->isPointerType() &&
                !expr->getSubExpr()->isNullPointerConstant(
@@ -2321,6 +2327,7 @@ std::string ConverterRefCount::ConvertPointeeType(clang::QualType ptr_type) {
   // not have a translation rule. Hence ToString(ptr_type->getPointeeType()) is
   // not enough
   auto str = ToString(ptr_type);
+  Unwrap(str, "PtrDyn<", ">");
   Unwrap(str, "Ptr<", ">");
   return str;
 }

--- a/cpp2rust/converter/models/converter_refcount.h
+++ b/cpp2rust/converter/models/converter_refcount.h
@@ -216,7 +216,7 @@ private:
   std::string ConvertFreshPointer(clang::Expr *expr) override;
 
   std::string ConvertPtrType(clang::QualType type);
-  std::string ConvertPointeeType(clang::QualType ptr_type);
+  std::string ConvertPointeeType(clang::QualType ptr_type) override;
 
   /// The kind of conversion that should be performed.
   enum class ConversionKind : uint8_t {

--- a/tests/unit/out/refcount/ptr_to_incomplete_struct.rs
+++ b/tests/unit/out/refcount/ptr_to_incomplete_struct.rs
@@ -1,0 +1,29 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let fp: Value<Ptr<::std::fs::File>> = Rc::new(RefCell::new((libcc2rs::cout()).clone()));
+    let p: Value<AnyPtr> = Rc::new(RefCell::new((*fp.borrow()).clone().to_any()));
+    let fp2: Value<Ptr<::std::fs::File>> = Rc::new(RefCell::new(
+        ((*p.borrow())
+            .cast::<::std::fs::File>()
+            .expect("ub:wrong type"))
+        .clone(),
+    ));
+    assert!(
+        ((({
+            let _lhs = (*fp.borrow()).clone();
+            _lhs == (*fp2.borrow()).clone()
+        }) as i32)
+            != 0)
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/ptr_to_incomplete_struct.rs
+++ b/tests/unit/out/unsafe/ptr_to_incomplete_struct.rs
@@ -12,9 +12,9 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut fp: *mut ::std::fs::File = libcc2rs::cout_unsafe();
+    let mut fp: *mut ::libc::FILE = libcc2rs::stdout_unsafe();
     let mut p: *mut ::libc::c_void = (fp as *mut ::libc::c_void);
-    let mut fp2: *mut ::std::fs::File = (p as *mut ::std::fs::File);
+    let mut fp2: *mut ::libc::FILE = (p as *mut ::libc::FILE);
     assert!(((((fp) == (fp2)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/ptr_to_incomplete_struct.rs
+++ b/tests/unit/out/unsafe/ptr_to_incomplete_struct.rs
@@ -1,0 +1,20 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut fp: *mut ::libc::FILE = libcc2rs::stdout_unsafe();
+    let mut p: *mut ::libc::c_void = (fp as *mut ::libc::c_void);
+    let mut fp2: *mut ::libc::FILE = (p as *mut ::libc::FILE);
+    assert!(((((fp) == (fp2)) as i32) != 0));
+    return 0;
+}

--- a/tests/unit/out/unsafe/ptr_to_incomplete_struct.rs
+++ b/tests/unit/out/unsafe/ptr_to_incomplete_struct.rs
@@ -12,9 +12,9 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut fp: *mut ::libc::FILE = libcc2rs::stdout_unsafe();
+    let mut fp: *mut ::std::fs::File = libcc2rs::cout_unsafe();
     let mut p: *mut ::libc::c_void = (fp as *mut ::libc::c_void);
-    let mut fp2: *mut ::libc::FILE = (p as *mut ::libc::FILE);
+    let mut fp2: *mut ::std::fs::File = (p as *mut ::std::fs::File);
     assert!(((((fp) == (fp2)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/sys_stat.rs
+++ b/tests/unit/out/unsafe/sys_stat.rs
@@ -8,50 +8,16 @@ use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn test_stat_0() {
     let mut path: *const u8 = (b"/tmp/cpp2rust_stat_test.tmp\0".as_ptr().cast_mut()).cast_const();
-    let mut fp: *mut ::std::fs::File =
-        match std::ffi::CStr::from_ptr((b"wb\0".as_ptr().cast_mut()).cast_const() as *const i8)
-            .to_str()
-            .expect("invalid c-string")
-        {
-            v if v == "rb" => std::fs::OpenOptions::new()
-                .read(true)
-                .open(
-                    std::ffi::CStr::from_ptr(path as *const i8)
-                        .to_str()
-                        .expect("invalid c-string"),
-                )
-                .ok()
-                .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-            v if v == "wb" => std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(
-                    std::ffi::CStr::from_ptr(path as *const i8)
-                        .to_str()
-                        .expect("invalid c-string"),
-                )
-                .ok()
-                .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-            _ => panic!("unsupported mode"),
-        };
-    assert!((((!((fp).is_null())) as i32) != 0));
-    {
-        let bytes =
-            std::ffi::CStr::from_ptr((b"hello\0".as_ptr().cast_mut()).cast_const() as *const i8)
-                .to_bytes();
-        match (*fp).write_all(bytes) {
-            Ok(()) => 0,
-            Err(_) => -1,
-        }
-    };
-    assert!(
-        (((({
-            Box::from_raw(fp);
-            0
-        }) == (0)) as i32)
-            != 0)
+    let mut fp: *mut ::libc::FILE = libc::fopen(
+        path as *const i8,
+        (b"wb\0".as_ptr().cast_mut()).cast_const() as *const i8,
     );
+    assert!((((!((fp).is_null())) as i32) != 0));
+    libc::fputs(
+        (b"hello\0".as_ptr().cast_mut()).cast_const() as *const i8,
+        fp,
+    );
+    assert!(((((libc::fclose(fp)) == (0)) as i32) != 0));
     let mut st: stat = std::mem::zeroed::<stat>();
     assert!(((((libc::stat(path as *const i8, (&mut st as *mut stat))) == (0)) as i32) != 0));
     assert!(((((st.st_size) == (5_i64)) as i32) != 0));
@@ -59,73 +25,21 @@ pub unsafe fn test_stat_0() {
 }
 pub unsafe fn test_fstat_1() {
     let mut path: *const u8 = (b"/tmp/cpp2rust_fstat_test.tmp\0".as_ptr().cast_mut()).cast_const();
-    let mut fp: *mut ::std::fs::File =
-        match std::ffi::CStr::from_ptr((b"wb\0".as_ptr().cast_mut()).cast_const() as *const i8)
-            .to_str()
-            .expect("invalid c-string")
-        {
-            v if v == "rb" => std::fs::OpenOptions::new()
-                .read(true)
-                .open(
-                    std::ffi::CStr::from_ptr(path as *const i8)
-                        .to_str()
-                        .expect("invalid c-string"),
-                )
-                .ok()
-                .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-            v if v == "wb" => std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(
-                    std::ffi::CStr::from_ptr(path as *const i8)
-                        .to_str()
-                        .expect("invalid c-string"),
-                )
-                .ok()
-                .map_or(std::ptr::null_mut(), |f| Box::into_raw(Box::new(f))),
-            _ => panic!("unsupported mode"),
-        };
+    let mut fp: *mut ::libc::FILE = libc::fopen(
+        path as *const i8,
+        (b"wb\0".as_ptr().cast_mut()).cast_const() as *const i8,
+    );
     assert!((((!((fp).is_null())) as i32) != 0));
-    {
-        let bytes = std::ffi::CStr::from_ptr(
-            (b"hello world\0".as_ptr().cast_mut()).cast_const() as *const i8
-        )
-        .to_bytes();
-        match (*fp).write_all(bytes) {
-            Ok(()) => 0,
-            Err(_) => -1,
-        }
-    };
-    if !(fp).is_null() {
-        match (*fp).sync_all() {
-            Ok(_) => 0,
-            Err(_) => -1,
-        }
-    } else {
-        ::std::io::stdout().flush().unwrap();
-        ::std::io::stderr().flush().unwrap();
-        0
-    };
-    let mut fd: i32 = if fp == libcc2rs::cin_unsafe() {
-        0
-    } else if fp == libcc2rs::cout_unsafe() {
-        1
-    } else if fp == libcc2rs::cerr_unsafe() {
-        2
-    } else {
-        ::std::os::fd::AsRawFd::as_raw_fd(&*fp)
-    };
+    libc::fputs(
+        (b"hello world\0".as_ptr().cast_mut()).cast_const() as *const i8,
+        fp,
+    );
+    libc::fflush(fp);
+    let mut fd: i32 = libc::fileno(fp);
     let mut st: stat = std::mem::zeroed::<stat>();
     assert!(((((libc::fstat(fd, (&mut st as *mut stat))) == (0)) as i32) != 0));
     assert!(((((st.st_size) == (11_i64)) as i32) != 0));
-    assert!(
-        (((({
-            Box::from_raw(fp);
-            0
-        }) == (0)) as i32)
-            != 0)
-    );
+    assert!(((((libc::fclose(fp)) == (0)) as i32) != 0));
     libc::unlink(path as *const i8);
 }
 pub fn main() {

--- a/tests/unit/ptr_to_incomplete_struct.c
+++ b/tests/unit/ptr_to_incomplete_struct.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+#include <stdio.h>
+
+int main(void) {
+  FILE *fp = stdout;
+  void *p = (void *)fp;
+  FILE *fp2 = (FILE *)p;
+  assert(fp == fp2);
+  return 0;
+}


### PR DESCRIPTION
`Convert(t->getPointeeType())` does not handle pointers to incomplete types, `ConvertPointeeType` does.