### PR TITLE
Add rules for strerror_r and gettimeofday

### DIFF
--- a/rules/cstring/src.c
+++ b/rules/cstring/src.c
@@ -40,3 +40,7 @@ void *f24(const void *a0, int a1, size_t a2) { return memrchr(a0, a1, a2); }
 #endif
 
 int f27(const char *a0, const char *a1) { return strcasecmp(a0, a1); }
+
+char *f28(int errnum, char *buf, size_t buflen) {
+    return strerror_r(errnum, buf, buflen);
+}

--- a/rules/cstring/src.c
+++ b/rules/cstring/src.c
@@ -41,6 +41,14 @@ void *f24(const void *a0, int a1, size_t a2) { return memrchr(a0, a1, a2); }
 
 int f27(const char *a0, const char *a1) { return strcasecmp(a0, a1); }
 
+#if defined(__linux__)
 char *f28(int errnum, char *buf, size_t buflen) {
     return strerror_r(errnum, buf, buflen);
 }
+#elif defined(__APPLE__)
+int f28(int errnum, char *buf, size_t buflen) {
+    return strerror_r(errnum, buf, buflen);
+}
+#else
+#error "Unsupported platform for strerror_r"
+#endif

--- a/rules/cstring/tgt_unsafe.rs
+++ b/rules/cstring/tgt_unsafe.rs
@@ -138,7 +138,13 @@ unsafe fn f27(a0: *const u8, a1: *const u8) -> i32 {
 // (immutable) static string (in which case buf is unused)
 //
 // So it's not 100% correct to always return a1. But the Rust libc version only returns int.
+#[cfg(target_os = "linux")]
 unsafe fn f28(a0: i32, a1: *mut u8, a2: usize) -> *mut u8 {
     libc::strerror_r(a0, a1 as *mut i8, a2 as usize);
     a1
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn f28(a0: i32, a1: *mut u8, a2: usize) -> i32 {
+    libc::strerror_r(a0, a1 as *mut i8, a2 as usize)
 }

--- a/rules/cstring/tgt_unsafe.rs
+++ b/rules/cstring/tgt_unsafe.rs
@@ -130,3 +130,15 @@ unsafe fn f26(a0: *mut u8, a1: i32, a2: usize) -> *mut ::libc::c_void {
 unsafe fn f27(a0: *const u8, a1: *const u8) -> i32 {
     libc::strcasecmp(a0 as *const i8, a1 as *const i8)
 }
+
+// From the man page:
+//
+// The GNU-specific strerror_r() returns a pointer to a string containing the error message.  This
+// may be either a pointer to a string that the function stores in buf, or a  pointer to some
+// (immutable) static string (in which case buf is unused)
+//
+// So it's not 100% correct to always return a1. But the Rust libc version only returns int.
+unsafe fn f28(a0: i32, a1: *mut u8, a2: usize) -> *mut u8 {
+    libc::strerror_r(a0, a1 as *mut i8, a2 as usize);
+    a1
+}

--- a/rules/time/src.c
+++ b/rules/time/src.c
@@ -25,3 +25,15 @@ size_t f6(char *s, size_t maxsize, const char *format, const struct tm *tp) {
 int f7(const char *file, const struct timeval tvp[2]) {
   return utimes(file, tvp);
 }
+
+#if defined(__linux__)
+int f8(struct timeval *tv, struct timezone *tz) {
+  return gettimeofday(tv, tz);
+}
+#elif defined(__APPLE__)
+int f8(struct timeval *tv, void *tz) {
+  return gettimeofday(tv, tz);
+}
+#else
+#error "Unsupported platform for gettimeofday"
+#endif

--- a/rules/time/tgt_unsafe.rs
+++ b/rules/time/tgt_unsafe.rs
@@ -27,7 +27,7 @@ unsafe fn f7(a0: *const u8, a1: *const ::libc::timeval) -> i32 {
 
 #[cfg(target_os = "linux")]
 unsafe fn f8(a0: *mut libc::timeval, a1: *mut libc::timezone) -> i32 {
-    libc::gettimeofday(a0, a1)
+    libc::gettimeofday(a0, a1 as *mut libc::timezone)
 }
 
 #[cfg(target_os = "macos")]

--- a/rules/time/tgt_unsafe.rs
+++ b/rules/time/tgt_unsafe.rs
@@ -24,3 +24,13 @@ unsafe fn f6(a0: *mut u8, a1: u64, a2: *const u8, a3: *const ::libc::tm) -> u64 
 unsafe fn f7(a0: *const u8, a1: *const ::libc::timeval) -> i32 {
     libc::utimes(a0 as *const i8, a1)
 }
+
+#[cfg(target_os = "linux")]
+unsafe fn f8(a0: *mut libc::timeval, a1: *mut libc::timezone) -> i32 {
+    libc::gettimeofday(a0, a1)
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn f8(a0: *mut libc::timeval, a1: *mut libc::c_void) -> i32 {
+    libc::gettimeofday(a0, a1)
+}


### PR DESCRIPTION
Both strerror_r and gettimeofday have platform specific signatures. Since the IR is not indexed in git anymore, adding rules for them is easy using a combination of ifdef `__linux__/__APPLE__` + target_os `linux/macos`