### PR TITLE
Add Inc and Dec traits for enums

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -2892,6 +2892,7 @@ bool Converter::VisitEnumDecl(clang::EnumDecl *decl) {
   StrCat("}");
 
   AddFromImpl(decl);
+  AddIncDecImpls(decl);
   return false;
 }
 
@@ -2911,6 +2912,10 @@ void Converter::AddFromImpl(clang::EnumDecl *decl) {
                        std::string_view(e->getName())));
   }
   StrCat(std::format("_ => panic!(\"invalid {} value: {{}}\", n),", name));
+}
+
+void Converter::AddIncDecImpls(clang::EnumDecl *decl) {
+  StrCat(std::format("libcc2rs::impl_enum_inc_dec!({});", GetRecordName(decl)));
 }
 
 bool Converter::VisitCXXDefaultArgExpr(clang::CXXDefaultArgExpr *expr) {

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -315,6 +315,8 @@ public:
 
   virtual void AddFromImpl(clang::EnumDecl *decl);
 
+  virtual void AddIncDecImpls(clang::EnumDecl *decl);
+
   virtual bool VisitCXXDefaultArgExpr(clang::CXXDefaultArgExpr *expr);
 
   virtual bool VisitLambdaExpr(clang::LambdaExpr *expr);

--- a/libcc2rs/src/inc.rs
+++ b/libcc2rs/src/inc.rs
@@ -124,6 +124,38 @@ impl<T> UnsafePrefixInc for *mut T {
     }
 }
 
+#[macro_export]
+macro_rules! impl_enum_inc_dec {
+    ($t:ty) => {
+        impl PostfixInc for $t {
+            fn postfix_inc(&mut self) -> Self {
+                let copy = *self;
+                *self = <$t>::from(*self as i32 + 1);
+                copy
+            }
+        }
+        impl PrefixInc for $t {
+            fn prefix_inc(&mut self) -> Self {
+                *self = <$t>::from(*self as i32 + 1);
+                *self
+            }
+        }
+        impl PostfixDec for $t {
+            fn postfix_dec(&mut self) -> Self {
+                let copy = *self;
+                *self = <$t>::from(*self as i32 - 1);
+                copy
+            }
+        }
+        impl PrefixDec for $t {
+            fn prefix_dec(&mut self) -> Self {
+                *self = <$t>::from(*self as i32 - 1);
+                *self
+            }
+        }
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/ub/enum_out_of_range_increment.c
+++ b/tests/ub/enum_out_of_range_increment.c
@@ -1,0 +1,9 @@
+// panic
+
+enum color { RED, GREEN, BLUE };
+
+int main() {
+  enum color c = BLUE;
+  c++;
+  return c == RED ? 0 : 1;
+}

--- a/tests/ub/out/refcount/enum_out_of_range_increment.rs
+++ b/tests/ub/out/refcount/enum_out_of_range_increment.rs
@@ -7,30 +7,30 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Color {
+enum color {
     #[default]
     RED = 0,
     GREEN = 1,
     BLUE = 2,
 }
-impl From<i32> for Color {
-    fn from(n: i32) -> Color {
+impl From<i32> for color {
+    fn from(n: i32) -> color {
         match n {
-            0 => Color::RED,
-            1 => Color::GREEN,
-            2 => Color::BLUE,
-            _ => panic!("invalid Color value: {}", n),
+            0 => color::RED,
+            1 => color::GREEN,
+            2 => color::BLUE,
+            _ => panic!("invalid color value: {}", n),
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Color);
+libcc2rs::impl_enum_inc_dec!(color);
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    let n: Value<i32> = Rc::new(RefCell::new(3));
-    let c: Value<Color> = Rc::new(RefCell::new(Color::from((*n.borrow()))));
-    return if (((*c.borrow()) as i32) == (Color::BLUE as i32)) {
+    let c: Value<color> = Rc::new(RefCell::new(color::BLUE));
+    (*c.borrow_mut()).postfix_inc();
+    return if (((((*c.borrow()) as u32) == ((color::RED as i32) as u32)) as i32) != 0) {
         0
     } else {
         1

--- a/tests/ub/out/unsafe/enum_out_of_range_increment.rs
+++ b/tests/ub/out/unsafe/enum_out_of_range_increment.rs
@@ -7,32 +7,32 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Color {
+enum color {
     #[default]
     RED = 0,
     GREEN = 1,
     BLUE = 2,
 }
-impl From<i32> for Color {
-    fn from(n: i32) -> Color {
+impl From<i32> for color {
+    fn from(n: i32) -> color {
         match n {
-            0 => Color::RED,
-            1 => Color::GREEN,
-            2 => Color::BLUE,
-            _ => panic!("invalid Color value: {}", n),
+            0 => color::RED,
+            1 => color::GREEN,
+            2 => color::BLUE,
+            _ => panic!("invalid color value: {}", n),
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Color);
+libcc2rs::impl_enum_inc_dec!(color);
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut n: i32 = 3;
-    let mut c: Color = Color::from(n);
-    return if ((c as i32) == (Color::BLUE as i32)) {
+    let mut c: color = color::BLUE;
+    c.postfix_inc();
+    return if ((((c as u32) == ((color::RED as i32) as u32)) as i32) != 0) {
         0
     } else {
         1

--- a/tests/unit/enum_increment.c
+++ b/tests/unit/enum_increment.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+
+enum color { RED, GREEN, BLUE, COLOR_LAST };
+
+int main() {
+  int count = 0;
+  for (enum color c = RED; c < COLOR_LAST; c++) {
+    count++;
+  }
+  assert(count == 3);
+
+  enum color c = RED;
+  assert(c++ == RED);
+  assert(++c == BLUE);
+  assert(c-- == BLUE);
+  assert(--c == RED);
+  return 0;
+}

--- a/tests/unit/out/refcount/anonymous_enum.rs
+++ b/tests/unit/out/refcount/anonymous_enum.rs
@@ -21,6 +21,7 @@ impl From<i32> for anon_enum_3 {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(anon_enum_3);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum anon_enum_11 {
     #[default]
@@ -36,6 +37,7 @@ impl From<i32> for anon_enum_11 {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(anon_enum_11);
 #[derive(Default)]
 pub struct S {
     pub a: Value<i32>,
@@ -73,6 +75,7 @@ impl From<i32> for TdEnum {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(TdEnum);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum anon_enum_24 {
     #[default]
@@ -88,6 +91,7 @@ impl From<i32> for anon_enum_24 {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(anon_enum_24);
 #[derive(Default)]
 pub struct WithAnonField {
     pub a: Value<i32>,
@@ -121,7 +125,8 @@ fn main_0() -> i32 {
                 _ => panic!("invalid anon_enum_31 value: {}", n),
             }
         }
-    };
+    }
+    libcc2rs::impl_enum_inc_dec!(anon_enum_31);
     assert!(((anon_enum_3::FIRST_A as i32) != (anon_enum_3::FIRST_B as i32)));
     assert!(((anon_enum_11::SECOND_A as i32) != (anon_enum_11::SECOND_B as i32)));
     assert!(((anon_enum_31::THIRD_A as i32) != (anon_enum_31::THIRD_B as i32)));

--- a/tests/unit/out/refcount/anonymous_enum_c.rs
+++ b/tests/unit/out/refcount/anonymous_enum_c.rs
@@ -21,6 +21,7 @@ impl From<i32> for anon_enum_3 {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(anon_enum_3);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum anon_enum_11 {
     #[default]
@@ -36,6 +37,7 @@ impl From<i32> for anon_enum_11 {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(anon_enum_11);
 #[derive(Default)]
 pub struct S {
     pub a: Value<i32>,
@@ -65,6 +67,7 @@ impl From<i32> for TdEnum {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(TdEnum);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum anon_enum_24 {
     #[default]
@@ -80,6 +83,7 @@ impl From<i32> for anon_enum_24 {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(anon_enum_24);
 #[derive(Default)]
 pub struct WithAnonField {
     pub a: Value<i32>,
@@ -104,7 +108,8 @@ fn main_0() -> i32 {
                 _ => panic!("invalid anon_enum_31 value: {}", n),
             }
         }
-    };
+    }
+    libcc2rs::impl_enum_inc_dec!(anon_enum_31);
     assert!(((((anon_enum_3::FIRST_A as i32) != (anon_enum_3::FIRST_B as i32)) as i32) != 0));
     assert!(((((anon_enum_11::SECOND_A as i32) != (anon_enum_11::SECOND_B as i32)) as i32) != 0));
     assert!(((((anon_enum_31::THIRD_A as i32) != (anon_enum_31::THIRD_B as i32)) as i32) != 0));

--- a/tests/unit/out/refcount/bool_condition_enum.rs
+++ b/tests/unit/out/refcount/bool_condition_enum.rs
@@ -23,6 +23,7 @@ impl From<i32> for Code {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Code);
 pub fn main() {
     std::process::exit(main_0());
 }

--- a/tests/unit/out/refcount/bool_condition_enum_c.rs
+++ b/tests/unit/out/refcount/bool_condition_enum_c.rs
@@ -23,6 +23,7 @@ impl From<i32> for Code {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Code);
 pub fn main() {
     std::process::exit(main_0());
 }

--- a/tests/unit/out/refcount/bool_condition_logical.rs
+++ b/tests/unit/out/refcount/bool_condition_logical.rs
@@ -23,6 +23,7 @@ impl From<i32> for Code {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Code);
 thread_local!(
     pub static side_effect: Value<i32> = Rc::new(RefCell::new(0));
 );

--- a/tests/unit/out/refcount/bool_condition_logical_c.rs
+++ b/tests/unit/out/refcount/bool_condition_logical_c.rs
@@ -23,6 +23,7 @@ impl From<i32> for Code {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Code);
 thread_local!(
     pub static side_effect: Value<i32> = Rc::new(RefCell::new(0));
 );

--- a/tests/unit/out/refcount/c_struct.rs
+++ b/tests/unit/out/refcount/c_struct.rs
@@ -52,6 +52,7 @@ impl From<i32> for Color {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Color);
 #[derive(Default)]
 pub struct Inner {
     pub a: Value<i32>,

--- a/tests/unit/out/refcount/enum_increment.rs
+++ b/tests/unit/out/refcount/enum_increment.rs
@@ -1,0 +1,54 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+enum color {
+    #[default]
+    RED = 0,
+    GREEN = 1,
+    BLUE = 2,
+    COLOR_LAST = 3,
+}
+impl From<i32> for color {
+    fn from(n: i32) -> color {
+        match n {
+            0 => color::RED,
+            1 => color::GREEN,
+            2 => color::BLUE,
+            3 => color::COLOR_LAST,
+            _ => panic!("invalid color value: {}", n),
+        }
+    }
+}
+libcc2rs::impl_enum_inc_dec!(color);
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let count: Value<i32> = Rc::new(RefCell::new(0));
+    let c: Value<color> = Rc::new(RefCell::new(color::RED));
+    'loop_: while (((((*c.borrow()) as u32) < ((color::COLOR_LAST as i32) as u32)) as i32) != 0) {
+        (*count.borrow_mut()).postfix_inc();
+        (*c.borrow_mut()).postfix_inc();
+    }
+    assert!(((((*count.borrow()) == 3) as i32) != 0));
+    let c: Value<color> = Rc::new(RefCell::new(color::RED));
+    assert!(
+        (((((*c.borrow_mut()).postfix_inc() as u32) == ((color::RED as i32) as u32)) as i32) != 0)
+    );
+    assert!(
+        (((((*c.borrow_mut()).prefix_inc() as u32) == ((color::BLUE as i32) as u32)) as i32) != 0)
+    );
+    assert!(
+        (((((*c.borrow_mut()).postfix_dec() as u32) == ((color::BLUE as i32) as u32)) as i32) != 0)
+    );
+    assert!(
+        (((((*c.borrow_mut()).prefix_dec() as u32) == ((color::RED as i32) as u32)) as i32) != 0)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/enum_int_interop.rs
+++ b/tests/unit/out/refcount/enum_int_interop.rs
@@ -23,6 +23,7 @@ impl From<i32> for Color {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Color);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Option {
     #[default]
@@ -42,6 +43,7 @@ impl From<i32> for Option {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Option);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Tag {
     #[default]
@@ -59,6 +61,7 @@ impl From<i32> for Tag {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Tag);
 #[derive(Default)]
 pub struct Entry {
     pub name: Value<Ptr<u8>>,

--- a/tests/unit/out/refcount/enum_int_interop_c.rs
+++ b/tests/unit/out/refcount/enum_int_interop_c.rs
@@ -23,6 +23,7 @@ impl From<i32> for Color {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Color);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Option {
     #[default]
@@ -42,6 +43,7 @@ impl From<i32> for Option {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Option);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Tag {
     #[default]
@@ -59,6 +61,7 @@ impl From<i32> for Tag {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Tag);
 #[derive(Default)]
 pub struct Entry {
     pub name: Value<Ptr<u8>>,

--- a/tests/unit/out/refcount/switch_char.rs
+++ b/tests/unit/out/refcount/switch_char.rs
@@ -47,6 +47,7 @@ impl From<i32> for Color {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Color);
 pub fn main() {
     std::process::exit(main_0());
 }

--- a/tests/unit/out/refcount/switch_enum.rs
+++ b/tests/unit/out/refcount/switch_enum.rs
@@ -23,6 +23,7 @@ impl From<i32> for Color {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Color);
 pub fn switch_enum_0(c: Color) -> i32 {
     let c: Value<Color> = Rc::new(RefCell::new(c));
     'switch: {

--- a/tests/unit/out/refcount/va_arg_non_primitive_ptrs.rs
+++ b/tests/unit/out/refcount/va_arg_non_primitive_ptrs.rs
@@ -31,6 +31,7 @@ impl From<i32> for opt {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(opt);
 pub fn dispatch_0(option: i32, __args: &[VaArg]) -> i32 {
     let option: Value<i32> = Rc::new(RefCell::new(option));
     let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));

--- a/tests/unit/out/unsafe/anonymous_enum.rs
+++ b/tests/unit/out/unsafe/anonymous_enum.rs
@@ -21,6 +21,7 @@ impl From<i32> for anon_enum_3 {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(anon_enum_3);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum anon_enum_11 {
     #[default]
@@ -36,6 +37,7 @@ impl From<i32> for anon_enum_11 {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(anon_enum_11);
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct S {
@@ -56,6 +58,7 @@ impl From<i32> for TdEnum {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(TdEnum);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum anon_enum_24 {
     #[default]
@@ -71,6 +74,7 @@ impl From<i32> for anon_enum_24 {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(anon_enum_24);
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct WithAnonField {
@@ -97,7 +101,8 @@ unsafe fn main_0() -> i32 {
                 _ => panic!("invalid anon_enum_31 value: {}", n),
             }
         }
-    };
+    }
+    libcc2rs::impl_enum_inc_dec!(anon_enum_31);
     assert!(((anon_enum_3::FIRST_A as i32) != (anon_enum_3::FIRST_B as i32)));
     assert!(((anon_enum_11::SECOND_A as i32) != (anon_enum_11::SECOND_B as i32)));
     assert!(((anon_enum_31::THIRD_A as i32) != (anon_enum_31::THIRD_B as i32)));

--- a/tests/unit/out/unsafe/anonymous_enum_c.rs
+++ b/tests/unit/out/unsafe/anonymous_enum_c.rs
@@ -21,6 +21,7 @@ impl From<i32> for anon_enum_3 {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(anon_enum_3);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum anon_enum_11 {
     #[default]
@@ -36,6 +37,7 @@ impl From<i32> for anon_enum_11 {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(anon_enum_11);
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct S {
@@ -56,6 +58,7 @@ impl From<i32> for TdEnum {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(TdEnum);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum anon_enum_24 {
     #[default]
@@ -71,6 +74,7 @@ impl From<i32> for anon_enum_24 {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(anon_enum_24);
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct WithAnonField {
@@ -97,7 +101,8 @@ unsafe fn main_0() -> i32 {
                 _ => panic!("invalid anon_enum_31 value: {}", n),
             }
         }
-    };
+    }
+    libcc2rs::impl_enum_inc_dec!(anon_enum_31);
     assert!(((((anon_enum_3::FIRST_A as i32) != (anon_enum_3::FIRST_B as i32)) as i32) != 0));
     assert!(((((anon_enum_11::SECOND_A as i32) != (anon_enum_11::SECOND_B as i32)) as i32) != 0));
     assert!(((((anon_enum_31::THIRD_A as i32) != (anon_enum_31::THIRD_B as i32)) as i32) != 0));

--- a/tests/unit/out/unsafe/bool_condition_enum.rs
+++ b/tests/unit/out/unsafe/bool_condition_enum.rs
@@ -23,6 +23,7 @@ impl From<i32> for Code {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Code);
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);

--- a/tests/unit/out/unsafe/bool_condition_enum_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_enum_c.rs
@@ -23,6 +23,7 @@ impl From<i32> for Code {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Code);
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);

--- a/tests/unit/out/unsafe/bool_condition_logical.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical.rs
@@ -23,6 +23,7 @@ impl From<i32> for Code {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Code);
 pub static mut side_effect: i32 = unsafe { 0 };
 pub unsafe fn observe_0(mut v: i32) -> i32 {
     side_effect.prefix_inc();

--- a/tests/unit/out/unsafe/bool_condition_logical_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical_c.rs
@@ -23,6 +23,7 @@ impl From<i32> for Code {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Code);
 pub static mut side_effect: i32 = unsafe { 0 };
 pub unsafe fn observe_0(mut v: i32) -> i32 {
     side_effect.prefix_inc();

--- a/tests/unit/out/unsafe/c_struct.rs
+++ b/tests/unit/out/unsafe/c_struct.rs
@@ -41,6 +41,7 @@ impl From<i32> for Color {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Color);
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Inner {

--- a/tests/unit/out/unsafe/enum_increment.rs
+++ b/tests/unit/out/unsafe/enum_increment.rs
@@ -1,0 +1,48 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+enum color {
+    #[default]
+    RED = 0,
+    GREEN = 1,
+    BLUE = 2,
+    COLOR_LAST = 3,
+}
+impl From<i32> for color {
+    fn from(n: i32) -> color {
+        match n {
+            0 => color::RED,
+            1 => color::GREEN,
+            2 => color::BLUE,
+            3 => color::COLOR_LAST,
+            _ => panic!("invalid color value: {}", n),
+        }
+    }
+}
+libcc2rs::impl_enum_inc_dec!(color);
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut count: i32 = 0;
+    let mut c: color = color::RED;
+    'loop_: while ((((c as u32) < ((color::COLOR_LAST as i32) as u32)) as i32) != 0) {
+        count.postfix_inc();
+        c.postfix_inc();
+    }
+    assert!(((((count) == (3)) as i32) != 0));
+    let mut c: color = color::RED;
+    assert!(((((c.postfix_inc() as u32) == ((color::RED as i32) as u32)) as i32) != 0));
+    assert!(((((c.prefix_inc() as u32) == ((color::BLUE as i32) as u32)) as i32) != 0));
+    assert!(((((c.postfix_dec() as u32) == ((color::BLUE as i32) as u32)) as i32) != 0));
+    assert!(((((c.prefix_dec() as u32) == ((color::RED as i32) as u32)) as i32) != 0));
+    return 0;
+}

--- a/tests/unit/out/unsafe/enum_int_interop.rs
+++ b/tests/unit/out/unsafe/enum_int_interop.rs
@@ -23,6 +23,7 @@ impl From<i32> for Color {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Color);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Option {
     #[default]
@@ -42,6 +43,7 @@ impl From<i32> for Option {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Option);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Tag {
     #[default]
@@ -59,6 +61,7 @@ impl From<i32> for Tag {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Tag);
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Entry {

--- a/tests/unit/out/unsafe/enum_int_interop_c.rs
+++ b/tests/unit/out/unsafe/enum_int_interop_c.rs
@@ -23,6 +23,7 @@ impl From<i32> for Color {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Color);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Option {
     #[default]
@@ -42,6 +43,7 @@ impl From<i32> for Option {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Option);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Tag {
     #[default]
@@ -59,6 +61,7 @@ impl From<i32> for Tag {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Tag);
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Entry {

--- a/tests/unit/out/unsafe/switch_char.rs
+++ b/tests/unit/out/unsafe/switch_char.rs
@@ -46,6 +46,7 @@ impl From<i32> for Color {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Color);
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);

--- a/tests/unit/out/unsafe/switch_enum.rs
+++ b/tests/unit/out/unsafe/switch_enum.rs
@@ -23,6 +23,7 @@ impl From<i32> for Color {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Color);
 pub unsafe fn switch_enum_0(mut c: Color) -> i32 {
     'switch: {
         let __match_cond = (c as i32);

--- a/tests/unit/out/unsafe/union_tagged_many_arms.rs
+++ b/tests/unit/out/unsafe/union_tagged_many_arms.rs
@@ -27,6 +27,7 @@ impl From<i32> for Tag {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Tag);
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union Slot_anon_0 {

--- a/tests/unit/out/unsafe/union_tagged_simple.rs
+++ b/tests/unit/out/unsafe/union_tagged_simple.rs
@@ -21,6 +21,7 @@ impl From<i32> for Kind {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Kind);
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union Event_anon_0 {

--- a/tests/unit/out/unsafe/union_tagged_struct_arms.rs
+++ b/tests/unit/out/unsafe/union_tagged_struct_arms.rs
@@ -23,6 +23,7 @@ impl From<i32> for Choice {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Choice);
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Branch_anon_0_anon_0 {

--- a/tests/unit/out/unsafe/union_void_ptr_sized_deref.rs
+++ b/tests/unit/out/unsafe/union_void_ptr_sized_deref.rs
@@ -23,6 +23,7 @@ impl From<i32> for Width {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Width);
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union Sink_anon_0 {

--- a/tests/unit/out/unsafe/va_arg_non_primitive_ptrs.rs
+++ b/tests/unit/out/unsafe/va_arg_non_primitive_ptrs.rs
@@ -31,6 +31,7 @@ impl From<i32> for opt {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(opt);
 pub unsafe fn dispatch_0(mut option: i32, __args: &[VaArg]) -> i32 {
     let mut ap: VaList = VaList::default();
     ap = VaList::new(__args);


### PR DESCRIPTION
This implements PostfixInc, PrefixInc, PostfixDec, PrefixDec for all user defined enum types.

Instead of generatic more than 30 lines of trait implementations per user-defined enum, I declared a macro in libcc2rs that enums call in order to take care of the actual trait implementation.