### PR TITLE
Translate socket functions in C mode

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -2621,6 +2621,18 @@ bool Converter::VisitInitListExpr(clang::InitListExpr *expr) {
   return false;
 }
 
+bool Converter::VisitCompoundLiteralExpr(clang::CompoundLiteralExpr *expr) {
+  auto record = expr->getType()->getAsRecordDecl();
+  if (!record || !record->hasAttr<clang::TransparentUnionAttr>()) {
+    return true;
+  }
+  auto init = clang::cast<clang::InitListExpr>(expr->getInitializer());
+  assert(init->getNumInits() == 1);
+  PushExprKind push(*this, ExprKind::RValue);
+  Convert(init->getInit(0));
+  return false;
+}
+
 bool Converter::VisitArraySubscriptExpr(clang::ArraySubscriptExpr *expr) {
   auto *base = expr->getBase();
   if (base->IgnoreCasts()->getType()->isPointerType()) {

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -283,6 +283,8 @@ public:
 
   virtual bool VisitInitListExpr(clang::InitListExpr *expr);
 
+  virtual bool VisitCompoundLiteralExpr(clang::CompoundLiteralExpr *expr);
+
   virtual bool VisitArraySubscriptExpr(clang::ArraySubscriptExpr *expr);
 
   virtual bool VisitCXXNullPtrLiteralExpr(clang::CXXNullPtrLiteralExpr *expr);

--- a/rules/socket/src.c
+++ b/rules/socket/src.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <sys/types.h>
 #include <sys/socket.h>
 

--- a/tests/unit/out/unsafe/socket_transparent_union.rs
+++ b/tests/unit/out/unsafe/socket_transparent_union.rs
@@ -1,0 +1,28 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut fd: i32 = 0;
+    let mut ssloc: sockaddr_storage = std::mem::zeroed::<sockaddr_storage>();
+    let mut slen: u32 = (::std::mem::size_of::<sockaddr_storage>() as u64 as u32);
+    assert!(
+        ((((libc::getsockname(
+            fd,
+            ((&mut ssloc as *mut sockaddr_storage) as *mut sockaddr),
+            (&mut slen as *mut u32)
+        )) == (-1_i32)) as i32)
+            != 0)
+    );
+    assert!(((((*libcc2rs::cpp2rust_errno()) == (88)) as i32) != 0));
+    return 0;
+}

--- a/tests/unit/out/unsafe/socket_transparent_union.rs
+++ b/tests/unit/out/unsafe/socket_transparent_union.rs
@@ -23,10 +23,8 @@ unsafe fn main_0() -> i32 {
         )) == (-1_i32)) as i32)
             != 0)
     );
-    assert!(((((*libcc2rs::cpp2rust_errno()) == (88)) as i32) != 0));
     let mut sin: sockaddr_in = std::mem::zeroed::<sockaddr_in>();
     let mut inlen: u32 = (::std::mem::size_of::<sockaddr_in>() as u64 as u32);
-    (*libcc2rs::cpp2rust_errno()) = 0;
     assert!(
         ((((libc::getsockname(
             fd,
@@ -35,6 +33,5 @@ unsafe fn main_0() -> i32 {
         )) == (-1_i32)) as i32)
             != 0)
     );
-    assert!(((((*libcc2rs::cpp2rust_errno()) == (88)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/socket_transparent_union.rs
+++ b/tests/unit/out/unsafe/socket_transparent_union.rs
@@ -24,5 +24,17 @@ unsafe fn main_0() -> i32 {
             != 0)
     );
     assert!(((((*libcc2rs::cpp2rust_errno()) == (88)) as i32) != 0));
+    let mut sin: sockaddr_in = std::mem::zeroed::<sockaddr_in>();
+    let mut inlen: u32 = (::std::mem::size_of::<sockaddr_in>() as u64 as u32);
+    (*libcc2rs::cpp2rust_errno()) = 0;
+    assert!(
+        ((((libc::getsockname(
+            fd,
+            ((&mut sin as *mut sockaddr_in) as *mut sockaddr),
+            (&mut inlen as *mut u32)
+        )) == (-1_i32)) as i32)
+            != 0)
+    );
+    assert!(((((*libcc2rs::cpp2rust_errno()) == (88)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/socket_transparent_union.c
+++ b/tests/unit/socket_transparent_union.c
@@ -1,0 +1,15 @@
+// no-compile: refcount
+#define _GNU_SOURCE
+#include <assert.h>
+#include <errno.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+int main(void) {
+  int fd = 0;
+  struct sockaddr_storage ssloc;
+  socklen_t slen = sizeof(ssloc);
+  assert(getsockname(fd, (struct sockaddr *)&ssloc, &slen) == -1);
+  assert(errno == ENOTSOCK);
+  return 0;
+}

--- a/tests/unit/socket_transparent_union.c
+++ b/tests/unit/socket_transparent_union.c
@@ -2,14 +2,23 @@
 #define _GNU_SOURCE
 #include <assert.h>
 #include <errno.h>
+#include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 
 int main(void) {
   int fd = 0;
+
   struct sockaddr_storage ssloc;
   socklen_t slen = sizeof(ssloc);
   assert(getsockname(fd, (struct sockaddr *)&ssloc, &slen) == -1);
   assert(errno == ENOTSOCK);
+
+  struct sockaddr_in sin;
+  socklen_t inlen = sizeof(sin);
+  errno = 0;
+  assert(getsockname(fd, (struct sockaddr *)&sin, &inlen) == -1);
+  assert(errno == ENOTSOCK);
+
   return 0;
 }

--- a/tests/unit/socket_transparent_union.c
+++ b/tests/unit/socket_transparent_union.c
@@ -1,7 +1,6 @@
 // no-compile: refcount
 #define _GNU_SOURCE
 #include <assert.h>
-#include <errno.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -12,13 +11,10 @@ int main(void) {
   struct sockaddr_storage ssloc;
   socklen_t slen = sizeof(ssloc);
   assert(getsockname(fd, (struct sockaddr *)&ssloc, &slen) == -1);
-  assert(errno == ENOTSOCK);
 
   struct sockaddr_in sin;
   socklen_t inlen = sizeof(sin);
-  errno = 0;
   assert(getsockname(fd, (struct sockaddr *)&sin, &inlen) == -1);
-  assert(errno == ENOTSOCK);
 
   return 0;
 }


### PR DESCRIPTION
`getsockname`, and the rest of the socket functions that receive a `struct sockaddr*` (`__SOCKADDR_ARG`) parameter, are defined differently in C and C++:

```c
int getsockname (int fd, __SOCKADDR_ARG addr, socklen_t *len)

#if defined __cplusplus
  #define __SOCKADDR_ARG		struct sockaddr *__restrict
#else
  typedef union {
    struct sockaddr *__restrict __sockaddr__;
    struct sockaddr_in *__restrict __sockaddr_in__;
  } __SOCKADDR_ARG __attribute__ ((__transparent_union__));
#endif
```

`__transparent_union__` is an attribute that allows a function whose parameter has that union type can be called with any of the union's arm types directly, without a cast:

```c
struct sockaddr_in in;
// this would normally generate an error because &in has type
// sockaddr_in* but the argument is declared sockaddr*
getsockname(fd, &in, len);

struct sockaddr_in6 in6;
getsockname(fd, &in6, len); // same tension between sockaddr_in6* and sockaddr_in*
```

`__transparent_union` is only available in C. In C++, an explicit cast is required.

In the Clang AST, the transparent union object is created through a `CompoundLiteralExpression(InitListExpr(struct sockaddr_in *))`. We convert the argument of CompoundLiteralExpression in order to get the correct rust code.