### PR TITLE
Add rules for inet_ntop and inet_pton

### DIFF
--- a/rules/arpa_inet/src.cpp
+++ b/rules/arpa_inet/src.cpp
@@ -7,3 +7,7 @@ uint32_t f1(uint32_t x) { return ntohl(x); }
 uint16_t f2(uint16_t x) { return ntohs(x); }
 uint16_t f3(uint16_t x) { return htons(x); }
 uint32_t f4(uint32_t x) { return htonl(x); }
+int f5(int af, const char *src, void *dst) { return inet_pton(af, src, dst); }
+const char *f6(int af, const void *src, char *dst, socklen_t size) {
+  return inet_ntop(af, src, dst, size);
+}

--- a/rules/arpa_inet/tgt_unsafe.rs
+++ b/rules/arpa_inet/tgt_unsafe.rs
@@ -13,3 +13,15 @@ unsafe fn f3(a0: u16) -> u16 {
 unsafe fn f4(a0: u32) -> u32 {
     u32::to_be(a0)
 }
+unsafe fn f5(a0: i32, a1: *const u8, a2: *mut ::libc::c_void) -> i32 {
+    unsafe extern "C" {
+        fn inet_pton(af: i32, src: *const u8, dst: *mut ::libc::c_void) -> i32;
+    }
+    inet_pton(a0, a1, a2)
+}
+unsafe fn f6(a0: i32, a1: *const ::libc::c_void, a2: *mut u8, a3: u32) -> *const u8 {
+    unsafe extern "C" {
+        fn inet_ntop(af: i32, src: *const ::libc::c_void, dst: *mut u8, size: u32) -> *const u8;
+    }
+    inet_ntop(a0, a1, a2, a3)
+}


### PR DESCRIPTION
inet_ntop and inet_pton don't have mappings in Rust libc. I declared them extern because they exist in the linked-against libc.