### PR TITLE
Avoid name collision of static linkage variables

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -393,6 +393,10 @@ void Converter::ConvertVaListVarDecl(clang::VarDecl *decl) {
   StrCat(keyword_mut_, GetNamedDeclAsString(decl), token::kColon, "VaList");
 }
 
+static std::string StaticVarName(const clang::NamedDecl *decl) {
+  return "s_" + ReplaceAll(Mapper::ToString(decl), "::", "_");
+}
+
 bool Converter::ConvertVarDeclSkipInit(clang::VarDecl *decl) {
   auto qual_type = decl->getType();
   auto name = GetNamedDeclAsString(decl);
@@ -403,7 +407,7 @@ bool Converter::ConvertVarDeclSkipInit(clang::VarDecl *decl) {
   }
 
   if (decl->isFileVarDecl()) {
-    name = ReplaceAll(Mapper::ToString(decl), "::", "_");
+    name = StaticVarName(decl);
     if ((decl->isThisDeclarationADefinition() ==
              clang::VarDecl::DeclarationOnly &&
          !decl->hasInit()) ||
@@ -414,6 +418,7 @@ bool Converter::ConvertVarDeclSkipInit(clang::VarDecl *decl) {
            keyword_mut_);
     ENSURE(decl_ids_.insert(GetID(decl)).second);
   } else if (decl->isStaticLocal()) {
+    name = StaticVarName(decl);
     StrCat(keyword::kStatic, keyword_mut_);
   } else if (decl->isLocalVarDecl()) {
     StrCat(keyword::kLet);
@@ -2378,7 +2383,7 @@ std::string Converter::ConvertDeclRefExpr(clang::DeclRefExpr *expr) {
   }
 
   if (IsGlobalVar(expr)) {
-    return ReplaceAll(Mapper::ToString(expr->getDecl()), "::", "_");
+    return StaticVarName(expr->getDecl());
   }
 
   return GetNamedDeclAsString(decl);

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -393,10 +393,6 @@ void Converter::ConvertVaListVarDecl(clang::VarDecl *decl) {
   StrCat(keyword_mut_, GetNamedDeclAsString(decl), token::kColon, "VaList");
 }
 
-static std::string staticVarName(const clang::NamedDecl *decl) {
-  return "s_" + ReplaceAll(Mapper::ToString(decl), "::", "_");
-}
-
 bool Converter::ConvertVarDeclSkipInit(clang::VarDecl *decl) {
   auto qual_type = decl->getType();
   auto name = GetNamedDeclAsString(decl);
@@ -407,7 +403,6 @@ bool Converter::ConvertVarDeclSkipInit(clang::VarDecl *decl) {
   }
 
   if (decl->isFileVarDecl()) {
-    name = staticVarName(decl);
     if ((decl->isThisDeclarationADefinition() ==
              clang::VarDecl::DeclarationOnly &&
          !decl->hasInit()) ||
@@ -418,7 +413,6 @@ bool Converter::ConvertVarDeclSkipInit(clang::VarDecl *decl) {
            keyword_mut_);
     ENSURE(decl_ids_.insert(GetID(decl)).second);
   } else if (decl->isStaticLocal()) {
-    name = staticVarName(decl);
     StrCat(keyword::kStatic, keyword_mut_);
   } else if (decl->isLocalVarDecl()) {
     StrCat(keyword::kLet);
@@ -2383,7 +2377,7 @@ std::string Converter::ConvertDeclRefExpr(clang::DeclRefExpr *expr) {
   }
 
   if (IsGlobalVar(expr)) {
-    return staticVarName(expr->getDecl());
+    return GetNamedDeclAsString(expr->getDecl());
   }
 
   return GetNamedDeclAsString(decl);

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -393,7 +393,7 @@ void Converter::ConvertVaListVarDecl(clang::VarDecl *decl) {
   StrCat(keyword_mut_, GetNamedDeclAsString(decl), token::kColon, "VaList");
 }
 
-static std::string StaticVarName(const clang::NamedDecl *decl) {
+static std::string staticVarName(const clang::NamedDecl *decl) {
   return "s_" + ReplaceAll(Mapper::ToString(decl), "::", "_");
 }
 
@@ -407,7 +407,7 @@ bool Converter::ConvertVarDeclSkipInit(clang::VarDecl *decl) {
   }
 
   if (decl->isFileVarDecl()) {
-    name = StaticVarName(decl);
+    name = staticVarName(decl);
     if ((decl->isThisDeclarationADefinition() ==
              clang::VarDecl::DeclarationOnly &&
          !decl->hasInit()) ||
@@ -418,7 +418,7 @@ bool Converter::ConvertVarDeclSkipInit(clang::VarDecl *decl) {
            keyword_mut_);
     ENSURE(decl_ids_.insert(GetID(decl)).second);
   } else if (decl->isStaticLocal()) {
-    name = StaticVarName(decl);
+    name = staticVarName(decl);
     StrCat(keyword::kStatic, keyword_mut_);
   } else if (decl->isLocalVarDecl()) {
     StrCat(keyword::kLet);
@@ -2383,7 +2383,7 @@ std::string Converter::ConvertDeclRefExpr(clang::DeclRefExpr *expr) {
   }
 
   if (IsGlobalVar(expr)) {
-    return StaticVarName(expr->getDecl());
+    return staticVarName(expr->getDecl());
   }
 
   return GetNamedDeclAsString(decl);

--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -369,6 +369,16 @@ std::string GetID(const clang::Decl *decl) {
 
 static std::unordered_map<std::string, size_t> type_mapping;
 
+static size_t GetDeclId(const clang::NamedDecl *decl, bool internal) {
+  std::string key =
+      clang::ASTNameGenerator(decl->getASTContext()).getName(decl) +
+      GetParamSignature(decl);
+  if (internal) {
+    key += GetLocationID(decl);
+  }
+  return type_mapping.try_emplace(key, type_mapping.size()).first->second;
+}
+
 std::string GetNamedDeclAsString(const clang::NamedDecl *decl) {
   auto name = decl->getDeclName().isIdentifier() ? decl->getName().str()
                                                  : decl->getNameAsString();
@@ -384,19 +394,19 @@ std::string GetNamedDeclAsString(const clang::NamedDecl *decl) {
     return std::format("anon_{}", GetAnonIndex(target));
   }
 
+  std::optional<size_t> id;
   if (auto *fn = clang::dyn_cast<clang::FunctionDecl>(decl)) {
     if (!clang::isa<clang::CXXMethodDecl>(fn)) {
-      auto mangled =
-          clang::ASTNameGenerator(decl->getASTContext()).getName(decl) +
-          GetParamSignature(decl);
-      if (fn->getFormalLinkage() == clang::Linkage::Internal) {
-        mangled += GetLocationID(decl);
-      }
-      auto id =
-          type_mapping.try_emplace(mangled, type_mapping.size()).first->second;
-      name += '_';
-      name += std::to_string(id);
+      id = GetDeclId(decl, fn->getFormalLinkage() == clang::Linkage::Internal);
     }
+  } else if (auto *var = clang::dyn_cast<clang::VarDecl>(decl);
+             var && (var->isFileVarDecl() || var->isStaticLocal())) {
+    id = GetDeclId(var->getCanonicalDecl(),
+                   var->getFormalLinkage() != clang::Linkage::External);
+  }
+  if (id) {
+    name += '_';
+    name += std::to_string(*id);
   }
 
   // transform decl names that are rust keywords:

--- a/tests/multi-file/static_name_collision/CMakeLists.txt
+++ b/tests/multi-file/static_name_collision/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.16)
+project(static_name_collision LANGUAGES C)
+add_executable(app a.c b.c)

--- a/tests/multi-file/static_name_collision/a.c
+++ b/tests/multi-file/static_name_collision/a.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+
+static int same_name_different_type = 1;
+static int same_name_same_type = 5;
+
+int a_foo() { return same_name_different_type; }
+int a_bar() { return same_name_same_type; }
+
+float b_foo();
+int b_bar();
+
+int main(void) {
+  assert(a_foo() == 1);
+  assert(b_foo() == 1.0f);
+  assert(a_bar() == 5);
+  assert(b_bar() == 6);
+  return 0;
+}

--- a/tests/multi-file/static_name_collision/b.c
+++ b/tests/multi-file/static_name_collision/b.c
@@ -1,0 +1,5 @@
+static float same_name_different_type = 1.0f;
+static int same_name_same_type = 6;
+
+float b_foo() { return same_name_different_type; }
+int b_bar() { return same_name_same_type; }

--- a/tests/multi-file/static_name_collision/out/refcount/static_name_collision.rs
+++ b/tests/multi-file/static_name_collision/out/refcount/static_name_collision.rs
@@ -1,0 +1,42 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+thread_local!(
+    pub static same_name_different_type_0: Value<i32> = Rc::new(RefCell::new(1));
+);
+thread_local!(
+    pub static same_name_same_type_1: Value<i32> = Rc::new(RefCell::new(5));
+);
+pub fn a_foo_2() -> i32 {
+    return (*same_name_different_type_0.with(Value::clone).borrow());
+}
+pub fn a_bar_3() -> i32 {
+    return (*same_name_same_type_1.with(Value::clone).borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!((((({ a_foo_2() }) == 1) as i32) != 0));
+    assert!((((({ b_foo_4() }) == 1.0E+0) as i32) != 0));
+    assert!((((({ a_bar_3() }) == 5) as i32) != 0));
+    assert!((((({ b_bar_5() }) == 6) as i32) != 0));
+    return 0;
+}
+thread_local!(
+    pub static same_name_different_type_6: Value<f32> = Rc::new(RefCell::new(1.0E+0));
+);
+thread_local!(
+    pub static same_name_same_type_7: Value<i32> = Rc::new(RefCell::new(6));
+);
+pub fn b_foo_4() -> f32 {
+    return (*same_name_different_type_6.with(Value::clone).borrow());
+}
+pub fn b_bar_5() -> i32 {
+    return (*same_name_same_type_7.with(Value::clone).borrow());
+}

--- a/tests/multi-file/static_name_collision/out/unsafe/static_name_collision.rs
+++ b/tests/multi-file/static_name_collision/out/unsafe/static_name_collision.rs
@@ -1,0 +1,36 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub static mut same_name_different_type_0: i32 = unsafe { 1 };
+pub static mut same_name_same_type_1: i32 = unsafe { 5 };
+pub unsafe fn a_foo_2() -> i32 {
+    return same_name_different_type_0;
+}
+pub unsafe fn a_bar_3() -> i32 {
+    return same_name_same_type_1;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(((((unsafe { a_foo_2() }) == (1)) as i32) != 0));
+    assert!(((((unsafe { b_foo_4() }) == (1.0E+0)) as i32) != 0));
+    assert!(((((unsafe { a_bar_3() }) == (5)) as i32) != 0));
+    assert!(((((unsafe { b_bar_5() }) == (6)) as i32) != 0));
+    return 0;
+}
+pub static mut same_name_different_type_6: f32 = unsafe { 1.0E+0 };
+pub static mut same_name_same_type_7: i32 = unsafe { 6 };
+pub unsafe fn b_foo_4() -> f32 {
+    return same_name_different_type_6;
+}
+pub unsafe fn b_bar_5() -> i32 {
+    return same_name_same_type_7;
+}

--- a/tests/unit/out/refcount/addr_of_global.rs
+++ b/tests/unit/out/refcount/addr_of_global.rs
@@ -42,29 +42,29 @@ impl Clone for Outer {
 }
 impl ByteRepr for Outer {}
 thread_local!(
-    pub static alpha: Value<Inner> = Rc::new(RefCell::new(Inner {
+    pub static s_alpha: Value<Inner> = Rc::new(RefCell::new(Inner {
         value: Rc::new(RefCell::new(1)),
     }));
 );
 thread_local!(
-    pub static beta: Value<Inner> = Rc::new(RefCell::new(Inner {
+    pub static s_beta: Value<Inner> = Rc::new(RefCell::new(Inner {
         value: Rc::new(RefCell::new(2)),
     }));
 );
 thread_local!(
-    pub static shared: Value<Inner> = Rc::new(RefCell::new(Inner {
+    pub static s_shared: Value<Inner> = Rc::new(RefCell::new(Inner {
         value: Rc::new(RefCell::new(42)),
     }));
 );
 thread_local!(
-    pub static items: Value<Box<[Ptr<Inner>]>> = Rc::new(RefCell::new(Box::new([
-        (alpha.with(Value::clone).as_pointer()),
-        (beta.with(Value::clone).as_pointer()),
+    pub static s_items: Value<Box<[Ptr<Inner>]>> = Rc::new(RefCell::new(Box::new([
+        (s_alpha.with(Value::clone).as_pointer()),
+        (s_beta.with(Value::clone).as_pointer()),
     ])));
 );
 thread_local!(
-    pub static obj: Value<Outer> = Rc::new(RefCell::new(Outer {
-        p: Rc::new(RefCell::new((shared.with(Value::clone).as_pointer()))),
+    pub static s_obj: Value<Outer> = Rc::new(RefCell::new(Outer {
+        p: Rc::new(RefCell::new((s_shared.with(Value::clone).as_pointer()))),
     }));
 );
 pub fn main() {
@@ -72,7 +72,7 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     assert!(
-        ((*(*(*items.with(Value::clone).borrow())[(0) as usize]
+        ((*(*(*s_items.with(Value::clone).borrow())[(0) as usize]
             .upgrade()
             .deref())
         .value
@@ -80,7 +80,7 @@ fn main_0() -> i32 {
             == 1)
     );
     assert!(
-        ((*(*(*items.with(Value::clone).borrow())[(1) as usize]
+        ((*(*(*s_items.with(Value::clone).borrow())[(1) as usize]
             .upgrade()
             .deref())
         .value
@@ -88,7 +88,7 @@ fn main_0() -> i32 {
             == 2)
     );
     assert!(
-        ((*(*(*(*obj.with(Value::clone).borrow()).p.borrow())
+        ((*(*(*(*s_obj.with(Value::clone).borrow()).p.borrow())
             .upgrade()
             .deref())
         .value
@@ -96,13 +96,13 @@ fn main_0() -> i32 {
             == 42)
     );
     thread_local!(
-        static cache: Value<Box<[Ptr<Inner>]>> = Rc::new(RefCell::new(Box::new([
-            (alpha.with(Value::clone).as_pointer()),
-            (beta.with(Value::clone).as_pointer()),
+        static s_cache: Value<Box<[Ptr<Inner>]>> = Rc::new(RefCell::new(Box::new([
+            (s_alpha.with(Value::clone).as_pointer()),
+            (s_beta.with(Value::clone).as_pointer()),
         ])));
     );
     assert!(
-        ((*(*(*cache.with(Value::clone).borrow())[(0) as usize]
+        ((*(*(*s_cache.with(Value::clone).borrow())[(0) as usize]
             .upgrade()
             .deref())
         .value
@@ -110,7 +110,7 @@ fn main_0() -> i32 {
             == 1)
     );
     assert!(
-        ((*(*(*cache.with(Value::clone).borrow())[(1) as usize]
+        ((*(*(*s_cache.with(Value::clone).borrow())[(1) as usize]
             .upgrade()
             .deref())
         .value

--- a/tests/unit/out/refcount/addr_of_global.rs
+++ b/tests/unit/out/refcount/addr_of_global.rs
@@ -42,29 +42,29 @@ impl Clone for Outer {
 }
 impl ByteRepr for Outer {}
 thread_local!(
-    pub static s_alpha: Value<Inner> = Rc::new(RefCell::new(Inner {
+    pub static alpha_0: Value<Inner> = Rc::new(RefCell::new(Inner {
         value: Rc::new(RefCell::new(1)),
     }));
 );
 thread_local!(
-    pub static s_beta: Value<Inner> = Rc::new(RefCell::new(Inner {
+    pub static beta_1: Value<Inner> = Rc::new(RefCell::new(Inner {
         value: Rc::new(RefCell::new(2)),
     }));
 );
 thread_local!(
-    pub static s_shared: Value<Inner> = Rc::new(RefCell::new(Inner {
+    pub static shared_2: Value<Inner> = Rc::new(RefCell::new(Inner {
         value: Rc::new(RefCell::new(42)),
     }));
 );
 thread_local!(
-    pub static s_items: Value<Box<[Ptr<Inner>]>> = Rc::new(RefCell::new(Box::new([
-        (s_alpha.with(Value::clone).as_pointer()),
-        (s_beta.with(Value::clone).as_pointer()),
+    pub static items_3: Value<Box<[Ptr<Inner>]>> = Rc::new(RefCell::new(Box::new([
+        (alpha_0.with(Value::clone).as_pointer()),
+        (beta_1.with(Value::clone).as_pointer()),
     ])));
 );
 thread_local!(
-    pub static s_obj: Value<Outer> = Rc::new(RefCell::new(Outer {
-        p: Rc::new(RefCell::new((s_shared.with(Value::clone).as_pointer()))),
+    pub static obj_4: Value<Outer> = Rc::new(RefCell::new(Outer {
+        p: Rc::new(RefCell::new((shared_2.with(Value::clone).as_pointer()))),
     }));
 );
 pub fn main() {
@@ -72,7 +72,7 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     assert!(
-        ((*(*(*s_items.with(Value::clone).borrow())[(0) as usize]
+        ((*(*(*items_3.with(Value::clone).borrow())[(0) as usize]
             .upgrade()
             .deref())
         .value
@@ -80,7 +80,7 @@ fn main_0() -> i32 {
             == 1)
     );
     assert!(
-        ((*(*(*s_items.with(Value::clone).borrow())[(1) as usize]
+        ((*(*(*items_3.with(Value::clone).borrow())[(1) as usize]
             .upgrade()
             .deref())
         .value
@@ -88,7 +88,7 @@ fn main_0() -> i32 {
             == 2)
     );
     assert!(
-        ((*(*(*(*s_obj.with(Value::clone).borrow()).p.borrow())
+        ((*(*(*(*obj_4.with(Value::clone).borrow()).p.borrow())
             .upgrade()
             .deref())
         .value
@@ -96,13 +96,13 @@ fn main_0() -> i32 {
             == 42)
     );
     thread_local!(
-        static s_cache: Value<Box<[Ptr<Inner>]>> = Rc::new(RefCell::new(Box::new([
-            (s_alpha.with(Value::clone).as_pointer()),
-            (s_beta.with(Value::clone).as_pointer()),
+        static cache_5: Value<Box<[Ptr<Inner>]>> = Rc::new(RefCell::new(Box::new([
+            (alpha_0.with(Value::clone).as_pointer()),
+            (beta_1.with(Value::clone).as_pointer()),
         ])));
     );
     assert!(
-        ((*(*(*s_cache.with(Value::clone).borrow())[(0) as usize]
+        ((*(*(*cache_5.with(Value::clone).borrow())[(0) as usize]
             .upgrade()
             .deref())
         .value
@@ -110,7 +110,7 @@ fn main_0() -> i32 {
             == 1)
     );
     assert!(
-        ((*(*(*s_cache.with(Value::clone).borrow())[(1) as usize]
+        ((*(*(*cache_5.with(Value::clone).borrow())[(1) as usize]
             .upgrade()
             .deref())
         .value

--- a/tests/unit/out/refcount/bool_condition_logical.rs
+++ b/tests/unit/out/refcount/bool_condition_logical.rs
@@ -25,11 +25,11 @@ impl From<i32> for Code {
 }
 libcc2rs::impl_enum_inc_dec!(Code);
 thread_local!(
-    pub static side_effect: Value<i32> = Rc::new(RefCell::new(0));
+    pub static s_side_effect: Value<i32> = Rc::new(RefCell::new(0));
 );
 pub fn observe_0(v: i32) -> i32 {
     let v: Value<i32> = Rc::new(RefCell::new(v));
-    (*side_effect.with(Value::clone).borrow_mut()).prefix_inc();
+    (*s_side_effect.with(Value::clone).borrow_mut()).prefix_inc();
     return (*v.borrow());
 }
 pub fn returns_one_1() -> i32 {
@@ -66,7 +66,7 @@ fn main_0() -> i32 {
     {
         assert!(true);
     }
-    (*side_effect.with(Value::clone).borrow_mut()) = 0;
+    (*s_side_effect.with(Value::clone).borrow_mut()) = 0;
     if ((*zero.borrow()) != 0)
         && (({
             let _v: i32 = 1;
@@ -75,7 +75,7 @@ fn main_0() -> i32 {
     {
         assert!(false);
     }
-    assert!(((*side_effect.with(Value::clone).borrow()) == 0));
+    assert!(((*s_side_effect.with(Value::clone).borrow()) == 0));
     if ((*n.borrow()) != 0)
         || (({
             let _v: i32 = 1;
@@ -84,7 +84,7 @@ fn main_0() -> i32 {
     {
         assert!(true);
     }
-    assert!(((*side_effect.with(Value::clone).borrow()) == 0));
+    assert!(((*s_side_effect.with(Value::clone).borrow()) == 0));
     let x: Value<i32> = Rc::new(RefCell::new(5));
     let y: Value<i32> = Rc::new(RefCell::new(3));
     let flags: Value<u32> = Rc::new(RefCell::new(2_u32));

--- a/tests/unit/out/refcount/bool_condition_logical.rs
+++ b/tests/unit/out/refcount/bool_condition_logical.rs
@@ -23,6 +23,7 @@ impl From<i32> for Code {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Code);
 thread_local!(
     pub static side_effect_0: Value<i32> = Rc::new(RefCell::new(0));
 );

--- a/tests/unit/out/refcount/bool_condition_logical.rs
+++ b/tests/unit/out/refcount/bool_condition_logical.rs
@@ -23,7 +23,6 @@ impl From<i32> for Code {
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Code);
 thread_local!(
     pub static side_effect_0: Value<i32> = Rc::new(RefCell::new(0));
 );

--- a/tests/unit/out/refcount/bool_condition_logical.rs
+++ b/tests/unit/out/refcount/bool_condition_logical.rs
@@ -25,17 +25,17 @@ impl From<i32> for Code {
 }
 libcc2rs::impl_enum_inc_dec!(Code);
 thread_local!(
-    pub static s_side_effect: Value<i32> = Rc::new(RefCell::new(0));
+    pub static side_effect_0: Value<i32> = Rc::new(RefCell::new(0));
 );
-pub fn observe_0(v: i32) -> i32 {
+pub fn observe_1(v: i32) -> i32 {
     let v: Value<i32> = Rc::new(RefCell::new(v));
-    (*s_side_effect.with(Value::clone).borrow_mut()).prefix_inc();
+    (*side_effect_0.with(Value::clone).borrow_mut()).prefix_inc();
     return (*v.borrow());
 }
-pub fn returns_one_1() -> i32 {
+pub fn returns_one_2() -> i32 {
     return 1;
 }
-pub fn returns_zero_2() -> i32 {
+pub fn returns_zero_3() -> i32 {
     return 0;
 }
 pub fn main() {
@@ -66,25 +66,25 @@ fn main_0() -> i32 {
     {
         assert!(true);
     }
-    (*s_side_effect.with(Value::clone).borrow_mut()) = 0;
+    (*side_effect_0.with(Value::clone).borrow_mut()) = 0;
     if ((*zero.borrow()) != 0)
         && (({
             let _v: i32 = 1;
-            observe_0(_v)
+            observe_1(_v)
         }) != 0)
     {
         assert!(false);
     }
-    assert!(((*s_side_effect.with(Value::clone).borrow()) == 0));
+    assert!(((*side_effect_0.with(Value::clone).borrow()) == 0));
     if ((*n.borrow()) != 0)
         || (({
             let _v: i32 = 1;
-            observe_0(_v)
+            observe_1(_v)
         }) != 0)
     {
         assert!(true);
     }
-    assert!(((*s_side_effect.with(Value::clone).borrow()) == 0));
+    assert!(((*side_effect_0.with(Value::clone).borrow()) == 0));
     let x: Value<i32> = Rc::new(RefCell::new(5));
     let y: Value<i32> = Rc::new(RefCell::new(3));
     let flags: Value<u32> = Rc::new(RefCell::new(2_u32));
@@ -138,19 +138,19 @@ fn main_0() -> i32 {
     if ((*x.borrow()) > (*y.borrow())) && (((*n.borrow()) != 0) && (!(*cp.borrow()).is_null())) {
         assert!(true);
     }
-    if ((*x.borrow()) > (*y.borrow())) && (({ returns_one_1() }) != 0) {
+    if ((*x.borrow()) > (*y.borrow())) && (({ returns_one_2() }) != 0) {
         assert!(true);
     }
-    if ((*x.borrow()) > (*y.borrow())) && (!(({ returns_zero_2() }) != 0)) {
+    if ((*x.borrow()) > (*y.borrow())) && (!(({ returns_zero_3() }) != 0)) {
         assert!(true);
     }
-    if ((*x.borrow()) < (*y.borrow())) || (({ returns_one_1() }) != 0) {
+    if ((*x.borrow()) < (*y.borrow())) || (({ returns_one_2() }) != 0) {
         assert!(true);
     }
-    if ((*x.borrow()) < (*y.borrow())) || (!(({ returns_one_1() }) != 0)) {
+    if ((*x.borrow()) < (*y.borrow())) || (!(({ returns_one_2() }) != 0)) {
         assert!(false);
     }
-    if ((!((*p.borrow()).is_null())) && (({ returns_one_1() }) != 0)) && ((*n.borrow()) != 0) {
+    if ((!((*p.borrow()).is_null())) && (({ returns_one_2() }) != 0)) && ((*n.borrow()) != 0) {
         assert!(true);
     }
     return 0;

--- a/tests/unit/out/refcount/bool_condition_logical_c.rs
+++ b/tests/unit/out/refcount/bool_condition_logical_c.rs
@@ -25,11 +25,11 @@ impl From<i32> for Code {
 }
 libcc2rs::impl_enum_inc_dec!(Code);
 thread_local!(
-    pub static side_effect: Value<i32> = Rc::new(RefCell::new(0));
+    pub static s_side_effect: Value<i32> = Rc::new(RefCell::new(0));
 );
 pub fn observe_0(v: i32) -> i32 {
     let v: Value<i32> = Rc::new(RefCell::new(v));
-    (*side_effect.with(Value::clone).borrow_mut()).prefix_inc();
+    (*s_side_effect.with(Value::clone).borrow_mut()).prefix_inc();
     return (*v.borrow());
 }
 pub fn returns_one_1() -> i32 {
@@ -70,7 +70,7 @@ fn main_0() -> i32 {
     {
         assert!((1 != 0));
     }
-    (*side_effect.with(Value::clone).borrow_mut()) = 0;
+    (*s_side_effect.with(Value::clone).borrow_mut()) = 0;
     if (((((*zero.borrow()) != 0)
         && (({
             let _v: i32 = 1;
@@ -80,7 +80,7 @@ fn main_0() -> i32 {
     {
         assert!((0 != 0));
     }
-    assert!(((((*side_effect.with(Value::clone).borrow()) == 0) as i32) != 0));
+    assert!(((((*s_side_effect.with(Value::clone).borrow()) == 0) as i32) != 0));
     if (((((*n.borrow()) != 0)
         || (({
             let _v: i32 = 1;
@@ -90,7 +90,7 @@ fn main_0() -> i32 {
     {
         assert!((1 != 0));
     }
-    assert!(((((*side_effect.with(Value::clone).borrow()) == 0) as i32) != 0));
+    assert!(((((*s_side_effect.with(Value::clone).borrow()) == 0) as i32) != 0));
     let x: Value<i32> = Rc::new(RefCell::new(5));
     let y: Value<i32> = Rc::new(RefCell::new(3));
     let flags: Value<u32> = Rc::new(RefCell::new(2_u32));

--- a/tests/unit/out/refcount/bool_condition_logical_c.rs
+++ b/tests/unit/out/refcount/bool_condition_logical_c.rs
@@ -23,6 +23,7 @@ impl From<i32> for Code {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Code);
 thread_local!(
     pub static side_effect_0: Value<i32> = Rc::new(RefCell::new(0));
 );

--- a/tests/unit/out/refcount/bool_condition_logical_c.rs
+++ b/tests/unit/out/refcount/bool_condition_logical_c.rs
@@ -23,7 +23,6 @@ impl From<i32> for Code {
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Code);
 thread_local!(
     pub static side_effect_0: Value<i32> = Rc::new(RefCell::new(0));
 );

--- a/tests/unit/out/refcount/bool_condition_logical_c.rs
+++ b/tests/unit/out/refcount/bool_condition_logical_c.rs
@@ -25,17 +25,17 @@ impl From<i32> for Code {
 }
 libcc2rs::impl_enum_inc_dec!(Code);
 thread_local!(
-    pub static s_side_effect: Value<i32> = Rc::new(RefCell::new(0));
+    pub static side_effect_0: Value<i32> = Rc::new(RefCell::new(0));
 );
-pub fn observe_0(v: i32) -> i32 {
+pub fn observe_1(v: i32) -> i32 {
     let v: Value<i32> = Rc::new(RefCell::new(v));
-    (*s_side_effect.with(Value::clone).borrow_mut()).prefix_inc();
+    (*side_effect_0.with(Value::clone).borrow_mut()).prefix_inc();
     return (*v.borrow());
 }
-pub fn returns_one_1() -> i32 {
+pub fn returns_one_2() -> i32 {
     return 1;
 }
-pub fn returns_zero_2() -> i32 {
+pub fn returns_zero_3() -> i32 {
     return 0;
 }
 pub fn main() {
@@ -70,27 +70,27 @@ fn main_0() -> i32 {
     {
         assert!((1 != 0));
     }
-    (*s_side_effect.with(Value::clone).borrow_mut()) = 0;
+    (*side_effect_0.with(Value::clone).borrow_mut()) = 0;
     if (((((*zero.borrow()) != 0)
         && (({
             let _v: i32 = 1;
-            observe_0(_v)
+            observe_1(_v)
         }) != 0)) as i32)
         != 0)
     {
         assert!((0 != 0));
     }
-    assert!(((((*s_side_effect.with(Value::clone).borrow()) == 0) as i32) != 0));
+    assert!(((((*side_effect_0.with(Value::clone).borrow()) == 0) as i32) != 0));
     if (((((*n.borrow()) != 0)
         || (({
             let _v: i32 = 1;
-            observe_0(_v)
+            observe_1(_v)
         }) != 0)) as i32)
         != 0)
     {
         assert!((1 != 0));
     }
-    assert!(((((*s_side_effect.with(Value::clone).borrow()) == 0) as i32) != 0));
+    assert!(((((*side_effect_0.with(Value::clone).borrow()) == 0) as i32) != 0));
     let x: Value<i32> = Rc::new(RefCell::new(5));
     let y: Value<i32> = Rc::new(RefCell::new(3));
     let flags: Value<u32> = Rc::new(RefCell::new(2_u32));
@@ -170,29 +170,29 @@ fn main_0() -> i32 {
     {
         assert!((1 != 0));
     }
-    if (((((((*x.borrow()) > (*y.borrow())) as i32) != 0) && (({ returns_one_1() }) != 0)) as i32)
+    if (((((((*x.borrow()) > (*y.borrow())) as i32) != 0) && (({ returns_one_2() }) != 0)) as i32)
         != 0)
     {
         assert!((1 != 0));
     }
-    if (((((((*x.borrow()) > (*y.borrow())) as i32) != 0) && (!(({ returns_zero_2() }) != 0)))
+    if (((((((*x.borrow()) > (*y.borrow())) as i32) != 0) && (!(({ returns_zero_3() }) != 0)))
         as i32)
         != 0)
     {
         assert!((1 != 0));
     }
-    if (((((((*x.borrow()) < (*y.borrow())) as i32) != 0) || (({ returns_one_1() }) != 0)) as i32)
+    if (((((((*x.borrow()) < (*y.borrow())) as i32) != 0) || (({ returns_one_2() }) != 0)) as i32)
         != 0)
     {
         assert!((1 != 0));
     }
-    if (((((((*x.borrow()) < (*y.borrow())) as i32) != 0) || (!(({ returns_one_1() }) != 0)))
+    if (((((((*x.borrow()) < (*y.borrow())) as i32) != 0) || (!(({ returns_one_2() }) != 0)))
         as i32)
         != 0)
     {
         assert!((0 != 0));
     }
-    if (((((((((!((*p.borrow()).is_null())) as i32) != 0) && (({ returns_one_1() }) != 0)) as i32)
+    if (((((((((!((*p.borrow()).is_null())) as i32) != 0) && (({ returns_one_2() }) != 0)) as i32)
         != 0)
         && ((((*n.borrow()) != 0) as i32) != 0)) as i32)
         != 0)

--- a/tests/unit/out/refcount/default_in_statics.rs
+++ b/tests/unit/out/refcount/default_in_statics.rs
@@ -99,18 +99,18 @@ impl Default for Foo {
 }
 impl ByteRepr for Foo {}
 thread_local!(
-    pub static static_fn: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::null()));
+    pub static s_static_fn: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::null()));
 );
 thread_local!(
-    pub static static_outer: Value<Outer> = Rc::new(RefCell::new(<Outer>::default()));
+    pub static s_static_outer: Value<Outer> = Rc::new(RefCell::new(<Outer>::default()));
 );
 thread_local!(
-    pub static static_inner_array: Value<Box<[Inner]>> = Rc::new(RefCell::new(
+    pub static s_static_inner_array: Value<Box<[Inner]>> = Rc::new(RefCell::new(
         (0..2).map(|_| <Inner>::default()).collect::<Box<[Inner]>>(),
     ));
 );
 thread_local!(
-    pub static static_foo: Value<Foo> = Rc::new(RefCell::new(Foo {
+    pub static s_static_foo: Value<Foo> = Rc::new(RefCell::new(Foo {
         s1: Rc::new(RefCell::new(Ptr::from_string_literal("hello"))),
         s2: Rc::new(RefCell::new(Ptr::<u8>::null())),
         fn1: Rc::new(RefCell::new(FnPtr::null())),
@@ -119,7 +119,7 @@ thread_local!(
     }));
 );
 thread_local!(
-    pub static static_foo_array: Value<Box<[Foo]>> = Rc::new(RefCell::new(Box::new([
+    pub static s_static_foo_array: Value<Box<[Foo]>> = Rc::new(RefCell::new(Box::new([
         Foo {
             s1: Rc::new(RefCell::new(Ptr::from_string_literal("first"))),
             s2: Rc::new(RefCell::new(Ptr::<u8>::null())),
@@ -138,38 +138,39 @@ thread_local!(
 );
 pub fn check_local_static_0() {
     thread_local!(
-        static local_outer: Value<Outer> = Rc::new(RefCell::new(<Outer>::default()));
+        static s_local_outer: Value<Outer> = Rc::new(RefCell::new(<Outer>::default()));
     );
     thread_local!(
-        static local_fn: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::null()));
+        static s_local_fn: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::null()));
     );
     thread_local!(
-        static local_p: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
+        static s_local_p: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
     );
-    assert!((*(*local_outer.with(Value::clone).borrow()).p1.borrow()).is_null());
-    assert!((*(*local_outer.with(Value::clone).borrow()).fn_.borrow()).is_null());
-    assert!((*local_fn.with(Value::clone).borrow()).is_null());
-    assert!((*local_p.with(Value::clone).borrow()).is_null());
+    assert!((*(*s_local_outer.with(Value::clone).borrow()).p1.borrow()).is_null());
+    assert!((*(*s_local_outer.with(Value::clone).borrow()).fn_.borrow()).is_null());
+    assert!((*s_local_fn.with(Value::clone).borrow()).is_null());
+    assert!((*s_local_p.with(Value::clone).borrow()).is_null());
 }
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    assert!((*static_fn.with(Value::clone).borrow()).is_null());
-    assert!((*(*static_outer.with(Value::clone).borrow()).p1.borrow()).is_null());
-    assert!((*(*static_outer.with(Value::clone).borrow()).p2.borrow()).is_null());
-    assert!((*(*static_outer.with(Value::clone).borrow()).cp.borrow()).is_null());
-    assert!((*(*static_outer.with(Value::clone).borrow()).pp.borrow()).is_null());
-    assert!((*(*static_outer.with(Value::clone).borrow()).fn_.borrow()).is_null());
+    assert!((*s_static_fn.with(Value::clone).borrow()).is_null());
+    assert!((*(*s_static_outer.with(Value::clone).borrow()).p1.borrow()).is_null());
+    assert!((*(*s_static_outer.with(Value::clone).borrow()).p2.borrow()).is_null());
+    assert!((*(*s_static_outer.with(Value::clone).borrow()).cp.borrow()).is_null());
+    assert!((*(*s_static_outer.with(Value::clone).borrow()).pp.borrow()).is_null());
+    assert!((*(*s_static_outer.with(Value::clone).borrow()).fn_.borrow()).is_null());
     let i: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while ((*i.borrow()) < 3) {
-        assert!(((*(*static_outer.with(Value::clone).borrow()).arr.borrow())
-            [(*i.borrow()) as usize])
-            .is_null());
+        assert!(
+            ((*(*s_static_outer.with(Value::clone).borrow()).arr.borrow())[(*i.borrow()) as usize])
+                .is_null()
+        );
         (*i.borrow_mut()).prefix_inc();
     }
     assert!(
-        (*(*(*static_outer.with(Value::clone).borrow()).inner.borrow())
+        (*(*(*s_static_outer.with(Value::clone).borrow()).inner.borrow())
             .name
             .borrow())
         .is_null()
@@ -177,33 +178,33 @@ fn main_0() -> i32 {
     let i: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while ((*i.borrow()) < 2) {
         assert!(
-            (*(*static_inner_array.with(Value::clone).borrow())[(*i.borrow()) as usize]
+            (*(*s_static_inner_array.with(Value::clone).borrow())[(*i.borrow()) as usize]
                 .name
                 .borrow())
             .is_null()
         );
         (*i.borrow_mut()).prefix_inc();
     }
-    assert!((*(*static_foo.with(Value::clone).borrow()).s2.borrow()).is_null());
-    assert!((*(*static_foo.with(Value::clone).borrow()).fn1.borrow()).is_null());
-    assert!((*(*static_foo.with(Value::clone).borrow()).fn2.borrow()).is_null());
-    assert!(((*(*static_foo.with(Value::clone).borrow()).n.borrow()) == 42));
+    assert!((*(*s_static_foo.with(Value::clone).borrow()).s2.borrow()).is_null());
+    assert!((*(*s_static_foo.with(Value::clone).borrow()).fn1.borrow()).is_null());
+    assert!((*(*s_static_foo.with(Value::clone).borrow()).fn2.borrow()).is_null());
+    assert!(((*(*s_static_foo.with(Value::clone).borrow()).n.borrow()) == 42));
     let i: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while ((*i.borrow()) < 2) {
         assert!(
-            (*(*static_foo_array.with(Value::clone).borrow())[(*i.borrow()) as usize]
+            (*(*s_static_foo_array.with(Value::clone).borrow())[(*i.borrow()) as usize]
                 .s2
                 .borrow())
             .is_null()
         );
         assert!(
-            (*(*static_foo_array.with(Value::clone).borrow())[(*i.borrow()) as usize]
+            (*(*s_static_foo_array.with(Value::clone).borrow())[(*i.borrow()) as usize]
                 .fn1
                 .borrow())
             .is_null()
         );
         assert!(
-            (*(*static_foo_array.with(Value::clone).borrow())[(*i.borrow()) as usize]
+            (*(*s_static_foo_array.with(Value::clone).borrow())[(*i.borrow()) as usize]
                 .fn2
                 .borrow())
             .is_null()

--- a/tests/unit/out/refcount/default_in_statics.rs
+++ b/tests/unit/out/refcount/default_in_statics.rs
@@ -99,18 +99,18 @@ impl Default for Foo {
 }
 impl ByteRepr for Foo {}
 thread_local!(
-    pub static s_static_fn: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::null()));
+    pub static static_fn_0: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::null()));
 );
 thread_local!(
-    pub static s_static_outer: Value<Outer> = Rc::new(RefCell::new(<Outer>::default()));
+    pub static static_outer_1: Value<Outer> = Rc::new(RefCell::new(<Outer>::default()));
 );
 thread_local!(
-    pub static s_static_inner_array: Value<Box<[Inner]>> = Rc::new(RefCell::new(
+    pub static static_inner_array_2: Value<Box<[Inner]>> = Rc::new(RefCell::new(
         (0..2).map(|_| <Inner>::default()).collect::<Box<[Inner]>>(),
     ));
 );
 thread_local!(
-    pub static s_static_foo: Value<Foo> = Rc::new(RefCell::new(Foo {
+    pub static static_foo_3: Value<Foo> = Rc::new(RefCell::new(Foo {
         s1: Rc::new(RefCell::new(Ptr::from_string_literal("hello"))),
         s2: Rc::new(RefCell::new(Ptr::<u8>::null())),
         fn1: Rc::new(RefCell::new(FnPtr::null())),
@@ -119,7 +119,7 @@ thread_local!(
     }));
 );
 thread_local!(
-    pub static s_static_foo_array: Value<Box<[Foo]>> = Rc::new(RefCell::new(Box::new([
+    pub static static_foo_array_4: Value<Box<[Foo]>> = Rc::new(RefCell::new(Box::new([
         Foo {
             s1: Rc::new(RefCell::new(Ptr::from_string_literal("first"))),
             s2: Rc::new(RefCell::new(Ptr::<u8>::null())),
@@ -136,41 +136,41 @@ thread_local!(
         },
     ])));
 );
-pub fn check_local_static_0() {
+pub fn check_local_static_5() {
     thread_local!(
-        static s_local_outer: Value<Outer> = Rc::new(RefCell::new(<Outer>::default()));
+        static local_outer_6: Value<Outer> = Rc::new(RefCell::new(<Outer>::default()));
     );
     thread_local!(
-        static s_local_fn: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::null()));
+        static local_fn_7: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::null()));
     );
     thread_local!(
-        static s_local_p: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
+        static local_p_8: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
     );
-    assert!((*(*s_local_outer.with(Value::clone).borrow()).p1.borrow()).is_null());
-    assert!((*(*s_local_outer.with(Value::clone).borrow()).fn_.borrow()).is_null());
-    assert!((*s_local_fn.with(Value::clone).borrow()).is_null());
-    assert!((*s_local_p.with(Value::clone).borrow()).is_null());
+    assert!((*(*local_outer_6.with(Value::clone).borrow()).p1.borrow()).is_null());
+    assert!((*(*local_outer_6.with(Value::clone).borrow()).fn_.borrow()).is_null());
+    assert!((*local_fn_7.with(Value::clone).borrow()).is_null());
+    assert!((*local_p_8.with(Value::clone).borrow()).is_null());
 }
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    assert!((*s_static_fn.with(Value::clone).borrow()).is_null());
-    assert!((*(*s_static_outer.with(Value::clone).borrow()).p1.borrow()).is_null());
-    assert!((*(*s_static_outer.with(Value::clone).borrow()).p2.borrow()).is_null());
-    assert!((*(*s_static_outer.with(Value::clone).borrow()).cp.borrow()).is_null());
-    assert!((*(*s_static_outer.with(Value::clone).borrow()).pp.borrow()).is_null());
-    assert!((*(*s_static_outer.with(Value::clone).borrow()).fn_.borrow()).is_null());
+    assert!((*static_fn_0.with(Value::clone).borrow()).is_null());
+    assert!((*(*static_outer_1.with(Value::clone).borrow()).p1.borrow()).is_null());
+    assert!((*(*static_outer_1.with(Value::clone).borrow()).p2.borrow()).is_null());
+    assert!((*(*static_outer_1.with(Value::clone).borrow()).cp.borrow()).is_null());
+    assert!((*(*static_outer_1.with(Value::clone).borrow()).pp.borrow()).is_null());
+    assert!((*(*static_outer_1.with(Value::clone).borrow()).fn_.borrow()).is_null());
     let i: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while ((*i.borrow()) < 3) {
         assert!(
-            ((*(*s_static_outer.with(Value::clone).borrow()).arr.borrow())[(*i.borrow()) as usize])
+            ((*(*static_outer_1.with(Value::clone).borrow()).arr.borrow())[(*i.borrow()) as usize])
                 .is_null()
         );
         (*i.borrow_mut()).prefix_inc();
     }
     assert!(
-        (*(*(*s_static_outer.with(Value::clone).borrow()).inner.borrow())
+        (*(*(*static_outer_1.with(Value::clone).borrow()).inner.borrow())
             .name
             .borrow())
         .is_null()
@@ -178,39 +178,39 @@ fn main_0() -> i32 {
     let i: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while ((*i.borrow()) < 2) {
         assert!(
-            (*(*s_static_inner_array.with(Value::clone).borrow())[(*i.borrow()) as usize]
+            (*(*static_inner_array_2.with(Value::clone).borrow())[(*i.borrow()) as usize]
                 .name
                 .borrow())
             .is_null()
         );
         (*i.borrow_mut()).prefix_inc();
     }
-    assert!((*(*s_static_foo.with(Value::clone).borrow()).s2.borrow()).is_null());
-    assert!((*(*s_static_foo.with(Value::clone).borrow()).fn1.borrow()).is_null());
-    assert!((*(*s_static_foo.with(Value::clone).borrow()).fn2.borrow()).is_null());
-    assert!(((*(*s_static_foo.with(Value::clone).borrow()).n.borrow()) == 42));
+    assert!((*(*static_foo_3.with(Value::clone).borrow()).s2.borrow()).is_null());
+    assert!((*(*static_foo_3.with(Value::clone).borrow()).fn1.borrow()).is_null());
+    assert!((*(*static_foo_3.with(Value::clone).borrow()).fn2.borrow()).is_null());
+    assert!(((*(*static_foo_3.with(Value::clone).borrow()).n.borrow()) == 42));
     let i: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while ((*i.borrow()) < 2) {
         assert!(
-            (*(*s_static_foo_array.with(Value::clone).borrow())[(*i.borrow()) as usize]
+            (*(*static_foo_array_4.with(Value::clone).borrow())[(*i.borrow()) as usize]
                 .s2
                 .borrow())
             .is_null()
         );
         assert!(
-            (*(*s_static_foo_array.with(Value::clone).borrow())[(*i.borrow()) as usize]
+            (*(*static_foo_array_4.with(Value::clone).borrow())[(*i.borrow()) as usize]
                 .fn1
                 .borrow())
             .is_null()
         );
         assert!(
-            (*(*s_static_foo_array.with(Value::clone).borrow())[(*i.borrow()) as usize]
+            (*(*static_foo_array_4.with(Value::clone).borrow())[(*i.borrow()) as usize]
                 .fn2
                 .borrow())
             .is_null()
         );
         (*i.borrow_mut()).prefix_inc();
     }
-    ({ check_local_static_0() });
+    ({ check_local_static_5() });
     return 0;
 }

--- a/tests/unit/out/refcount/enum_int_interop.rs
+++ b/tests/unit/out/refcount/enum_int_interop.rs
@@ -80,16 +80,16 @@ impl Clone for Entry {
 }
 impl ByteRepr for Entry {}
 thread_local!(
-    pub static global_color: Value<Color> = Rc::new(RefCell::new(Color::GREEN));
+    pub static s_global_color: Value<Color> = Rc::new(RefCell::new(Color::GREEN));
 );
 thread_local!(
-    pub static global_opt: Value<Option> = Rc::new(RefCell::new(Option::OPT_B));
+    pub static s_global_opt: Value<Option> = Rc::new(RefCell::new(Option::OPT_B));
 );
 thread_local!(
-    pub static global_tag: Value<Tag> = Rc::new(RefCell::new(Tag::TAG_TWO));
+    pub static s_global_tag: Value<Tag> = Rc::new(RefCell::new(Tag::TAG_TWO));
 );
 thread_local!(
-    pub static entries: Value<Box<[Entry]>> = Rc::new(RefCell::new(Box::new([
+    pub static s_entries: Value<Box<[Entry]>> = Rc::new(RefCell::new(Box::new([
         Entry {
             name: Rc::new(RefCell::new(Ptr::from_string_literal("first"))),
             color: Rc::new(RefCell::new(Color::RED)),
@@ -231,41 +231,41 @@ fn main_0() -> i32 {
         (((Color::RED as i32) + (Color::GREEN as i32)) + (Color::BLUE as i32)),
     ));
     assert!(((*extra.borrow()) == ((0 + 1) + 2)));
-    assert!((((*global_color.with(Value::clone).borrow()) as i32) == (Color::GREEN as i32)));
-    assert!((((*global_opt.with(Value::clone).borrow()) as i32) == (Option::OPT_B as i32)));
-    assert!((((*global_tag.with(Value::clone).borrow()) as i32) == (Tag::TAG_TWO as i32)));
+    assert!((((*s_global_color.with(Value::clone).borrow()) as i32) == (Color::GREEN as i32)));
+    assert!((((*s_global_opt.with(Value::clone).borrow()) as i32) == (Option::OPT_B as i32)));
+    assert!((((*s_global_tag.with(Value::clone).borrow()) as i32) == (Tag::TAG_TWO as i32)));
     assert!(
-        (((*(*entries.with(Value::clone).borrow())[(0) as usize]
+        (((*(*s_entries.with(Value::clone).borrow())[(0) as usize]
             .color
             .borrow()) as i32)
             == (Color::RED as i32))
     );
     assert!(
-        (((*(*entries.with(Value::clone).borrow())[(0) as usize]
+        (((*(*s_entries.with(Value::clone).borrow())[(0) as usize]
             .opt
             .borrow()) as i32)
             == (Option::OPT_NONE as i32))
     );
     assert!(
-        (((*(*entries.with(Value::clone).borrow())[(1) as usize]
+        (((*(*s_entries.with(Value::clone).borrow())[(1) as usize]
             .color
             .borrow()) as i32)
             == (Color::GREEN as i32))
     );
     assert!(
-        (((*(*entries.with(Value::clone).borrow())[(1) as usize]
+        (((*(*s_entries.with(Value::clone).borrow())[(1) as usize]
             .opt
             .borrow()) as i32)
             == (Option::OPT_A as i32))
     );
     assert!(
-        (((*(*entries.with(Value::clone).borrow())[(2) as usize]
+        (((*(*s_entries.with(Value::clone).borrow())[(2) as usize]
             .color
             .borrow()) as i32)
             == (Color::BLUE as i32))
     );
     assert!(
-        (((*(*entries.with(Value::clone).borrow())[(2) as usize]
+        (((*(*s_entries.with(Value::clone).borrow())[(2) as usize]
             .opt
             .borrow()) as i32)
             == (Option::OPT_C as i32))

--- a/tests/unit/out/refcount/enum_int_interop.rs
+++ b/tests/unit/out/refcount/enum_int_interop.rs
@@ -23,6 +23,7 @@ impl From<i32> for Color {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Color);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Option {
     #[default]
@@ -42,6 +43,7 @@ impl From<i32> for Option {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Option);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Tag {
     #[default]
@@ -59,6 +61,7 @@ impl From<i32> for Tag {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Tag);
 #[derive(Default)]
 pub struct Entry {
     pub name: Value<Ptr<u8>>,

--- a/tests/unit/out/refcount/enum_int_interop.rs
+++ b/tests/unit/out/refcount/enum_int_interop.rs
@@ -23,7 +23,6 @@ impl From<i32> for Color {
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Color);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Option {
     #[default]
@@ -43,7 +42,6 @@ impl From<i32> for Option {
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Option);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Tag {
     #[default]
@@ -61,7 +59,6 @@ impl From<i32> for Tag {
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Tag);
 #[derive(Default)]
 pub struct Entry {
     pub name: Value<Ptr<u8>>,

--- a/tests/unit/out/refcount/enum_int_interop.rs
+++ b/tests/unit/out/refcount/enum_int_interop.rs
@@ -80,16 +80,16 @@ impl Clone for Entry {
 }
 impl ByteRepr for Entry {}
 thread_local!(
-    pub static s_global_color: Value<Color> = Rc::new(RefCell::new(Color::GREEN));
+    pub static global_color_0: Value<Color> = Rc::new(RefCell::new(Color::GREEN));
 );
 thread_local!(
-    pub static s_global_opt: Value<Option> = Rc::new(RefCell::new(Option::OPT_B));
+    pub static global_opt_1: Value<Option> = Rc::new(RefCell::new(Option::OPT_B));
 );
 thread_local!(
-    pub static s_global_tag: Value<Tag> = Rc::new(RefCell::new(Tag::TAG_TWO));
+    pub static global_tag_2: Value<Tag> = Rc::new(RefCell::new(Tag::TAG_TWO));
 );
 thread_local!(
-    pub static s_entries: Value<Box<[Entry]>> = Rc::new(RefCell::new(Box::new([
+    pub static entries_3: Value<Box<[Entry]>> = Rc::new(RefCell::new(Box::new([
         Entry {
             name: Rc::new(RefCell::new(Ptr::from_string_literal("first"))),
             color: Rc::new(RefCell::new(Color::RED)),
@@ -107,11 +107,11 @@ thread_local!(
         },
     ])));
 );
-pub fn as_int_0(c: Color) -> i32 {
+pub fn as_int_4(c: Color) -> i32 {
     let c: Value<Color> = Rc::new(RefCell::new(c));
     return ((*c.borrow()) as i32).clone();
 }
-pub fn classify_option_1(option: i32) -> i32 {
+pub fn classify_option_5(option: i32) -> i32 {
     let option: Value<i32> = Rc::new(RefCell::new(option));
     'switch: {
         let __match_cond = (*option.borrow());
@@ -135,7 +135,7 @@ pub fn classify_option_1(option: i32) -> i32 {
     };
     panic!("ub: non-void function does not return a value")
 }
-pub fn make_color_2(n: i32) -> Color {
+pub fn make_color_6(n: i32) -> Color {
     let n: Value<i32> = Rc::new(RefCell::new(n));
     return Color::from((*n.borrow()));
 }
@@ -176,7 +176,7 @@ fn main_0() -> i32 {
     assert!((((*c.borrow()) as i32) == 2));
     (*c.borrow_mut()) = ({
         let _n: i32 = 1;
-        make_color_2(_n)
+        make_color_6(_n)
     });
     assert!((((*c.borrow()) as i32) == (Color::GREEN as i32)));
     let cmp: Value<Color> = Rc::new(RefCell::new(Color::from((((*c.borrow()) as i32) + 1))));
@@ -191,18 +191,18 @@ fn main_0() -> i32 {
     let rc: Value<i32> = Rc::new(RefCell::new(
         ({
             let _option: i32 = ((*o.borrow()) as i32).clone();
-            classify_option_1(_option)
+            classify_option_5(_option)
         }),
     ));
     assert!(((*rc.borrow()) == 2));
     (*rc.borrow_mut()) = ({
         let _option: i32 = 20;
-        classify_option_1(_option)
+        classify_option_5(_option)
     });
     assert!(((*rc.borrow()) == 2));
     (*rc.borrow_mut()) = ({
         let _option: i32 = (Option::OPT_C as i32);
-        classify_option_1(_option)
+        classify_option_5(_option)
     });
     assert!(((*rc.borrow()) == 3));
     let t: Value<Tag> = Rc::new(RefCell::new(Tag::TAG_ONE));
@@ -231,41 +231,41 @@ fn main_0() -> i32 {
         (((Color::RED as i32) + (Color::GREEN as i32)) + (Color::BLUE as i32)),
     ));
     assert!(((*extra.borrow()) == ((0 + 1) + 2)));
-    assert!((((*s_global_color.with(Value::clone).borrow()) as i32) == (Color::GREEN as i32)));
-    assert!((((*s_global_opt.with(Value::clone).borrow()) as i32) == (Option::OPT_B as i32)));
-    assert!((((*s_global_tag.with(Value::clone).borrow()) as i32) == (Tag::TAG_TWO as i32)));
+    assert!((((*global_color_0.with(Value::clone).borrow()) as i32) == (Color::GREEN as i32)));
+    assert!((((*global_opt_1.with(Value::clone).borrow()) as i32) == (Option::OPT_B as i32)));
+    assert!((((*global_tag_2.with(Value::clone).borrow()) as i32) == (Tag::TAG_TWO as i32)));
     assert!(
-        (((*(*s_entries.with(Value::clone).borrow())[(0) as usize]
+        (((*(*entries_3.with(Value::clone).borrow())[(0) as usize]
             .color
             .borrow()) as i32)
             == (Color::RED as i32))
     );
     assert!(
-        (((*(*s_entries.with(Value::clone).borrow())[(0) as usize]
+        (((*(*entries_3.with(Value::clone).borrow())[(0) as usize]
             .opt
             .borrow()) as i32)
             == (Option::OPT_NONE as i32))
     );
     assert!(
-        (((*(*s_entries.with(Value::clone).borrow())[(1) as usize]
+        (((*(*entries_3.with(Value::clone).borrow())[(1) as usize]
             .color
             .borrow()) as i32)
             == (Color::GREEN as i32))
     );
     assert!(
-        (((*(*s_entries.with(Value::clone).borrow())[(1) as usize]
+        (((*(*entries_3.with(Value::clone).borrow())[(1) as usize]
             .opt
             .borrow()) as i32)
             == (Option::OPT_A as i32))
     );
     assert!(
-        (((*(*s_entries.with(Value::clone).borrow())[(2) as usize]
+        (((*(*entries_3.with(Value::clone).borrow())[(2) as usize]
             .color
             .borrow()) as i32)
             == (Color::BLUE as i32))
     );
     assert!(
-        (((*(*s_entries.with(Value::clone).borrow())[(2) as usize]
+        (((*(*entries_3.with(Value::clone).borrow())[(2) as usize]
             .opt
             .borrow()) as i32)
             == (Option::OPT_C as i32))

--- a/tests/unit/out/refcount/enum_int_interop_c.rs
+++ b/tests/unit/out/refcount/enum_int_interop_c.rs
@@ -23,6 +23,7 @@ impl From<i32> for Color {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Color);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Option {
     #[default]
@@ -42,6 +43,7 @@ impl From<i32> for Option {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Option);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Tag {
     #[default]
@@ -59,6 +61,7 @@ impl From<i32> for Tag {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Tag);
 #[derive(Default)]
 pub struct Entry {
     pub name: Value<Ptr<u8>>,

--- a/tests/unit/out/refcount/enum_int_interop_c.rs
+++ b/tests/unit/out/refcount/enum_int_interop_c.rs
@@ -70,16 +70,16 @@ pub struct Entry {
 }
 impl ByteRepr for Entry {}
 thread_local!(
-    pub static global_color: Value<Color> = Rc::new(RefCell::new(Color::GREEN));
+    pub static s_global_color: Value<Color> = Rc::new(RefCell::new(Color::GREEN));
 );
 thread_local!(
-    pub static global_opt: Value<Option> = Rc::new(RefCell::new(Option::OPT_B));
+    pub static s_global_opt: Value<Option> = Rc::new(RefCell::new(Option::OPT_B));
 );
 thread_local!(
-    pub static global_tag: Value<Tag> = Rc::new(RefCell::new(Tag::TAG_TWO));
+    pub static s_global_tag: Value<Tag> = Rc::new(RefCell::new(Tag::TAG_TWO));
 );
 thread_local!(
-    pub static entries: Value<Box<[Entry]>> = Rc::new(RefCell::new(Box::new([
+    pub static s_entries: Value<Box<[Entry]>> = Rc::new(RefCell::new(Box::new([
         Entry {
             name: Rc::new(RefCell::new(Ptr::from_string_literal("first"))),
             color: Rc::new(RefCell::new(Color::RED)),
@@ -226,57 +226,57 @@ fn main_0() -> i32 {
     ));
     assert!(((((*extra.borrow()) == ((0 + 1) + 2)) as i32) != 0));
     assert!(
-        (((((*global_color.with(Value::clone).borrow()) as u32) == ((Color::GREEN as i32) as u32))
+        (((((*s_global_color.with(Value::clone).borrow()) as u32) == ((Color::GREEN as i32) as u32))
             as i32)
             != 0)
     );
     assert!(
-        (((((*global_opt.with(Value::clone).borrow()) as u32) == ((Option::OPT_B as i32) as u32))
+        (((((*s_global_opt.with(Value::clone).borrow()) as u32) == ((Option::OPT_B as i32) as u32))
             as i32)
             != 0)
     );
     assert!(
-        (((((*global_tag.with(Value::clone).borrow()) as u32) == ((Tag::TAG_TWO as i32) as u32))
+        (((((*s_global_tag.with(Value::clone).borrow()) as u32) == ((Tag::TAG_TWO as i32) as u32))
             as i32)
             != 0)
     );
     assert!(
-        (((((*(*entries.with(Value::clone).borrow())[(0) as usize]
+        (((((*(*s_entries.with(Value::clone).borrow())[(0) as usize]
             .color
             .borrow()) as u32)
             == ((Color::RED as i32) as u32)) as i32)
             != 0)
     );
     assert!(
-        (((((*(*entries.with(Value::clone).borrow())[(0) as usize]
+        (((((*(*s_entries.with(Value::clone).borrow())[(0) as usize]
             .opt
             .borrow()) as u32)
             == ((Option::OPT_NONE as i32) as u32)) as i32)
             != 0)
     );
     assert!(
-        (((((*(*entries.with(Value::clone).borrow())[(1) as usize]
+        (((((*(*s_entries.with(Value::clone).borrow())[(1) as usize]
             .color
             .borrow()) as u32)
             == ((Color::GREEN as i32) as u32)) as i32)
             != 0)
     );
     assert!(
-        (((((*(*entries.with(Value::clone).borrow())[(1) as usize]
+        (((((*(*s_entries.with(Value::clone).borrow())[(1) as usize]
             .opt
             .borrow()) as u32)
             == ((Option::OPT_A as i32) as u32)) as i32)
             != 0)
     );
     assert!(
-        (((((*(*entries.with(Value::clone).borrow())[(2) as usize]
+        (((((*(*s_entries.with(Value::clone).borrow())[(2) as usize]
             .color
             .borrow()) as u32)
             == ((Color::BLUE as i32) as u32)) as i32)
             != 0)
     );
     assert!(
-        (((((*(*entries.with(Value::clone).borrow())[(2) as usize]
+        (((((*(*s_entries.with(Value::clone).borrow())[(2) as usize]
             .opt
             .borrow()) as u32)
             == ((Option::OPT_C as i32) as u32)) as i32)

--- a/tests/unit/out/refcount/enum_int_interop_c.rs
+++ b/tests/unit/out/refcount/enum_int_interop_c.rs
@@ -23,7 +23,6 @@ impl From<i32> for Color {
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Color);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Option {
     #[default]
@@ -43,7 +42,6 @@ impl From<i32> for Option {
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Option);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Tag {
     #[default]
@@ -61,7 +59,6 @@ impl From<i32> for Tag {
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Tag);
 #[derive(Default)]
 pub struct Entry {
     pub name: Value<Ptr<u8>>,

--- a/tests/unit/out/refcount/enum_int_interop_c.rs
+++ b/tests/unit/out/refcount/enum_int_interop_c.rs
@@ -70,16 +70,16 @@ pub struct Entry {
 }
 impl ByteRepr for Entry {}
 thread_local!(
-    pub static s_global_color: Value<Color> = Rc::new(RefCell::new(Color::GREEN));
+    pub static global_color_0: Value<Color> = Rc::new(RefCell::new(Color::GREEN));
 );
 thread_local!(
-    pub static s_global_opt: Value<Option> = Rc::new(RefCell::new(Option::OPT_B));
+    pub static global_opt_1: Value<Option> = Rc::new(RefCell::new(Option::OPT_B));
 );
 thread_local!(
-    pub static s_global_tag: Value<Tag> = Rc::new(RefCell::new(Tag::TAG_TWO));
+    pub static global_tag_2: Value<Tag> = Rc::new(RefCell::new(Tag::TAG_TWO));
 );
 thread_local!(
-    pub static s_entries: Value<Box<[Entry]>> = Rc::new(RefCell::new(Box::new([
+    pub static entries_3: Value<Box<[Entry]>> = Rc::new(RefCell::new(Box::new([
         Entry {
             name: Rc::new(RefCell::new(Ptr::from_string_literal("first"))),
             color: Rc::new(RefCell::new(Color::RED)),
@@ -97,11 +97,11 @@ thread_local!(
         },
     ])));
 );
-pub fn as_int_0(c: Color) -> i32 {
+pub fn as_int_4(c: Color) -> i32 {
     let c: Value<Color> = Rc::new(RefCell::new(c));
     return ((*c.borrow()) as i32).clone();
 }
-pub fn classify_option_1(option: i32) -> i32 {
+pub fn classify_option_5(option: i32) -> i32 {
     let option: Value<i32> = Rc::new(RefCell::new(option));
     'switch: {
         let __match_cond = (*option.borrow());
@@ -125,7 +125,7 @@ pub fn classify_option_1(option: i32) -> i32 {
     };
     panic!("ub: non-void function does not return a value")
 }
-pub fn make_color_2(n: i32) -> Color {
+pub fn make_color_6(n: i32) -> Color {
     let n: Value<i32> = Rc::new(RefCell::new(n));
     return Color::from((*n.borrow()));
 }
@@ -168,7 +168,7 @@ fn main_0() -> i32 {
     assert!((((((*c.borrow()) as u32) == 2_u32) as i32) != 0));
     (*c.borrow_mut()) = ({
         let _n: i32 = 1;
-        make_color_2(_n)
+        make_color_6(_n)
     });
     assert!((((((*c.borrow()) as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0));
     let cmp: Value<Color> = Rc::new(RefCell::new(Color::from(
@@ -185,18 +185,18 @@ fn main_0() -> i32 {
     let rc: Value<i32> = Rc::new(RefCell::new(
         ({
             let _option: i32 = ((*o.borrow()) as i32).clone();
-            classify_option_1(_option)
+            classify_option_5(_option)
         }),
     ));
     assert!(((((*rc.borrow()) == 2) as i32) != 0));
     (*rc.borrow_mut()) = ({
         let _option: i32 = 20;
-        classify_option_1(_option)
+        classify_option_5(_option)
     });
     assert!(((((*rc.borrow()) == 2) as i32) != 0));
     (*rc.borrow_mut()) = ({
         let _option: i32 = (Option::OPT_C as i32);
-        classify_option_1(_option)
+        classify_option_5(_option)
     });
     assert!(((((*rc.borrow()) == 3) as i32) != 0));
     let t: Value<Tag> = Rc::new(RefCell::new(Tag::TAG_ONE));
@@ -226,57 +226,57 @@ fn main_0() -> i32 {
     ));
     assert!(((((*extra.borrow()) == ((0 + 1) + 2)) as i32) != 0));
     assert!(
-        (((((*s_global_color.with(Value::clone).borrow()) as u32) == ((Color::GREEN as i32) as u32))
+        (((((*global_color_0.with(Value::clone).borrow()) as u32) == ((Color::GREEN as i32) as u32))
             as i32)
             != 0)
     );
     assert!(
-        (((((*s_global_opt.with(Value::clone).borrow()) as u32) == ((Option::OPT_B as i32) as u32))
+        (((((*global_opt_1.with(Value::clone).borrow()) as u32) == ((Option::OPT_B as i32) as u32))
             as i32)
             != 0)
     );
     assert!(
-        (((((*s_global_tag.with(Value::clone).borrow()) as u32) == ((Tag::TAG_TWO as i32) as u32))
+        (((((*global_tag_2.with(Value::clone).borrow()) as u32) == ((Tag::TAG_TWO as i32) as u32))
             as i32)
             != 0)
     );
     assert!(
-        (((((*(*s_entries.with(Value::clone).borrow())[(0) as usize]
+        (((((*(*entries_3.with(Value::clone).borrow())[(0) as usize]
             .color
             .borrow()) as u32)
             == ((Color::RED as i32) as u32)) as i32)
             != 0)
     );
     assert!(
-        (((((*(*s_entries.with(Value::clone).borrow())[(0) as usize]
+        (((((*(*entries_3.with(Value::clone).borrow())[(0) as usize]
             .opt
             .borrow()) as u32)
             == ((Option::OPT_NONE as i32) as u32)) as i32)
             != 0)
     );
     assert!(
-        (((((*(*s_entries.with(Value::clone).borrow())[(1) as usize]
+        (((((*(*entries_3.with(Value::clone).borrow())[(1) as usize]
             .color
             .borrow()) as u32)
             == ((Color::GREEN as i32) as u32)) as i32)
             != 0)
     );
     assert!(
-        (((((*(*s_entries.with(Value::clone).borrow())[(1) as usize]
+        (((((*(*entries_3.with(Value::clone).borrow())[(1) as usize]
             .opt
             .borrow()) as u32)
             == ((Option::OPT_A as i32) as u32)) as i32)
             != 0)
     );
     assert!(
-        (((((*(*s_entries.with(Value::clone).borrow())[(2) as usize]
+        (((((*(*entries_3.with(Value::clone).borrow())[(2) as usize]
             .color
             .borrow()) as u32)
             == ((Color::BLUE as i32) as u32)) as i32)
             != 0)
     );
     assert!(
-        (((((*(*s_entries.with(Value::clone).borrow())[(2) as usize]
+        (((((*(*entries_3.with(Value::clone).borrow())[(2) as usize]
             .opt
             .borrow()) as u32)
             == ((Option::OPT_C as i32) as u32)) as i32)

--- a/tests/unit/out/refcount/fn_ptr_global.rs
+++ b/tests/unit/out/refcount/fn_ptr_global.rs
@@ -15,18 +15,18 @@ pub fn triple_it_1(x: i32) -> i32 {
     return ((*x.borrow()) * 3);
 }
 thread_local!(
-    pub static g_op: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::null()));
+    pub static s_g_op: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::null()));
 );
 pub fn set_op_2(fn_: FnPtr<fn(i32) -> i32>) {
     let fn_: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(fn_));
-    (*g_op.with(Value::clone).borrow_mut()) = (*fn_.borrow()).clone();
+    (*s_g_op.with(Value::clone).borrow_mut()) = (*fn_.borrow()).clone();
 }
 pub fn call_op_3(x: i32) -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(x));
-    if !(*g_op.with(Value::clone).borrow()).is_null() {
+    if !(*s_g_op.with(Value::clone).borrow()).is_null() {
         return ({
             let _arg0: i32 = (*x.borrow());
-            (*(*g_op.with(Value::clone).borrow()))(_arg0)
+            (*(*s_g_op.with(Value::clone).borrow()))(_arg0)
         });
     }
     return (*x.borrow());
@@ -45,9 +45,9 @@ fn main_0() -> i32 {
         let _fn: FnPtr<fn(i32) -> i32> = FnPtr::<fn(i32) -> i32>::new(double_it_0);
         set_op_2(_fn)
     });
-    assert!(!((*g_op.with(Value::clone).borrow()).is_null()));
+    assert!(!((*s_g_op.with(Value::clone).borrow()).is_null()));
     assert!({
-        let _lhs = (*g_op.with(Value::clone).borrow()).clone();
+        let _lhs = (*s_g_op.with(Value::clone).borrow()).clone();
         _lhs == FnPtr::<fn(i32) -> i32>::new(double_it_0)
     });
     assert!(
@@ -61,7 +61,7 @@ fn main_0() -> i32 {
         set_op_2(_fn)
     });
     assert!({
-        let _lhs = (*g_op.with(Value::clone).borrow()).clone();
+        let _lhs = (*s_g_op.with(Value::clone).borrow()).clone();
         _lhs == FnPtr::<fn(i32) -> i32>::new(triple_it_1)
     });
     assert!(
@@ -74,7 +74,7 @@ fn main_0() -> i32 {
         let _fn: FnPtr<fn(i32) -> i32> = FnPtr::null();
         set_op_2(_fn)
     });
-    assert!((*g_op.with(Value::clone).borrow()).is_null());
+    assert!((*s_g_op.with(Value::clone).borrow()).is_null());
     assert!(
         (({
             let _x: i32 = 5;

--- a/tests/unit/out/refcount/fn_ptr_global.rs
+++ b/tests/unit/out/refcount/fn_ptr_global.rs
@@ -15,18 +15,18 @@ pub fn triple_it_1(x: i32) -> i32 {
     return ((*x.borrow()) * 3);
 }
 thread_local!(
-    pub static s_g_op: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::null()));
+    pub static g_op_2: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::null()));
 );
-pub fn set_op_2(fn_: FnPtr<fn(i32) -> i32>) {
+pub fn set_op_3(fn_: FnPtr<fn(i32) -> i32>) {
     let fn_: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(fn_));
-    (*s_g_op.with(Value::clone).borrow_mut()) = (*fn_.borrow()).clone();
+    (*g_op_2.with(Value::clone).borrow_mut()) = (*fn_.borrow()).clone();
 }
-pub fn call_op_3(x: i32) -> i32 {
+pub fn call_op_4(x: i32) -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(x));
-    if !(*s_g_op.with(Value::clone).borrow()).is_null() {
+    if !(*g_op_2.with(Value::clone).borrow()).is_null() {
         return ({
             let _arg0: i32 = (*x.borrow());
-            (*(*s_g_op.with(Value::clone).borrow()))(_arg0)
+            (*(*g_op_2.with(Value::clone).borrow()))(_arg0)
         });
     }
     return (*x.borrow());
@@ -38,47 +38,47 @@ fn main_0() -> i32 {
     assert!(
         (({
             let _x: i32 = 5;
-            call_op_3(_x)
+            call_op_4(_x)
         }) == 5)
     );
     ({
         let _fn: FnPtr<fn(i32) -> i32> = FnPtr::<fn(i32) -> i32>::new(double_it_0);
-        set_op_2(_fn)
+        set_op_3(_fn)
     });
-    assert!(!((*s_g_op.with(Value::clone).borrow()).is_null()));
+    assert!(!((*g_op_2.with(Value::clone).borrow()).is_null()));
     assert!({
-        let _lhs = (*s_g_op.with(Value::clone).borrow()).clone();
+        let _lhs = (*g_op_2.with(Value::clone).borrow()).clone();
         _lhs == FnPtr::<fn(i32) -> i32>::new(double_it_0)
     });
     assert!(
         (({
             let _x: i32 = 5;
-            call_op_3(_x)
+            call_op_4(_x)
         }) == 10)
     );
     ({
         let _fn: FnPtr<fn(i32) -> i32> = FnPtr::<fn(i32) -> i32>::new(triple_it_1);
-        set_op_2(_fn)
+        set_op_3(_fn)
     });
     assert!({
-        let _lhs = (*s_g_op.with(Value::clone).borrow()).clone();
+        let _lhs = (*g_op_2.with(Value::clone).borrow()).clone();
         _lhs == FnPtr::<fn(i32) -> i32>::new(triple_it_1)
     });
     assert!(
         (({
             let _x: i32 = 5;
-            call_op_3(_x)
+            call_op_4(_x)
         }) == 15)
     );
     ({
         let _fn: FnPtr<fn(i32) -> i32> = FnPtr::null();
-        set_op_2(_fn)
+        set_op_3(_fn)
     });
-    assert!((*s_g_op.with(Value::clone).borrow()).is_null());
+    assert!((*g_op_2.with(Value::clone).borrow()).is_null());
     assert!(
         (({
             let _x: i32 = 5;
-            call_op_3(_x)
+            call_op_4(_x)
         }) == 5)
     );
     return 0;

--- a/tests/unit/out/refcount/fn_ptr_vtable.rs
+++ b/tests/unit/out/refcount/fn_ptr_vtable.rs
@@ -33,12 +33,12 @@ impl Default for Vtable {
 }
 impl ByteRepr for Vtable {}
 thread_local!(
-    pub static storage: Value<i32> = <Value<i32>>::default();
+    pub static s_storage: Value<i32> = <Value<i32>>::default();
 );
 pub fn int_create_0(val: i32) -> AnyPtr {
     let val: Value<i32> = Rc::new(RefCell::new(val));
-    (*storage.with(Value::clone).borrow_mut()) = (*val.borrow());
-    return ((storage.with(Value::clone).as_pointer()) as Ptr<i32>).to_any();
+    (*s_storage.with(Value::clone).borrow_mut()) = (*val.borrow());
+    return ((s_storage.with(Value::clone).as_pointer()) as Ptr<i32>).to_any();
 }
 pub fn int_get_1(p: AnyPtr) -> i32 {
     let p: Value<AnyPtr> = Rc::new(RefCell::new(p));
@@ -78,7 +78,7 @@ fn main_0() -> i32 {
         let _arg0: AnyPtr = (*obj.borrow()).clone();
         (*(*(*vt.borrow()).destroy.borrow()))(_arg0)
     });
-    assert!(((*storage.with(Value::clone).borrow()) == 0));
+    assert!(((*s_storage.with(Value::clone).borrow()) == 0));
     (*(*vt.borrow()).get.borrow_mut()) = FnPtr::null();
     assert!((*(*vt.borrow()).get.borrow()).is_null());
     return 0;

--- a/tests/unit/out/refcount/fn_ptr_vtable.rs
+++ b/tests/unit/out/refcount/fn_ptr_vtable.rs
@@ -33,18 +33,18 @@ impl Default for Vtable {
 }
 impl ByteRepr for Vtable {}
 thread_local!(
-    pub static s_storage: Value<i32> = <Value<i32>>::default();
+    pub static storage_0: Value<i32> = <Value<i32>>::default();
 );
-pub fn int_create_0(val: i32) -> AnyPtr {
+pub fn int_create_1(val: i32) -> AnyPtr {
     let val: Value<i32> = Rc::new(RefCell::new(val));
-    (*s_storage.with(Value::clone).borrow_mut()) = (*val.borrow());
-    return ((s_storage.with(Value::clone).as_pointer()) as Ptr<i32>).to_any();
+    (*storage_0.with(Value::clone).borrow_mut()) = (*val.borrow());
+    return ((storage_0.with(Value::clone).as_pointer()) as Ptr<i32>).to_any();
 }
-pub fn int_get_1(p: AnyPtr) -> i32 {
+pub fn int_get_2(p: AnyPtr) -> i32 {
     let p: Value<AnyPtr> = Rc::new(RefCell::new(p));
     return ((*p.borrow()).cast::<i32>().expect("ub:wrong type").read());
 }
-pub fn int_destroy_2(p: AnyPtr) {
+pub fn int_destroy_3(p: AnyPtr) {
     let p: Value<AnyPtr> = Rc::new(RefCell::new(p));
     (*p.borrow()).cast::<i32>().expect("ub:wrong type").write(0);
 }
@@ -54,10 +54,10 @@ pub fn main() {
 fn main_0() -> i32 {
     let vt: Value<Vtable> = Rc::new(RefCell::new(Vtable {
         create: Rc::new(RefCell::new(
-            (FnPtr::<fn(i32) -> AnyPtr>::new(int_create_0)).clone(),
+            (FnPtr::<fn(i32) -> AnyPtr>::new(int_create_1)).clone(),
         )),
-        get: Rc::new(RefCell::new(FnPtr::<fn(AnyPtr) -> i32>::new(int_get_1))),
-        destroy: Rc::new(RefCell::new(FnPtr::<fn(AnyPtr)>::new(int_destroy_2))),
+        get: Rc::new(RefCell::new(FnPtr::<fn(AnyPtr) -> i32>::new(int_get_2))),
+        destroy: Rc::new(RefCell::new(FnPtr::<fn(AnyPtr)>::new(int_destroy_3))),
     }));
     assert!(!((*(*vt.borrow()).create.borrow()).is_null()));
     assert!(!((*(*vt.borrow()).get.borrow()).is_null()));
@@ -78,7 +78,7 @@ fn main_0() -> i32 {
         let _arg0: AnyPtr = (*obj.borrow()).clone();
         (*(*(*vt.borrow()).destroy.borrow()))(_arg0)
     });
-    assert!(((*s_storage.with(Value::clone).borrow()) == 0));
+    assert!(((*storage_0.with(Value::clone).borrow()) == 0));
     (*(*vt.borrow()).get.borrow_mut()) = FnPtr::null();
     assert!((*(*vt.borrow()).get.borrow()).is_null());
     return 0;

--- a/tests/unit/out/refcount/global-initialization-using-global.rs
+++ b/tests/unit/out/refcount/global-initialization-using-global.rs
@@ -7,17 +7,19 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 thread_local!(
-    pub static first: Value<i32> = <Value<i32>>::default();
+    pub static s_first: Value<i32> = <Value<i32>>::default();
 );
 thread_local!(
-    pub static second: Value<i32> =
-        Rc::new(RefCell::new(((*first.with(Value::clone).borrow()) + 1)));
+    pub static s_second: Value<i32> =
+        Rc::new(RefCell::new(((*s_first.with(Value::clone).borrow()) + 1)));
 );
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    assert!(((*first.with(Value::clone).borrow()) == 0));
-    assert!(((*second.with(Value::clone).borrow()) == ((*first.with(Value::clone).borrow()) + 1)));
+    assert!(((*s_first.with(Value::clone).borrow()) == 0));
+    assert!(
+        ((*s_second.with(Value::clone).borrow()) == ((*s_first.with(Value::clone).borrow()) + 1))
+    );
     return 0;
 }

--- a/tests/unit/out/refcount/global-initialization-using-global.rs
+++ b/tests/unit/out/refcount/global-initialization-using-global.rs
@@ -7,19 +7,19 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 thread_local!(
-    pub static s_first: Value<i32> = <Value<i32>>::default();
+    pub static first_0: Value<i32> = <Value<i32>>::default();
 );
 thread_local!(
-    pub static s_second: Value<i32> =
-        Rc::new(RefCell::new(((*s_first.with(Value::clone).borrow()) + 1)));
+    pub static second_1: Value<i32> =
+        Rc::new(RefCell::new(((*first_0.with(Value::clone).borrow()) + 1)));
 );
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    assert!(((*s_first.with(Value::clone).borrow()) == 0));
+    assert!(((*first_0.with(Value::clone).borrow()) == 0));
     assert!(
-        ((*s_second.with(Value::clone).borrow()) == ((*s_first.with(Value::clone).borrow()) + 1))
+        ((*second_1.with(Value::clone).borrow()) == ((*first_0.with(Value::clone).borrow()) + 1))
     );
     return 0;
 }

--- a/tests/unit/out/refcount/global_pointers.rs
+++ b/tests/unit/out/refcount/global_pointers.rs
@@ -22,13 +22,13 @@ impl Clone for Entry {
 }
 impl ByteRepr for Entry {}
 thread_local!(
-    pub static single_entry: Value<Entry> = Rc::new(RefCell::new(Entry {
+    pub static s_single_entry: Value<Entry> = Rc::new(RefCell::new(Entry {
         name: Rc::new(RefCell::new(Ptr::from_string_literal("alone"))),
         p: Rc::new(RefCell::new(Ptr::<i32>::null())),
     }));
 );
 thread_local!(
-    pub static entries: Value<Box<[Entry]>> = Rc::new(RefCell::new(Box::new([
+    pub static s_entries: Value<Box<[Entry]>> = Rc::new(RefCell::new(Box::new([
         Entry {
             name: Rc::new(RefCell::new(Ptr::from_string_literal("first"))),
             p: Rc::new(RefCell::new(Ptr::<i32>::null())),
@@ -40,7 +40,7 @@ thread_local!(
     ])));
 );
 thread_local!(
-    pub static arr_of_pointers: Value<Box<[Ptr<u8>]>> = Rc::new(RefCell::new(Box::new([
+    pub static s_arr_of_pointers: Value<Box<[Ptr<u8>]>> = Rc::new(RefCell::new(Box::new([
         Ptr::<u8>::null(),
         Ptr::<u8>::null(),
         Ptr::<u8>::null(),
@@ -50,16 +50,18 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    assert!((*(*single_entry.with(Value::clone).borrow()).p.borrow()).is_null());
+    assert!((*(*s_single_entry.with(Value::clone).borrow()).p.borrow()).is_null());
     let i: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while ((*i.borrow()) < 2) {
         assert!(
-            (*(*entries.with(Value::clone).borrow())[(*i.borrow()) as usize]
+            (*(*s_entries.with(Value::clone).borrow())[(*i.borrow()) as usize]
                 .p
                 .borrow())
             .is_null()
         );
-        assert!(((*arr_of_pointers.with(Value::clone).borrow())[(*i.borrow()) as usize]).is_null());
+        assert!(
+            ((*s_arr_of_pointers.with(Value::clone).borrow())[(*i.borrow()) as usize]).is_null()
+        );
         (*i.borrow_mut()).prefix_inc();
     }
     return 0;

--- a/tests/unit/out/refcount/global_pointers.rs
+++ b/tests/unit/out/refcount/global_pointers.rs
@@ -22,13 +22,13 @@ impl Clone for Entry {
 }
 impl ByteRepr for Entry {}
 thread_local!(
-    pub static s_single_entry: Value<Entry> = Rc::new(RefCell::new(Entry {
+    pub static single_entry_0: Value<Entry> = Rc::new(RefCell::new(Entry {
         name: Rc::new(RefCell::new(Ptr::from_string_literal("alone"))),
         p: Rc::new(RefCell::new(Ptr::<i32>::null())),
     }));
 );
 thread_local!(
-    pub static s_entries: Value<Box<[Entry]>> = Rc::new(RefCell::new(Box::new([
+    pub static entries_1: Value<Box<[Entry]>> = Rc::new(RefCell::new(Box::new([
         Entry {
             name: Rc::new(RefCell::new(Ptr::from_string_literal("first"))),
             p: Rc::new(RefCell::new(Ptr::<i32>::null())),
@@ -40,7 +40,7 @@ thread_local!(
     ])));
 );
 thread_local!(
-    pub static s_arr_of_pointers: Value<Box<[Ptr<u8>]>> = Rc::new(RefCell::new(Box::new([
+    pub static arr_of_pointers_2: Value<Box<[Ptr<u8>]>> = Rc::new(RefCell::new(Box::new([
         Ptr::<u8>::null(),
         Ptr::<u8>::null(),
         Ptr::<u8>::null(),
@@ -50,17 +50,17 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    assert!((*(*s_single_entry.with(Value::clone).borrow()).p.borrow()).is_null());
+    assert!((*(*single_entry_0.with(Value::clone).borrow()).p.borrow()).is_null());
     let i: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while ((*i.borrow()) < 2) {
         assert!(
-            (*(*s_entries.with(Value::clone).borrow())[(*i.borrow()) as usize]
+            (*(*entries_1.with(Value::clone).borrow())[(*i.borrow()) as usize]
                 .p
                 .borrow())
             .is_null()
         );
         assert!(
-            ((*s_arr_of_pointers.with(Value::clone).borrow())[(*i.borrow()) as usize]).is_null()
+            ((*arr_of_pointers_2.with(Value::clone).borrow())[(*i.borrow()) as usize]).is_null()
         );
         (*i.borrow_mut()).prefix_inc();
     }

--- a/tests/unit/out/refcount/global_without_initializer.rs
+++ b/tests/unit/out/refcount/global_without_initializer.rs
@@ -29,20 +29,20 @@ impl ByteRepr for S {
     }
 }
 thread_local!(
-    pub static s: Value<Ptr<S>> = Rc::new(RefCell::new(Ptr::<S>::null()));
+    pub static s_s: Value<Ptr<S>> = Rc::new(RefCell::new(Ptr::<S>::null()));
 );
 thread_local!(
-    pub static file: Value<Ptr<::std::fs::File>> = Rc::new(RefCell::new(Ptr::null()));
+    pub static s_file: Value<Ptr<::std::fs::File>> = Rc::new(RefCell::new(Ptr::null()));
 );
 thread_local!(
-    pub static size: Value<u64> = <Value<u64>>::default();
+    pub static s_size: Value<u64> = <Value<u64>>::default();
 );
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    assert!((*s.with(Value::clone).borrow()).is_null());
-    assert!((*file.with(Value::clone).borrow()).is_null());
-    assert!(((*size.with(Value::clone).borrow()) == 0_u64));
+    assert!((*s_s.with(Value::clone).borrow()).is_null());
+    assert!((*s_file.with(Value::clone).borrow()).is_null());
+    assert!(((*s_size.with(Value::clone).borrow()) == 0_u64));
     return 0;
 }

--- a/tests/unit/out/refcount/global_without_initializer.rs
+++ b/tests/unit/out/refcount/global_without_initializer.rs
@@ -29,20 +29,20 @@ impl ByteRepr for S {
     }
 }
 thread_local!(
-    pub static s_s: Value<Ptr<S>> = Rc::new(RefCell::new(Ptr::<S>::null()));
+    pub static s_0: Value<Ptr<S>> = Rc::new(RefCell::new(Ptr::<S>::null()));
 );
 thread_local!(
-    pub static s_file: Value<Ptr<::std::fs::File>> = Rc::new(RefCell::new(Ptr::null()));
+    pub static file_1: Value<Ptr<::std::fs::File>> = Rc::new(RefCell::new(Ptr::null()));
 );
 thread_local!(
-    pub static s_size: Value<u64> = <Value<u64>>::default();
+    pub static size_2: Value<u64> = <Value<u64>>::default();
 );
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    assert!((*s_s.with(Value::clone).borrow()).is_null());
-    assert!((*s_file.with(Value::clone).borrow()).is_null());
-    assert!(((*s_size.with(Value::clone).borrow()) == 0_u64));
+    assert!((*s_0.with(Value::clone).borrow()).is_null());
+    assert!((*file_1.with(Value::clone).borrow()).is_null());
+    assert!(((*size_2.with(Value::clone).borrow()) == 0_u64));
     return 0;
 }

--- a/tests/unit/out/refcount/null_in_statics.rs
+++ b/tests/unit/out/refcount/null_in_statics.rs
@@ -7,58 +7,58 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 thread_local!(
-    pub static p_mut: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
+    pub static s_p_mut: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
 );
 thread_local!(
-    pub static p_const: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
+    pub static s_p_const: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
 );
 thread_local!(
-    pub static cp: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::<u8>::null()));
+    pub static s_cp: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::<u8>::null()));
 );
 thread_local!(
-    pub static arr_of_ptr: Value<Box<[Ptr<i32>]>> = Rc::new(RefCell::new(
+    pub static s_arr_of_ptr: Value<Box<[Ptr<i32>]>> = Rc::new(RefCell::new(
         (0..4)
             .map(|_| Ptr::<i32>::null())
             .collect::<Box<[Ptr<i32>]>>(),
     ));
 );
 thread_local!(
-    pub static pp: Value<Ptr<Ptr<i32>>> = Rc::new(RefCell::new(Ptr::<Ptr<i32>>::null()));
+    pub static s_pp: Value<Ptr<Ptr<i32>>> = Rc::new(RefCell::new(Ptr::<Ptr<i32>>::null()));
 );
 thread_local!(
-    pub static const_arr_of_ptr: Value<Box<[Ptr<i32>]>> = Rc::new(RefCell::new(
+    pub static s_const_arr_of_ptr: Value<Box<[Ptr<i32>]>> = Rc::new(RefCell::new(
         (0..3)
             .map(|_| Ptr::<i32>::null())
             .collect::<Box<[Ptr<i32>]>>(),
     ));
 );
 thread_local!(
-    pub static cp_explicit_null: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::<u8>::null()));
+    pub static s_cp_explicit_null: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::<u8>::null()));
 );
 thread_local!(
-    pub static p_zero: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
+    pub static s_p_zero: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
 );
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    assert!((*p_mut.with(Value::clone).borrow()).is_null());
-    assert!((*p_const.with(Value::clone).borrow()).is_null());
-    assert!((*cp.with(Value::clone).borrow()).is_null());
+    assert!((*s_p_mut.with(Value::clone).borrow()).is_null());
+    assert!((*s_p_const.with(Value::clone).borrow()).is_null());
+    assert!((*s_cp.with(Value::clone).borrow()).is_null());
     let i: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while ((*i.borrow()) < 4) {
-        assert!(((*arr_of_ptr.with(Value::clone).borrow())[(*i.borrow()) as usize]).is_null());
+        assert!(((*s_arr_of_ptr.with(Value::clone).borrow())[(*i.borrow()) as usize]).is_null());
         (*i.borrow_mut()).prefix_inc();
     }
-    assert!((*pp.with(Value::clone).borrow()).is_null());
+    assert!((*s_pp.with(Value::clone).borrow()).is_null());
     let i: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while ((*i.borrow()) < 3) {
         assert!(
-            ((*const_arr_of_ptr.with(Value::clone).borrow())[(*i.borrow()) as usize]).is_null()
+            ((*s_const_arr_of_ptr.with(Value::clone).borrow())[(*i.borrow()) as usize]).is_null()
         );
         (*i.borrow_mut()).prefix_inc();
     }
-    assert!((*cp_explicit_null.with(Value::clone).borrow()).is_null());
-    assert!((*p_zero.with(Value::clone).borrow()).is_null());
+    assert!((*s_cp_explicit_null.with(Value::clone).borrow()).is_null());
+    assert!((*s_p_zero.with(Value::clone).borrow()).is_null());
     return 0;
 }

--- a/tests/unit/out/refcount/null_in_statics.rs
+++ b/tests/unit/out/refcount/null_in_statics.rs
@@ -7,58 +7,58 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 thread_local!(
-    pub static s_p_mut: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
+    pub static p_mut_0: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
 );
 thread_local!(
-    pub static s_p_const: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
+    pub static p_const_1: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
 );
 thread_local!(
-    pub static s_cp: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::<u8>::null()));
+    pub static cp_2: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::<u8>::null()));
 );
 thread_local!(
-    pub static s_arr_of_ptr: Value<Box<[Ptr<i32>]>> = Rc::new(RefCell::new(
+    pub static arr_of_ptr_3: Value<Box<[Ptr<i32>]>> = Rc::new(RefCell::new(
         (0..4)
             .map(|_| Ptr::<i32>::null())
             .collect::<Box<[Ptr<i32>]>>(),
     ));
 );
 thread_local!(
-    pub static s_pp: Value<Ptr<Ptr<i32>>> = Rc::new(RefCell::new(Ptr::<Ptr<i32>>::null()));
+    pub static pp_4: Value<Ptr<Ptr<i32>>> = Rc::new(RefCell::new(Ptr::<Ptr<i32>>::null()));
 );
 thread_local!(
-    pub static s_const_arr_of_ptr: Value<Box<[Ptr<i32>]>> = Rc::new(RefCell::new(
+    pub static const_arr_of_ptr_5: Value<Box<[Ptr<i32>]>> = Rc::new(RefCell::new(
         (0..3)
             .map(|_| Ptr::<i32>::null())
             .collect::<Box<[Ptr<i32>]>>(),
     ));
 );
 thread_local!(
-    pub static s_cp_explicit_null: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::<u8>::null()));
+    pub static cp_explicit_null_6: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::<u8>::null()));
 );
 thread_local!(
-    pub static s_p_zero: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
+    pub static p_zero_7: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
 );
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    assert!((*s_p_mut.with(Value::clone).borrow()).is_null());
-    assert!((*s_p_const.with(Value::clone).borrow()).is_null());
-    assert!((*s_cp.with(Value::clone).borrow()).is_null());
+    assert!((*p_mut_0.with(Value::clone).borrow()).is_null());
+    assert!((*p_const_1.with(Value::clone).borrow()).is_null());
+    assert!((*cp_2.with(Value::clone).borrow()).is_null());
     let i: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while ((*i.borrow()) < 4) {
-        assert!(((*s_arr_of_ptr.with(Value::clone).borrow())[(*i.borrow()) as usize]).is_null());
+        assert!(((*arr_of_ptr_3.with(Value::clone).borrow())[(*i.borrow()) as usize]).is_null());
         (*i.borrow_mut()).prefix_inc();
     }
-    assert!((*s_pp.with(Value::clone).borrow()).is_null());
+    assert!((*pp_4.with(Value::clone).borrow()).is_null());
     let i: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while ((*i.borrow()) < 3) {
         assert!(
-            ((*s_const_arr_of_ptr.with(Value::clone).borrow())[(*i.borrow()) as usize]).is_null()
+            ((*const_arr_of_ptr_5.with(Value::clone).borrow())[(*i.borrow()) as usize]).is_null()
         );
         (*i.borrow_mut()).prefix_inc();
     }
-    assert!((*s_cp_explicit_null.with(Value::clone).borrow()).is_null());
-    assert!((*s_p_zero.with(Value::clone).borrow()).is_null());
+    assert!((*cp_explicit_null_6.with(Value::clone).borrow()).is_null());
+    assert!((*p_zero_7.with(Value::clone).borrow()).is_null());
     return 0;
 }

--- a/tests/unit/out/refcount/static_function_vars_same_name.rs
+++ b/tests/unit/out/refcount/static_function_vars_same_name.rs
@@ -1,0 +1,28 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn a_0() -> i32 {
+    thread_local!(
+        static i_1: Value<i32> = Rc::new(RefCell::new(1));
+    );
+    return (*i_1.with(Value::clone).borrow());
+}
+pub fn b_2() -> i32 {
+    thread_local!(
+        static i_3: Value<i32> = Rc::new(RefCell::new(2));
+    );
+    return (*i_3.with(Value::clone).borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!((({ a_0() }) == 1));
+    assert!((({ b_2() }) == 2));
+    return 0;
+}

--- a/tests/unit/out/refcount/static_local.rs
+++ b/tests/unit/out/refcount/static_local.rs
@@ -8,23 +8,23 @@ use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 pub fn foo_0() -> i32 {
     thread_local!(
-        static static_i: Value<i32> = <Value<i32>>::default();
+        static s_static_i: Value<i32> = <Value<i32>>::default();
     );
     thread_local!(
-        static static_f: Value<f32> = <Value<f32>>::default();
+        static s_static_f: Value<f32> = <Value<f32>>::default();
     );
     thread_local!(
-        static static_b: Value<bool> = <Value<bool>>::default();
+        static s_static_b: Value<bool> = <Value<bool>>::default();
     );
     thread_local!(
-        static kX1: Value<i32> = Rc::new(RefCell::new(1));
+        static s_kX1: Value<i32> = Rc::new(RefCell::new(1));
     );
     thread_local!(
-        static kX2: Value<i32> = Rc::new(RefCell::new(2));
+        static s_kX2: Value<i32> = Rc::new(RefCell::new(2));
     );
-    (*kX1.with(Value::clone).borrow_mut()) += 1;
-    return (((*kX1.with(Value::clone).borrow()) + (*kX2.with(Value::clone).borrow()))
-        + (*static_i.with(Value::clone).borrow()));
+    (*s_kX1.with(Value::clone).borrow_mut()) += 1;
+    return (((*s_kX1.with(Value::clone).borrow()) + (*s_kX2.with(Value::clone).borrow()))
+        + (*s_static_i.with(Value::clone).borrow()));
 }
 pub fn main() {
     std::process::exit(main_0());

--- a/tests/unit/out/refcount/static_local.rs
+++ b/tests/unit/out/refcount/static_local.rs
@@ -8,23 +8,23 @@ use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 pub fn foo_0() -> i32 {
     thread_local!(
-        static s_static_i: Value<i32> = <Value<i32>>::default();
+        static static_i_1: Value<i32> = <Value<i32>>::default();
     );
     thread_local!(
-        static s_static_f: Value<f32> = <Value<f32>>::default();
+        static static_f_2: Value<f32> = <Value<f32>>::default();
     );
     thread_local!(
-        static s_static_b: Value<bool> = <Value<bool>>::default();
+        static static_b_3: Value<bool> = <Value<bool>>::default();
     );
     thread_local!(
-        static s_kX1: Value<i32> = Rc::new(RefCell::new(1));
+        static kX1_4: Value<i32> = Rc::new(RefCell::new(1));
     );
     thread_local!(
-        static s_kX2: Value<i32> = Rc::new(RefCell::new(2));
+        static kX2_5: Value<i32> = Rc::new(RefCell::new(2));
     );
-    (*s_kX1.with(Value::clone).borrow_mut()) += 1;
-    return (((*s_kX1.with(Value::clone).borrow()) + (*s_kX2.with(Value::clone).borrow()))
-        + (*s_static_i.with(Value::clone).borrow()));
+    (*kX1_4.with(Value::clone).borrow_mut()) += 1;
+    return (((*kX1_4.with(Value::clone).borrow()) + (*kX2_5.with(Value::clone).borrow()))
+        + (*static_i_1.with(Value::clone).borrow()));
 }
 pub fn main() {
     std::process::exit(main_0());

--- a/tests/unit/out/refcount/static_shadow.rs
+++ b/tests/unit/out/refcount/static_shadow.rs
@@ -1,0 +1,37 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+thread_local!(
+    pub static s_value: Value<i32> = Rc::new(RefCell::new(5));
+);
+pub fn param_shadow_0(value: i32) -> i32 {
+    let value: Value<i32> = Rc::new(RefCell::new(value));
+    return ((*value.borrow()) + 1);
+}
+pub fn local_shadow_1() -> i32 {
+    let value: Value<i32> = Rc::new(RefCell::new(99));
+    return (*value.borrow());
+}
+pub fn read_global_2() -> i32 {
+    return (*s_value.with(Value::clone).borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(
+        (((({
+            let _value: i32 = 10;
+            param_shadow_0(_value)
+        }) == 11) as i32)
+            != 0)
+    );
+    assert!((((({ local_shadow_1() }) == 99) as i32) != 0));
+    assert!((((({ read_global_2() }) == 5) as i32) != 0));
+    return 0;
+}

--- a/tests/unit/out/refcount/static_shadow.rs
+++ b/tests/unit/out/refcount/static_shadow.rs
@@ -7,18 +7,18 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 thread_local!(
-    pub static s_value: Value<i32> = Rc::new(RefCell::new(5));
+    pub static value_0: Value<i32> = Rc::new(RefCell::new(5));
 );
-pub fn param_shadow_0(value: i32) -> i32 {
+pub fn param_shadow_1(value: i32) -> i32 {
     let value: Value<i32> = Rc::new(RefCell::new(value));
     return ((*value.borrow()) + 1);
 }
-pub fn local_shadow_1() -> i32 {
+pub fn local_shadow_2() -> i32 {
     let value: Value<i32> = Rc::new(RefCell::new(99));
     return (*value.borrow());
 }
-pub fn read_global_2() -> i32 {
-    return (*s_value.with(Value::clone).borrow());
+pub fn read_global_3() -> i32 {
+    return (*value_0.with(Value::clone).borrow());
 }
 pub fn main() {
     std::process::exit(main_0());
@@ -27,11 +27,11 @@ fn main_0() -> i32 {
     assert!(
         (((({
             let _value: i32 = 10;
-            param_shadow_0(_value)
+            param_shadow_1(_value)
         }) == 11) as i32)
             != 0)
     );
-    assert!((((({ local_shadow_1() }) == 99) as i32) != 0));
-    assert!((((({ read_global_2() }) == 5) as i32) != 0));
+    assert!((((({ local_shadow_2() }) == 99) as i32) != 0));
+    assert!((((({ read_global_3() }) == 5) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/refcount/static_var_in_class.rs
+++ b/tests/unit/out/refcount/static_var_in_class.rs
@@ -7,13 +7,13 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 thread_local!(
-    static C_inner_const: Value<i32> = Rc::new(RefCell::new(1));
+    static s_C_inner_const: Value<i32> = Rc::new(RefCell::new(1));
 );
 #[derive(Default)]
 pub struct C {}
 impl C {
     pub fn get(&self) -> i32 {
-        return (*C_inner_const.with(Value::clone).borrow());
+        return (*s_C_inner_const.with(Value::clone).borrow());
     }
 }
 impl Clone for C {
@@ -29,7 +29,7 @@ impl ByteRepr for C {
     }
 }
 thread_local!(
-    pub static S_inner_const: Value<i32> = Rc::new(RefCell::new(2));
+    pub static s_S_inner_const: Value<i32> = Rc::new(RefCell::new(2));
 );
 #[derive(Default)]
 pub struct S {}
@@ -51,6 +51,6 @@ pub fn main() {
 fn main_0() -> i32 {
     let c: Value<C> = Rc::new(RefCell::new(<C>::default()));
     assert!((({ (*c.borrow()).get() }) == 1));
-    assert!(((*S_inner_const.with(Value::clone).borrow()) == 2));
+    assert!(((*s_S_inner_const.with(Value::clone).borrow()) == 2));
     return 0;
 }

--- a/tests/unit/out/refcount/static_var_in_class.rs
+++ b/tests/unit/out/refcount/static_var_in_class.rs
@@ -7,13 +7,13 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 thread_local!(
-    static s_C_inner_const: Value<i32> = Rc::new(RefCell::new(1));
+    static inner_const_0: Value<i32> = Rc::new(RefCell::new(1));
 );
 #[derive(Default)]
 pub struct C {}
 impl C {
     pub fn get(&self) -> i32 {
-        return (*s_C_inner_const.with(Value::clone).borrow());
+        return (*inner_const_0.with(Value::clone).borrow());
     }
 }
 impl Clone for C {
@@ -29,7 +29,7 @@ impl ByteRepr for C {
     }
 }
 thread_local!(
-    pub static s_S_inner_const: Value<i32> = Rc::new(RefCell::new(2));
+    pub static inner_const_1: Value<i32> = Rc::new(RefCell::new(2));
 );
 #[derive(Default)]
 pub struct S {}
@@ -51,6 +51,6 @@ pub fn main() {
 fn main_0() -> i32 {
     let c: Value<C> = Rc::new(RefCell::new(<C>::default()));
     assert!((({ (*c.borrow()).get() }) == 1));
-    assert!(((*s_S_inner_const.with(Value::clone).borrow()) == 2));
+    assert!(((*inner_const_1.with(Value::clone).borrow()) == 2));
     return 0;
 }

--- a/tests/unit/out/refcount/string_escape.rs
+++ b/tests/unit/out/refcount/string_escape.rs
@@ -14,7 +14,7 @@ fn main_0() -> i32 {
         "\x07\x08\t\n\x0b\x0c\r !\"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~",
     )));
     thread_local!(
-        static expected: Value<Box<[u8]>> = Rc::new(RefCell::new(Box::new([
+        static s_expected: Value<Box<[u8]>> = Rc::new(RefCell::new(Box::new([
             7_u8, 8_u8, 9_u8, 10_u8, 11_u8, 12_u8, 13_u8, 32_u8, 33_u8, 34_u8, 35_u8, 36_u8, 37_u8,
             38_u8, 39_u8, 40_u8, 41_u8, 42_u8, 43_u8, 44_u8, 45_u8, 46_u8, 47_u8, 58_u8, 59_u8,
             60_u8, 61_u8, 62_u8, 63_u8, 64_u8, 91_u8, 92_u8, 93_u8, 94_u8, 95_u8, 96_u8, 123_u8,
@@ -28,7 +28,7 @@ fn main_0() -> i32 {
     {
         assert!({
             let _lhs = (((*special.borrow()).offset((*i.borrow()) as isize).read()) as i32);
-            _lhs == ((*expected.with(Value::clone).borrow())[(*i.borrow()) as usize] as i32)
+            _lhs == ((*s_expected.with(Value::clone).borrow())[(*i.borrow()) as usize] as i32)
         });
         (*i.borrow_mut()).postfix_inc();
     }

--- a/tests/unit/out/refcount/string_escape.rs
+++ b/tests/unit/out/refcount/string_escape.rs
@@ -14,7 +14,7 @@ fn main_0() -> i32 {
         "\x07\x08\t\n\x0b\x0c\r !\"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~",
     )));
     thread_local!(
-        static s_expected: Value<Box<[u8]>> = Rc::new(RefCell::new(Box::new([
+        static expected_0: Value<Box<[u8]>> = Rc::new(RefCell::new(Box::new([
             7_u8, 8_u8, 9_u8, 10_u8, 11_u8, 12_u8, 13_u8, 32_u8, 33_u8, 34_u8, 35_u8, 36_u8, 37_u8,
             38_u8, 39_u8, 40_u8, 41_u8, 42_u8, 43_u8, 44_u8, 45_u8, 46_u8, 47_u8, 58_u8, 59_u8,
             60_u8, 61_u8, 62_u8, 63_u8, 64_u8, 91_u8, 92_u8, 93_u8, 94_u8, 95_u8, 96_u8, 123_u8,
@@ -28,7 +28,7 @@ fn main_0() -> i32 {
     {
         assert!({
             let _lhs = (((*special.borrow()).offset((*i.borrow()) as isize).read()) as i32);
-            _lhs == ((*s_expected.with(Value::clone).borrow())[(*i.borrow()) as usize] as i32)
+            _lhs == ((*expected_0.with(Value::clone).borrow())[(*i.borrow()) as usize] as i32)
         });
         (*i.borrow_mut()).postfix_inc();
     }

--- a/tests/unit/out/refcount/void_cast.rs
+++ b/tests/unit/out/refcount/void_cast.rs
@@ -31,11 +31,11 @@ pub fn unused_ptr_param_2(p: Ptr<NonTrivial>) {
     (*(*p.borrow()).upgrade().deref()).clone();
 }
 thread_local!(
-    pub static side_effect_counter: Value<i32> = Rc::new(RefCell::new(0));
+    pub static s_side_effect_counter: Value<i32> = Rc::new(RefCell::new(0));
 );
 pub fn bump_and_return_3() -> i32 {
-    (*side_effect_counter.with(Value::clone).borrow_mut()).prefix_inc();
-    return (*side_effect_counter.with(Value::clone).borrow());
+    (*s_side_effect_counter.with(Value::clone).borrow_mut()).prefix_inc();
+    return (*s_side_effect_counter.with(Value::clone).borrow());
 }
 #[derive(Default)]
 pub struct Holder {
@@ -83,12 +83,12 @@ fn main_0() -> i32 {
     assert!(((*w.borrow()) == 3));
     assert!(((*counter.borrow()) == 3));
     ({ bump_and_return_3() });
-    assert!(((*side_effect_counter.with(Value::clone).borrow()) == 1));
+    assert!(((*s_side_effect_counter.with(Value::clone).borrow()) == 1));
     let v: Value<i32> = Rc::new(RefCell::new({
         ({ bump_and_return_3() });
         99
     }));
-    assert!(((*side_effect_counter.with(Value::clone).borrow()) == 2));
+    assert!(((*s_side_effect_counter.with(Value::clone).borrow()) == 2));
     assert!(((*v.borrow()) == 99));
     0;
     (0);
@@ -105,11 +105,11 @@ fn main_0() -> i32 {
     assert!(((*err.borrow()) == 7));
     assert!(((*chosen.borrow()) == 123));
     bump_and_return_3;
-    assert!(((*side_effect_counter.with(Value::clone).borrow()) == 2));
+    assert!(((*s_side_effect_counter.with(Value::clone).borrow()) == 2));
     (FnPtr::<fn() -> i32>::new(bump_and_return_3));
-    assert!(((*side_effect_counter.with(Value::clone).borrow()) == 2));
+    assert!(((*s_side_effect_counter.with(Value::clone).borrow()) == 2));
     ((FnPtr::<fn() -> i32>::new(bump_and_return_3)).cast::<fn() -> i32>(None));
-    assert!(((*side_effect_counter.with(Value::clone).borrow()) == 2));
+    assert!(((*s_side_effect_counter.with(Value::clone).borrow()) == 2));
     let storage: Value<i32> = Rc::new(RefCell::new(11));
     let p: Value<Ptr<i32>> = Rc::new(RefCell::new((storage.as_pointer())));
     ((*p.borrow()).read());

--- a/tests/unit/out/refcount/void_cast.rs
+++ b/tests/unit/out/refcount/void_cast.rs
@@ -31,11 +31,11 @@ pub fn unused_ptr_param_2(p: Ptr<NonTrivial>) {
     (*(*p.borrow()).upgrade().deref()).clone();
 }
 thread_local!(
-    pub static s_side_effect_counter: Value<i32> = Rc::new(RefCell::new(0));
+    pub static side_effect_counter_3: Value<i32> = Rc::new(RefCell::new(0));
 );
-pub fn bump_and_return_3() -> i32 {
-    (*s_side_effect_counter.with(Value::clone).borrow_mut()).prefix_inc();
-    return (*s_side_effect_counter.with(Value::clone).borrow());
+pub fn bump_and_return_4() -> i32 {
+    (*side_effect_counter_3.with(Value::clone).borrow_mut()).prefix_inc();
+    return (*side_effect_counter_3.with(Value::clone).borrow());
 }
 #[derive(Default)]
 pub struct Holder {
@@ -82,13 +82,13 @@ fn main_0() -> i32 {
     }));
     assert!(((*w.borrow()) == 3));
     assert!(((*counter.borrow()) == 3));
-    ({ bump_and_return_3() });
-    assert!(((*s_side_effect_counter.with(Value::clone).borrow()) == 1));
+    ({ bump_and_return_4() });
+    assert!(((*side_effect_counter_3.with(Value::clone).borrow()) == 1));
     let v: Value<i32> = Rc::new(RefCell::new({
-        ({ bump_and_return_3() });
+        ({ bump_and_return_4() });
         99
     }));
-    assert!(((*s_side_effect_counter.with(Value::clone).borrow()) == 2));
+    assert!(((*side_effect_counter_3.with(Value::clone).borrow()) == 2));
     assert!(((*v.borrow()) == 99));
     0;
     (0);
@@ -104,12 +104,12 @@ fn main_0() -> i32 {
     }));
     assert!(((*err.borrow()) == 7));
     assert!(((*chosen.borrow()) == 123));
-    bump_and_return_3;
-    assert!(((*s_side_effect_counter.with(Value::clone).borrow()) == 2));
-    (FnPtr::<fn() -> i32>::new(bump_and_return_3));
-    assert!(((*s_side_effect_counter.with(Value::clone).borrow()) == 2));
-    ((FnPtr::<fn() -> i32>::new(bump_and_return_3)).cast::<fn() -> i32>(None));
-    assert!(((*s_side_effect_counter.with(Value::clone).borrow()) == 2));
+    bump_and_return_4;
+    assert!(((*side_effect_counter_3.with(Value::clone).borrow()) == 2));
+    (FnPtr::<fn() -> i32>::new(bump_and_return_4));
+    assert!(((*side_effect_counter_3.with(Value::clone).borrow()) == 2));
+    ((FnPtr::<fn() -> i32>::new(bump_and_return_4)).cast::<fn() -> i32>(None));
+    assert!(((*side_effect_counter_3.with(Value::clone).borrow()) == 2));
     let storage: Value<i32> = Rc::new(RefCell::new(11));
     let p: Value<Ptr<i32>> = Rc::new(RefCell::new((storage.as_pointer())));
     ((*p.borrow()).read());

--- a/tests/unit/out/unsafe/addr_of_global.rs
+++ b/tests/unit/out/unsafe/addr_of_global.rs
@@ -16,18 +16,18 @@ pub struct Inner {
 pub struct Outer {
     pub p: *mut Inner,
 }
-pub static mut alpha: Inner = unsafe { Inner { value: 1 } };
-pub static mut beta: Inner = unsafe { Inner { value: 2 } };
-pub static mut shared: Inner = unsafe { Inner { value: 42 } };
-pub static mut items: [*mut Inner; 2] = unsafe {
+pub static mut s_alpha: Inner = unsafe { Inner { value: 1 } };
+pub static mut s_beta: Inner = unsafe { Inner { value: 2 } };
+pub static mut s_shared: Inner = unsafe { Inner { value: 42 } };
+pub static mut s_items: [*mut Inner; 2] = unsafe {
     [
-        (&raw mut alpha as *mut Inner),
-        (&raw mut beta as *mut Inner),
+        (&raw mut s_alpha as *mut Inner),
+        (&raw mut s_beta as *mut Inner),
     ]
 };
-pub static mut obj: Outer = unsafe {
+pub static mut s_obj: Outer = unsafe {
     Outer {
-        p: (&raw mut shared as *mut Inner),
+        p: (&raw mut s_shared as *mut Inner),
     }
 };
 pub fn main() {
@@ -36,16 +36,16 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    assert!((((*items[(0) as usize]).value) == (1)));
-    assert!((((*items[(1) as usize]).value) == (2)));
-    assert!((((*obj.p).value) == (42)));
-    static mut cache: [*mut Inner; 2] = unsafe {
+    assert!((((*s_items[(0) as usize]).value) == (1)));
+    assert!((((*s_items[(1) as usize]).value) == (2)));
+    assert!((((*s_obj.p).value) == (42)));
+    static mut s_cache: [*mut Inner; 2] = unsafe {
         [
-            (&raw mut alpha as *mut Inner),
-            (&raw mut beta as *mut Inner),
+            (&raw mut s_alpha as *mut Inner),
+            (&raw mut s_beta as *mut Inner),
         ]
     };;
-    assert!((((*cache[(0) as usize]).value) == (1)));
-    assert!((((*cache[(1) as usize]).value) == (2)));
+    assert!((((*s_cache[(0) as usize]).value) == (1)));
+    assert!((((*s_cache[(1) as usize]).value) == (2)));
     return 0;
 }

--- a/tests/unit/out/unsafe/addr_of_global.rs
+++ b/tests/unit/out/unsafe/addr_of_global.rs
@@ -16,18 +16,18 @@ pub struct Inner {
 pub struct Outer {
     pub p: *mut Inner,
 }
-pub static mut s_alpha: Inner = unsafe { Inner { value: 1 } };
-pub static mut s_beta: Inner = unsafe { Inner { value: 2 } };
-pub static mut s_shared: Inner = unsafe { Inner { value: 42 } };
-pub static mut s_items: [*mut Inner; 2] = unsafe {
+pub static mut alpha_0: Inner = unsafe { Inner { value: 1 } };
+pub static mut beta_1: Inner = unsafe { Inner { value: 2 } };
+pub static mut shared_2: Inner = unsafe { Inner { value: 42 } };
+pub static mut items_3: [*mut Inner; 2] = unsafe {
     [
-        (&raw mut s_alpha as *mut Inner),
-        (&raw mut s_beta as *mut Inner),
+        (&raw mut alpha_0 as *mut Inner),
+        (&raw mut beta_1 as *mut Inner),
     ]
 };
-pub static mut s_obj: Outer = unsafe {
+pub static mut obj_4: Outer = unsafe {
     Outer {
-        p: (&raw mut s_shared as *mut Inner),
+        p: (&raw mut shared_2 as *mut Inner),
     }
 };
 pub fn main() {
@@ -36,16 +36,16 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    assert!((((*s_items[(0) as usize]).value) == (1)));
-    assert!((((*s_items[(1) as usize]).value) == (2)));
-    assert!((((*s_obj.p).value) == (42)));
-    static mut s_cache: [*mut Inner; 2] = unsafe {
+    assert!((((*items_3[(0) as usize]).value) == (1)));
+    assert!((((*items_3[(1) as usize]).value) == (2)));
+    assert!((((*obj_4.p).value) == (42)));
+    static mut cache_5: [*mut Inner; 2] = unsafe {
         [
-            (&raw mut s_alpha as *mut Inner),
-            (&raw mut s_beta as *mut Inner),
+            (&raw mut alpha_0 as *mut Inner),
+            (&raw mut beta_1 as *mut Inner),
         ]
     };;
-    assert!((((*s_cache[(0) as usize]).value) == (1)));
-    assert!((((*s_cache[(1) as usize]).value) == (2)));
+    assert!((((*cache_5[(0) as usize]).value) == (1)));
+    assert!((((*cache_5[(1) as usize]).value) == (2)));
     return 0;
 }

--- a/tests/unit/out/unsafe/bool_condition_logical.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical.rs
@@ -24,9 +24,9 @@ impl From<i32> for Code {
     }
 }
 libcc2rs::impl_enum_inc_dec!(Code);
-pub static mut side_effect: i32 = unsafe { 0 };
+pub static mut s_side_effect: i32 = unsafe { 0 };
 pub unsafe fn observe_0(mut v: i32) -> i32 {
-    side_effect.prefix_inc();
+    s_side_effect.prefix_inc();
     return v;
 }
 pub unsafe fn returns_one_1() -> i32 {
@@ -63,7 +63,7 @@ unsafe fn main_0() -> i32 {
     if (((n != 0) && (u != 0)) && (!(p).is_null())) && ((code as i32) == (Code::CODE_OK as i32)) {
         assert!(true);
     }
-    side_effect = 0;
+    s_side_effect = 0;
     if (zero != 0)
         && ((unsafe {
             let _v: i32 = 1;
@@ -72,7 +72,7 @@ unsafe fn main_0() -> i32 {
     {
         assert!(false);
     }
-    assert!(((side_effect) == (0)));
+    assert!(((s_side_effect) == (0)));
     if (n != 0)
         || ((unsafe {
             let _v: i32 = 1;
@@ -81,7 +81,7 @@ unsafe fn main_0() -> i32 {
     {
         assert!(true);
     }
-    assert!(((side_effect) == (0)));
+    assert!(((s_side_effect) == (0)));
     let mut x: i32 = 5;
     let mut y: i32 = 3;
     let mut flags: u32 = 2_u32;

--- a/tests/unit/out/unsafe/bool_condition_logical.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical.rs
@@ -24,15 +24,15 @@ impl From<i32> for Code {
     }
 }
 libcc2rs::impl_enum_inc_dec!(Code);
-pub static mut s_side_effect: i32 = unsafe { 0 };
-pub unsafe fn observe_0(mut v: i32) -> i32 {
-    s_side_effect.prefix_inc();
+pub static mut side_effect_0: i32 = unsafe { 0 };
+pub unsafe fn observe_1(mut v: i32) -> i32 {
+    side_effect_0.prefix_inc();
     return v;
 }
-pub unsafe fn returns_one_1() -> i32 {
+pub unsafe fn returns_one_2() -> i32 {
     return 1;
 }
-pub unsafe fn returns_zero_2() -> i32 {
+pub unsafe fn returns_zero_3() -> i32 {
     return 0;
 }
 pub fn main() {
@@ -63,25 +63,25 @@ unsafe fn main_0() -> i32 {
     if (((n != 0) && (u != 0)) && (!(p).is_null())) && ((code as i32) == (Code::CODE_OK as i32)) {
         assert!(true);
     }
-    s_side_effect = 0;
+    side_effect_0 = 0;
     if (zero != 0)
         && ((unsafe {
             let _v: i32 = 1;
-            observe_0(_v)
+            observe_1(_v)
         }) != 0)
     {
         assert!(false);
     }
-    assert!(((s_side_effect) == (0)));
+    assert!(((side_effect_0) == (0)));
     if (n != 0)
         || ((unsafe {
             let _v: i32 = 1;
-            observe_0(_v)
+            observe_1(_v)
         }) != 0)
     {
         assert!(true);
     }
-    assert!(((s_side_effect) == (0)));
+    assert!(((side_effect_0) == (0)));
     let mut x: i32 = 5;
     let mut y: i32 = 3;
     let mut flags: u32 = 2_u32;
@@ -135,19 +135,19 @@ unsafe fn main_0() -> i32 {
     if ((x) > (y)) && ((n != 0) && (!(cp).is_null())) {
         assert!(true);
     }
-    if ((x) > (y)) && ((unsafe { returns_one_1() }) != 0) {
+    if ((x) > (y)) && ((unsafe { returns_one_2() }) != 0) {
         assert!(true);
     }
-    if ((x) > (y)) && (!((unsafe { returns_zero_2() }) != 0)) {
+    if ((x) > (y)) && (!((unsafe { returns_zero_3() }) != 0)) {
         assert!(true);
     }
-    if ((x) < (y)) || ((unsafe { returns_one_1() }) != 0) {
+    if ((x) < (y)) || ((unsafe { returns_one_2() }) != 0) {
         assert!(true);
     }
-    if ((x) < (y)) || (!((unsafe { returns_one_1() }) != 0)) {
+    if ((x) < (y)) || (!((unsafe { returns_one_2() }) != 0)) {
         assert!(false);
     }
-    if ((!((p).is_null())) && ((unsafe { returns_one_1() }) != 0)) && ((n) != (0)) {
+    if ((!((p).is_null())) && ((unsafe { returns_one_2() }) != 0)) && ((n) != (0)) {
         assert!(true);
     }
     return 0;

--- a/tests/unit/out/unsafe/bool_condition_logical.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical.rs
@@ -23,7 +23,6 @@ impl From<i32> for Code {
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Code);
 pub static mut side_effect_0: i32 = unsafe { 0 };
 pub unsafe fn observe_1(mut v: i32) -> i32 {
     side_effect_0.prefix_inc();

--- a/tests/unit/out/unsafe/bool_condition_logical.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical.rs
@@ -23,6 +23,7 @@ impl From<i32> for Code {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Code);
 pub static mut side_effect_0: i32 = unsafe { 0 };
 pub unsafe fn observe_1(mut v: i32) -> i32 {
     side_effect_0.prefix_inc();

--- a/tests/unit/out/unsafe/bool_condition_logical_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical_c.rs
@@ -24,9 +24,9 @@ impl From<i32> for Code {
     }
 }
 libcc2rs::impl_enum_inc_dec!(Code);
-pub static mut side_effect: i32 = unsafe { 0 };
+pub static mut s_side_effect: i32 = unsafe { 0 };
 pub unsafe fn observe_0(mut v: i32) -> i32 {
-    side_effect.prefix_inc();
+    s_side_effect.prefix_inc();
     return v;
 }
 pub unsafe fn returns_one_1() -> i32 {
@@ -66,7 +66,7 @@ unsafe fn main_0() -> i32 {
     {
         assert!((1 != 0));
     }
-    side_effect = 0;
+    s_side_effect = 0;
     if ((((zero != 0)
         && ((unsafe {
             let _v: i32 = 1;
@@ -76,7 +76,7 @@ unsafe fn main_0() -> i32 {
     {
         assert!((0 != 0));
     }
-    assert!(((((side_effect) == (0)) as i32) != 0));
+    assert!(((((s_side_effect) == (0)) as i32) != 0));
     if ((((n != 0)
         || ((unsafe {
             let _v: i32 = 1;
@@ -86,7 +86,7 @@ unsafe fn main_0() -> i32 {
     {
         assert!((1 != 0));
     }
-    assert!(((((side_effect) == (0)) as i32) != 0));
+    assert!(((((s_side_effect) == (0)) as i32) != 0));
     let mut x: i32 = 5;
     let mut y: i32 = 3;
     let mut flags: u32 = 2_u32;

--- a/tests/unit/out/unsafe/bool_condition_logical_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical_c.rs
@@ -24,15 +24,15 @@ impl From<i32> for Code {
     }
 }
 libcc2rs::impl_enum_inc_dec!(Code);
-pub static mut s_side_effect: i32 = unsafe { 0 };
-pub unsafe fn observe_0(mut v: i32) -> i32 {
-    s_side_effect.prefix_inc();
+pub static mut side_effect_0: i32 = unsafe { 0 };
+pub unsafe fn observe_1(mut v: i32) -> i32 {
+    side_effect_0.prefix_inc();
     return v;
 }
-pub unsafe fn returns_one_1() -> i32 {
+pub unsafe fn returns_one_2() -> i32 {
     return 1;
 }
-pub unsafe fn returns_zero_2() -> i32 {
+pub unsafe fn returns_zero_3() -> i32 {
     return 0;
 }
 pub fn main() {
@@ -66,27 +66,27 @@ unsafe fn main_0() -> i32 {
     {
         assert!((1 != 0));
     }
-    s_side_effect = 0;
+    side_effect_0 = 0;
     if ((((zero != 0)
         && ((unsafe {
             let _v: i32 = 1;
-            observe_0(_v)
+            observe_1(_v)
         }) != 0)) as i32)
         != 0)
     {
         assert!((0 != 0));
     }
-    assert!(((((s_side_effect) == (0)) as i32) != 0));
+    assert!(((((side_effect_0) == (0)) as i32) != 0));
     if ((((n != 0)
         || ((unsafe {
             let _v: i32 = 1;
-            observe_0(_v)
+            observe_1(_v)
         }) != 0)) as i32)
         != 0)
     {
         assert!((1 != 0));
     }
-    assert!(((((s_side_effect) == (0)) as i32) != 0));
+    assert!(((((side_effect_0) == (0)) as i32) != 0));
     let mut x: i32 = 5;
     let mut y: i32 = 3;
     let mut flags: u32 = 2_u32;
@@ -142,19 +142,19 @@ unsafe fn main_0() -> i32 {
     {
         assert!((1 != 0));
     }
-    if (((((((x) > (y)) as i32) != 0) && ((unsafe { returns_one_1() }) != 0)) as i32) != 0) {
+    if (((((((x) > (y)) as i32) != 0) && ((unsafe { returns_one_2() }) != 0)) as i32) != 0) {
         assert!((1 != 0));
     }
-    if (((((((x) > (y)) as i32) != 0) && (!((unsafe { returns_zero_2() }) != 0))) as i32) != 0) {
+    if (((((((x) > (y)) as i32) != 0) && (!((unsafe { returns_zero_3() }) != 0))) as i32) != 0) {
         assert!((1 != 0));
     }
-    if (((((((x) < (y)) as i32) != 0) || ((unsafe { returns_one_1() }) != 0)) as i32) != 0) {
+    if (((((((x) < (y)) as i32) != 0) || ((unsafe { returns_one_2() }) != 0)) as i32) != 0) {
         assert!((1 != 0));
     }
-    if (((((((x) < (y)) as i32) != 0) || (!((unsafe { returns_one_1() }) != 0))) as i32) != 0) {
+    if (((((((x) < (y)) as i32) != 0) || (!((unsafe { returns_one_2() }) != 0))) as i32) != 0) {
         assert!((0 != 0));
     }
-    if (((((((((!((p).is_null())) as i32) != 0) && ((unsafe { returns_one_1() }) != 0)) as i32)
+    if (((((((((!((p).is_null())) as i32) != 0) && ((unsafe { returns_one_2() }) != 0)) as i32)
         != 0)
         && ((((n) != (0)) as i32) != 0)) as i32)
         != 0)

--- a/tests/unit/out/unsafe/bool_condition_logical_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical_c.rs
@@ -23,7 +23,6 @@ impl From<i32> for Code {
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Code);
 pub static mut side_effect_0: i32 = unsafe { 0 };
 pub unsafe fn observe_1(mut v: i32) -> i32 {
     side_effect_0.prefix_inc();

--- a/tests/unit/out/unsafe/bool_condition_logical_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical_c.rs
@@ -23,6 +23,7 @@ impl From<i32> for Code {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Code);
 pub static mut side_effect_0: i32 = unsafe { 0 };
 pub unsafe fn observe_1(mut v: i32) -> i32 {
     side_effect_0.prefix_inc();

--- a/tests/unit/out/unsafe/default_in_statics.rs
+++ b/tests/unit/out/unsafe/default_in_statics.rs
@@ -58,8 +58,8 @@ impl Default for Foo {
         }
     }
 }
-pub static mut static_fn: Option<unsafe fn(i32) -> i32> = unsafe { None };
-pub static mut static_outer: Outer = unsafe {
+pub static mut s_static_fn: Option<unsafe fn(i32) -> i32> = unsafe { None };
+pub static mut s_static_outer: Outer = unsafe {
     Outer {
         p1: std::ptr::null_mut(),
         p2: std::ptr::null(),
@@ -74,13 +74,13 @@ pub static mut static_outer: Outer = unsafe {
         fn_: None,
     }
 };
-pub static mut static_inner_array: [Inner; 2] = unsafe {
+pub static mut s_static_inner_array: [Inner; 2] = unsafe {
     [Inner {
         v: 0_i32,
         name: std::ptr::null(),
     }; 2]
 };
-pub static mut static_foo: Foo = unsafe {
+pub static mut s_static_foo: Foo = unsafe {
     Foo {
         s1: b"hello\0".as_ptr(),
         s2: std::ptr::null(),
@@ -89,7 +89,7 @@ pub static mut static_foo: Foo = unsafe {
         n: 42,
     }
 };
-pub static mut static_foo_array: [Foo; 2] = unsafe {
+pub static mut s_static_foo_array: [Foo; 2] = unsafe {
     [
         Foo {
             s1: b"first\0".as_ptr(),
@@ -108,7 +108,7 @@ pub static mut static_foo_array: [Foo; 2] = unsafe {
     ]
 };
 pub unsafe fn check_local_static_0() {
-    static mut local_outer: Outer = unsafe {
+    static mut s_local_outer: Outer = unsafe {
         Outer {
             p1: std::ptr::null_mut(),
             p2: std::ptr::null(),
@@ -123,12 +123,12 @@ pub unsafe fn check_local_static_0() {
             fn_: None,
         }
     };;
-    static mut local_fn: Option<unsafe fn(i32) -> i32> = unsafe { None };;
-    static mut local_p: *mut i32 = unsafe { std::ptr::null_mut() };;
-    assert!((local_outer.p1).is_null());
-    assert!((local_outer.fn_).is_none());
-    assert!((local_fn).is_none());
-    assert!((local_p).is_null());
+    static mut s_local_fn: Option<unsafe fn(i32) -> i32> = unsafe { None };;
+    static mut s_local_p: *mut i32 = unsafe { std::ptr::null_mut() };;
+    assert!((s_local_outer.p1).is_null());
+    assert!((s_local_outer.fn_).is_none());
+    assert!((s_local_fn).is_none());
+    assert!((s_local_p).is_null());
 }
 pub fn main() {
     unsafe {
@@ -136,32 +136,32 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    assert!((static_fn).is_none());
-    assert!((static_outer.p1).is_null());
-    assert!((static_outer.p2).is_null());
-    assert!((static_outer.cp).is_null());
-    assert!((static_outer.pp).is_null());
-    assert!((static_outer.fn_).is_none());
+    assert!((s_static_fn).is_none());
+    assert!((s_static_outer.p1).is_null());
+    assert!((s_static_outer.p2).is_null());
+    assert!((s_static_outer.cp).is_null());
+    assert!((s_static_outer.pp).is_null());
+    assert!((s_static_outer.fn_).is_none());
     let mut i: i32 = 0;
     'loop_: while ((i) < (3)) {
-        assert!((static_outer.arr[(i) as usize]).is_null());
+        assert!((s_static_outer.arr[(i) as usize]).is_null());
         i.prefix_inc();
     }
-    assert!((static_outer.inner.name).is_null());
+    assert!((s_static_outer.inner.name).is_null());
     let mut i: i32 = 0;
     'loop_: while ((i) < (2)) {
-        assert!((static_inner_array[(i) as usize].name).is_null());
+        assert!((s_static_inner_array[(i) as usize].name).is_null());
         i.prefix_inc();
     }
-    assert!((static_foo.s2).is_null());
-    assert!((static_foo.fn1).is_none());
-    assert!((static_foo.fn2).is_none());
-    assert!(((static_foo.n) == (42)));
+    assert!((s_static_foo.s2).is_null());
+    assert!((s_static_foo.fn1).is_none());
+    assert!((s_static_foo.fn2).is_none());
+    assert!(((s_static_foo.n) == (42)));
     let mut i: i32 = 0;
     'loop_: while ((i) < (2)) {
-        assert!((static_foo_array[(i) as usize].s2).is_null());
-        assert!((static_foo_array[(i) as usize].fn1).is_none());
-        assert!((static_foo_array[(i) as usize].fn2).is_none());
+        assert!((s_static_foo_array[(i) as usize].s2).is_null());
+        assert!((s_static_foo_array[(i) as usize].fn1).is_none());
+        assert!((s_static_foo_array[(i) as usize].fn2).is_none());
         i.prefix_inc();
     }
     (unsafe { check_local_static_0() });

--- a/tests/unit/out/unsafe/default_in_statics.rs
+++ b/tests/unit/out/unsafe/default_in_statics.rs
@@ -58,8 +58,8 @@ impl Default for Foo {
         }
     }
 }
-pub static mut s_static_fn: Option<unsafe fn(i32) -> i32> = unsafe { None };
-pub static mut s_static_outer: Outer = unsafe {
+pub static mut static_fn_0: Option<unsafe fn(i32) -> i32> = unsafe { None };
+pub static mut static_outer_1: Outer = unsafe {
     Outer {
         p1: std::ptr::null_mut(),
         p2: std::ptr::null(),
@@ -74,13 +74,13 @@ pub static mut s_static_outer: Outer = unsafe {
         fn_: None,
     }
 };
-pub static mut s_static_inner_array: [Inner; 2] = unsafe {
+pub static mut static_inner_array_2: [Inner; 2] = unsafe {
     [Inner {
         v: 0_i32,
         name: std::ptr::null(),
     }; 2]
 };
-pub static mut s_static_foo: Foo = unsafe {
+pub static mut static_foo_3: Foo = unsafe {
     Foo {
         s1: b"hello\0".as_ptr(),
         s2: std::ptr::null(),
@@ -89,7 +89,7 @@ pub static mut s_static_foo: Foo = unsafe {
         n: 42,
     }
 };
-pub static mut s_static_foo_array: [Foo; 2] = unsafe {
+pub static mut static_foo_array_4: [Foo; 2] = unsafe {
     [
         Foo {
             s1: b"first\0".as_ptr(),
@@ -107,8 +107,8 @@ pub static mut s_static_foo_array: [Foo; 2] = unsafe {
         },
     ]
 };
-pub unsafe fn check_local_static_0() {
-    static mut s_local_outer: Outer = unsafe {
+pub unsafe fn check_local_static_5() {
+    static mut local_outer_6: Outer = unsafe {
         Outer {
             p1: std::ptr::null_mut(),
             p2: std::ptr::null(),
@@ -123,12 +123,12 @@ pub unsafe fn check_local_static_0() {
             fn_: None,
         }
     };;
-    static mut s_local_fn: Option<unsafe fn(i32) -> i32> = unsafe { None };;
-    static mut s_local_p: *mut i32 = unsafe { std::ptr::null_mut() };;
-    assert!((s_local_outer.p1).is_null());
-    assert!((s_local_outer.fn_).is_none());
-    assert!((s_local_fn).is_none());
-    assert!((s_local_p).is_null());
+    static mut local_fn_7: Option<unsafe fn(i32) -> i32> = unsafe { None };;
+    static mut local_p_8: *mut i32 = unsafe { std::ptr::null_mut() };;
+    assert!((local_outer_6.p1).is_null());
+    assert!((local_outer_6.fn_).is_none());
+    assert!((local_fn_7).is_none());
+    assert!((local_p_8).is_null());
 }
 pub fn main() {
     unsafe {
@@ -136,34 +136,34 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    assert!((s_static_fn).is_none());
-    assert!((s_static_outer.p1).is_null());
-    assert!((s_static_outer.p2).is_null());
-    assert!((s_static_outer.cp).is_null());
-    assert!((s_static_outer.pp).is_null());
-    assert!((s_static_outer.fn_).is_none());
+    assert!((static_fn_0).is_none());
+    assert!((static_outer_1.p1).is_null());
+    assert!((static_outer_1.p2).is_null());
+    assert!((static_outer_1.cp).is_null());
+    assert!((static_outer_1.pp).is_null());
+    assert!((static_outer_1.fn_).is_none());
     let mut i: i32 = 0;
     'loop_: while ((i) < (3)) {
-        assert!((s_static_outer.arr[(i) as usize]).is_null());
+        assert!((static_outer_1.arr[(i) as usize]).is_null());
         i.prefix_inc();
     }
-    assert!((s_static_outer.inner.name).is_null());
+    assert!((static_outer_1.inner.name).is_null());
     let mut i: i32 = 0;
     'loop_: while ((i) < (2)) {
-        assert!((s_static_inner_array[(i) as usize].name).is_null());
+        assert!((static_inner_array_2[(i) as usize].name).is_null());
         i.prefix_inc();
     }
-    assert!((s_static_foo.s2).is_null());
-    assert!((s_static_foo.fn1).is_none());
-    assert!((s_static_foo.fn2).is_none());
-    assert!(((s_static_foo.n) == (42)));
+    assert!((static_foo_3.s2).is_null());
+    assert!((static_foo_3.fn1).is_none());
+    assert!((static_foo_3.fn2).is_none());
+    assert!(((static_foo_3.n) == (42)));
     let mut i: i32 = 0;
     'loop_: while ((i) < (2)) {
-        assert!((s_static_foo_array[(i) as usize].s2).is_null());
-        assert!((s_static_foo_array[(i) as usize].fn1).is_none());
-        assert!((s_static_foo_array[(i) as usize].fn2).is_none());
+        assert!((static_foo_array_4[(i) as usize].s2).is_null());
+        assert!((static_foo_array_4[(i) as usize].fn1).is_none());
+        assert!((static_foo_array_4[(i) as usize].fn2).is_none());
         i.prefix_inc();
     }
-    (unsafe { check_local_static_0() });
+    (unsafe { check_local_static_5() });
     return 0;
 }

--- a/tests/unit/out/unsafe/enum_int_interop.rs
+++ b/tests/unit/out/unsafe/enum_int_interop.rs
@@ -69,10 +69,10 @@ pub struct Entry {
     pub color: Color,
     pub opt: Option,
 }
-pub static mut global_color: Color = unsafe { Color::GREEN };
-pub static mut global_opt: Option = unsafe { Option::OPT_B };
-pub static mut global_tag: Tag = unsafe { Tag::TAG_TWO };
-pub static mut entries: [Entry; 3] = unsafe {
+pub static mut s_global_color: Color = unsafe { Color::GREEN };
+pub static mut s_global_opt: Option = unsafe { Option::OPT_B };
+pub static mut s_global_tag: Tag = unsafe { Tag::TAG_TWO };
+pub static mut s_entries: [Entry; 3] = unsafe {
     [
         Entry {
             name: b"first\0".as_ptr(),
@@ -210,14 +210,14 @@ unsafe fn main_0() -> i32 {
     };
     let mut extra: i32 = (((Color::RED as i32) + (Color::GREEN as i32)) + (Color::BLUE as i32));
     assert!(((extra) == (((0) + (1)) + (2))));
-    assert!(((global_color as i32) == (Color::GREEN as i32)));
-    assert!(((global_opt as i32) == (Option::OPT_B as i32)));
-    assert!(((global_tag as i32) == (Tag::TAG_TWO as i32)));
-    assert!(((entries[(0) as usize].color as i32) == (Color::RED as i32)));
-    assert!(((entries[(0) as usize].opt as i32) == (Option::OPT_NONE as i32)));
-    assert!(((entries[(1) as usize].color as i32) == (Color::GREEN as i32)));
-    assert!(((entries[(1) as usize].opt as i32) == (Option::OPT_A as i32)));
-    assert!(((entries[(2) as usize].color as i32) == (Color::BLUE as i32)));
-    assert!(((entries[(2) as usize].opt as i32) == (Option::OPT_C as i32)));
+    assert!(((s_global_color as i32) == (Color::GREEN as i32)));
+    assert!(((s_global_opt as i32) == (Option::OPT_B as i32)));
+    assert!(((s_global_tag as i32) == (Tag::TAG_TWO as i32)));
+    assert!(((s_entries[(0) as usize].color as i32) == (Color::RED as i32)));
+    assert!(((s_entries[(0) as usize].opt as i32) == (Option::OPT_NONE as i32)));
+    assert!(((s_entries[(1) as usize].color as i32) == (Color::GREEN as i32)));
+    assert!(((s_entries[(1) as usize].opt as i32) == (Option::OPT_A as i32)));
+    assert!(((s_entries[(2) as usize].color as i32) == (Color::BLUE as i32)));
+    assert!(((s_entries[(2) as usize].opt as i32) == (Option::OPT_C as i32)));
     return 0;
 }

--- a/tests/unit/out/unsafe/enum_int_interop.rs
+++ b/tests/unit/out/unsafe/enum_int_interop.rs
@@ -23,6 +23,7 @@ impl From<i32> for Color {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Color);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Option {
     #[default]
@@ -42,6 +43,7 @@ impl From<i32> for Option {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Option);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Tag {
     #[default]
@@ -59,6 +61,7 @@ impl From<i32> for Tag {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Tag);
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Entry {

--- a/tests/unit/out/unsafe/enum_int_interop.rs
+++ b/tests/unit/out/unsafe/enum_int_interop.rs
@@ -69,10 +69,10 @@ pub struct Entry {
     pub color: Color,
     pub opt: Option,
 }
-pub static mut s_global_color: Color = unsafe { Color::GREEN };
-pub static mut s_global_opt: Option = unsafe { Option::OPT_B };
-pub static mut s_global_tag: Tag = unsafe { Tag::TAG_TWO };
-pub static mut s_entries: [Entry; 3] = unsafe {
+pub static mut global_color_0: Color = unsafe { Color::GREEN };
+pub static mut global_opt_1: Option = unsafe { Option::OPT_B };
+pub static mut global_tag_2: Tag = unsafe { Tag::TAG_TWO };
+pub static mut entries_3: [Entry; 3] = unsafe {
     [
         Entry {
             name: b"first\0".as_ptr(),
@@ -91,10 +91,10 @@ pub static mut s_entries: [Entry; 3] = unsafe {
         },
     ]
 };
-pub unsafe fn as_int_0(mut c: Color) -> i32 {
+pub unsafe fn as_int_4(mut c: Color) -> i32 {
     return (c as i32);
 }
-pub unsafe fn classify_option_1(mut option: i32) -> i32 {
+pub unsafe fn classify_option_5(mut option: i32) -> i32 {
     'switch: {
         let __match_cond = option;
         match __match_cond {
@@ -117,7 +117,7 @@ pub unsafe fn classify_option_1(mut option: i32) -> i32 {
     };
     panic!("ub: non-void function does not return a value")
 }
-pub unsafe fn make_color_2(mut n: i32) -> Color {
+pub unsafe fn make_color_6(mut n: i32) -> Color {
     return Color::from(n);
 }
 pub fn main() {
@@ -159,7 +159,7 @@ unsafe fn main_0() -> i32 {
     assert!(((c as i32) == (2)));
     c = (unsafe {
         let _n: i32 = 1;
-        make_color_2(_n)
+        make_color_6(_n)
     });
     assert!(((c as i32) == (Color::GREEN as i32)));
     let mut cmp: Color = Color::from(((c as i32) + (1)));
@@ -173,17 +173,17 @@ unsafe fn main_0() -> i32 {
     assert!(((o as i32) == (Option::OPT_B as i32)));
     let mut rc: i32 = (unsafe {
         let _option: i32 = (o as i32);
-        classify_option_1(_option)
+        classify_option_5(_option)
     });
     assert!(((rc) == (2)));
     rc = (unsafe {
         let _option: i32 = 20;
-        classify_option_1(_option)
+        classify_option_5(_option)
     });
     assert!(((rc) == (2)));
     rc = (unsafe {
         let _option: i32 = (Option::OPT_C as i32);
-        classify_option_1(_option)
+        classify_option_5(_option)
     });
     assert!(((rc) == (3)));
     let mut t: Tag = Tag::TAG_ONE;
@@ -210,14 +210,14 @@ unsafe fn main_0() -> i32 {
     };
     let mut extra: i32 = (((Color::RED as i32) + (Color::GREEN as i32)) + (Color::BLUE as i32));
     assert!(((extra) == (((0) + (1)) + (2))));
-    assert!(((s_global_color as i32) == (Color::GREEN as i32)));
-    assert!(((s_global_opt as i32) == (Option::OPT_B as i32)));
-    assert!(((s_global_tag as i32) == (Tag::TAG_TWO as i32)));
-    assert!(((s_entries[(0) as usize].color as i32) == (Color::RED as i32)));
-    assert!(((s_entries[(0) as usize].opt as i32) == (Option::OPT_NONE as i32)));
-    assert!(((s_entries[(1) as usize].color as i32) == (Color::GREEN as i32)));
-    assert!(((s_entries[(1) as usize].opt as i32) == (Option::OPT_A as i32)));
-    assert!(((s_entries[(2) as usize].color as i32) == (Color::BLUE as i32)));
-    assert!(((s_entries[(2) as usize].opt as i32) == (Option::OPT_C as i32)));
+    assert!(((global_color_0 as i32) == (Color::GREEN as i32)));
+    assert!(((global_opt_1 as i32) == (Option::OPT_B as i32)));
+    assert!(((global_tag_2 as i32) == (Tag::TAG_TWO as i32)));
+    assert!(((entries_3[(0) as usize].color as i32) == (Color::RED as i32)));
+    assert!(((entries_3[(0) as usize].opt as i32) == (Option::OPT_NONE as i32)));
+    assert!(((entries_3[(1) as usize].color as i32) == (Color::GREEN as i32)));
+    assert!(((entries_3[(1) as usize].opt as i32) == (Option::OPT_A as i32)));
+    assert!(((entries_3[(2) as usize].color as i32) == (Color::BLUE as i32)));
+    assert!(((entries_3[(2) as usize].opt as i32) == (Option::OPT_C as i32)));
     return 0;
 }

--- a/tests/unit/out/unsafe/enum_int_interop.rs
+++ b/tests/unit/out/unsafe/enum_int_interop.rs
@@ -23,7 +23,6 @@ impl From<i32> for Color {
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Color);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Option {
     #[default]
@@ -43,7 +42,6 @@ impl From<i32> for Option {
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Option);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Tag {
     #[default]
@@ -61,7 +59,6 @@ impl From<i32> for Tag {
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Tag);
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Entry {

--- a/tests/unit/out/unsafe/enum_int_interop_c.rs
+++ b/tests/unit/out/unsafe/enum_int_interop_c.rs
@@ -23,6 +23,7 @@ impl From<i32> for Color {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Color);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Option {
     #[default]
@@ -42,6 +43,7 @@ impl From<i32> for Option {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Option);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Tag {
     #[default]
@@ -59,6 +61,7 @@ impl From<i32> for Tag {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Tag);
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Entry {

--- a/tests/unit/out/unsafe/enum_int_interop_c.rs
+++ b/tests/unit/out/unsafe/enum_int_interop_c.rs
@@ -69,10 +69,10 @@ pub struct Entry {
     pub color: Color,
     pub opt: Option,
 }
-pub static mut global_color: Color = unsafe { Color::GREEN };
-pub static mut global_opt: Option = unsafe { Option::OPT_B };
-pub static mut global_tag: Tag = unsafe { Tag::TAG_TWO };
-pub static mut entries: [Entry; 3] = unsafe {
+pub static mut s_global_color: Color = unsafe { Color::GREEN };
+pub static mut s_global_opt: Option = unsafe { Option::OPT_B };
+pub static mut s_global_tag: Tag = unsafe { Tag::TAG_TWO };
+pub static mut s_entries: [Entry; 3] = unsafe {
     [
         Entry {
             name: (b"first\0".as_ptr().cast_mut()).cast_const(),
@@ -210,24 +210,27 @@ unsafe fn main_0() -> i32 {
     };
     let mut extra: i32 = (((Color::RED as i32) + (Color::GREEN as i32)) + (Color::BLUE as i32));
     assert!(((((extra) == (((0) + (1)) + (2))) as i32) != 0));
-    assert!(((((global_color as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0));
-    assert!(((((global_opt as u32) == ((Option::OPT_B as i32) as u32)) as i32) != 0));
-    assert!(((((global_tag as u32) == ((Tag::TAG_TWO as i32) as u32)) as i32) != 0));
-    assert!(((((entries[(0) as usize].color as u32) == ((Color::RED as i32) as u32)) as i32) != 0));
+    assert!(((((s_global_color as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0));
+    assert!(((((s_global_opt as u32) == ((Option::OPT_B as i32) as u32)) as i32) != 0));
+    assert!(((((s_global_tag as u32) == ((Tag::TAG_TWO as i32) as u32)) as i32) != 0));
     assert!(
-        ((((entries[(0) as usize].opt as u32) == ((Option::OPT_NONE as i32) as u32)) as i32) != 0)
+        ((((s_entries[(0) as usize].color as u32) == ((Color::RED as i32) as u32)) as i32) != 0)
     );
     assert!(
-        ((((entries[(1) as usize].color as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0)
+        ((((s_entries[(0) as usize].opt as u32) == ((Option::OPT_NONE as i32) as u32)) as i32)
+            != 0)
     );
     assert!(
-        ((((entries[(1) as usize].opt as u32) == ((Option::OPT_A as i32) as u32)) as i32) != 0)
+        ((((s_entries[(1) as usize].color as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0)
     );
     assert!(
-        ((((entries[(2) as usize].color as u32) == ((Color::BLUE as i32) as u32)) as i32) != 0)
+        ((((s_entries[(1) as usize].opt as u32) == ((Option::OPT_A as i32) as u32)) as i32) != 0)
     );
     assert!(
-        ((((entries[(2) as usize].opt as u32) == ((Option::OPT_C as i32) as u32)) as i32) != 0)
+        ((((s_entries[(2) as usize].color as u32) == ((Color::BLUE as i32) as u32)) as i32) != 0)
+    );
+    assert!(
+        ((((s_entries[(2) as usize].opt as u32) == ((Option::OPT_C as i32) as u32)) as i32) != 0)
     );
     return 0;
 }

--- a/tests/unit/out/unsafe/enum_int_interop_c.rs
+++ b/tests/unit/out/unsafe/enum_int_interop_c.rs
@@ -69,10 +69,10 @@ pub struct Entry {
     pub color: Color,
     pub opt: Option,
 }
-pub static mut s_global_color: Color = unsafe { Color::GREEN };
-pub static mut s_global_opt: Option = unsafe { Option::OPT_B };
-pub static mut s_global_tag: Tag = unsafe { Tag::TAG_TWO };
-pub static mut s_entries: [Entry; 3] = unsafe {
+pub static mut global_color_0: Color = unsafe { Color::GREEN };
+pub static mut global_opt_1: Option = unsafe { Option::OPT_B };
+pub static mut global_tag_2: Tag = unsafe { Tag::TAG_TWO };
+pub static mut entries_3: [Entry; 3] = unsafe {
     [
         Entry {
             name: (b"first\0".as_ptr().cast_mut()).cast_const(),
@@ -91,10 +91,10 @@ pub static mut s_entries: [Entry; 3] = unsafe {
         },
     ]
 };
-pub unsafe fn as_int_0(mut c: Color) -> i32 {
+pub unsafe fn as_int_4(mut c: Color) -> i32 {
     return (c as i32);
 }
-pub unsafe fn classify_option_1(mut option: i32) -> i32 {
+pub unsafe fn classify_option_5(mut option: i32) -> i32 {
     'switch: {
         let __match_cond = option;
         match __match_cond {
@@ -117,7 +117,7 @@ pub unsafe fn classify_option_1(mut option: i32) -> i32 {
     };
     panic!("ub: non-void function does not return a value")
 }
-pub unsafe fn make_color_2(mut n: i32) -> Color {
+pub unsafe fn make_color_6(mut n: i32) -> Color {
     return Color::from(n);
 }
 pub fn main() {
@@ -159,7 +159,7 @@ unsafe fn main_0() -> i32 {
     assert!(((((c as u32) == (2_u32)) as i32) != 0));
     c = (unsafe {
         let _n: i32 = 1;
-        make_color_2(_n)
+        make_color_6(_n)
     });
     assert!(((((c as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0));
     let mut cmp: Color = Color::from(((c as u32).wrapping_add(1_u32)) as i32);
@@ -173,17 +173,17 @@ unsafe fn main_0() -> i32 {
     assert!(((((o as u32) == ((Option::OPT_B as i32) as u32)) as i32) != 0));
     let mut rc: i32 = (unsafe {
         let _option: i32 = (o as i32);
-        classify_option_1(_option)
+        classify_option_5(_option)
     });
     assert!(((((rc) == (2)) as i32) != 0));
     rc = (unsafe {
         let _option: i32 = 20;
-        classify_option_1(_option)
+        classify_option_5(_option)
     });
     assert!(((((rc) == (2)) as i32) != 0));
     rc = (unsafe {
         let _option: i32 = (Option::OPT_C as i32);
-        classify_option_1(_option)
+        classify_option_5(_option)
     });
     assert!(((((rc) == (3)) as i32) != 0));
     let mut t: Tag = Tag::TAG_ONE;
@@ -210,27 +210,27 @@ unsafe fn main_0() -> i32 {
     };
     let mut extra: i32 = (((Color::RED as i32) + (Color::GREEN as i32)) + (Color::BLUE as i32));
     assert!(((((extra) == (((0) + (1)) + (2))) as i32) != 0));
-    assert!(((((s_global_color as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0));
-    assert!(((((s_global_opt as u32) == ((Option::OPT_B as i32) as u32)) as i32) != 0));
-    assert!(((((s_global_tag as u32) == ((Tag::TAG_TWO as i32) as u32)) as i32) != 0));
+    assert!(((((global_color_0 as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0));
+    assert!(((((global_opt_1 as u32) == ((Option::OPT_B as i32) as u32)) as i32) != 0));
+    assert!(((((global_tag_2 as u32) == ((Tag::TAG_TWO as i32) as u32)) as i32) != 0));
     assert!(
-        ((((s_entries[(0) as usize].color as u32) == ((Color::RED as i32) as u32)) as i32) != 0)
+        ((((entries_3[(0) as usize].color as u32) == ((Color::RED as i32) as u32)) as i32) != 0)
     );
     assert!(
-        ((((s_entries[(0) as usize].opt as u32) == ((Option::OPT_NONE as i32) as u32)) as i32)
+        ((((entries_3[(0) as usize].opt as u32) == ((Option::OPT_NONE as i32) as u32)) as i32)
             != 0)
     );
     assert!(
-        ((((s_entries[(1) as usize].color as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0)
+        ((((entries_3[(1) as usize].color as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0)
     );
     assert!(
-        ((((s_entries[(1) as usize].opt as u32) == ((Option::OPT_A as i32) as u32)) as i32) != 0)
+        ((((entries_3[(1) as usize].opt as u32) == ((Option::OPT_A as i32) as u32)) as i32) != 0)
     );
     assert!(
-        ((((s_entries[(2) as usize].color as u32) == ((Color::BLUE as i32) as u32)) as i32) != 0)
+        ((((entries_3[(2) as usize].color as u32) == ((Color::BLUE as i32) as u32)) as i32) != 0)
     );
     assert!(
-        ((((s_entries[(2) as usize].opt as u32) == ((Option::OPT_C as i32) as u32)) as i32) != 0)
+        ((((entries_3[(2) as usize].opt as u32) == ((Option::OPT_C as i32) as u32)) as i32) != 0)
     );
     return 0;
 }

--- a/tests/unit/out/unsafe/enum_int_interop_c.rs
+++ b/tests/unit/out/unsafe/enum_int_interop_c.rs
@@ -23,7 +23,6 @@ impl From<i32> for Color {
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Color);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Option {
     #[default]
@@ -43,7 +42,6 @@ impl From<i32> for Option {
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Option);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Tag {
     #[default]
@@ -61,7 +59,6 @@ impl From<i32> for Tag {
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Tag);
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Entry {

--- a/tests/unit/out/unsafe/fn_ptr_global.rs
+++ b/tests/unit/out/unsafe/fn_ptr_global.rs
@@ -12,15 +12,15 @@ pub unsafe fn double_it_0(mut x: i32) -> i32 {
 pub unsafe fn triple_it_1(mut x: i32) -> i32 {
     return ((x) * (3));
 }
-pub static mut g_op: Option<unsafe fn(i32) -> i32> = unsafe { None };
+pub static mut s_g_op: Option<unsafe fn(i32) -> i32> = unsafe { None };
 pub unsafe fn set_op_2(mut fn_: Option<unsafe fn(i32) -> i32>) {
-    g_op = fn_;
+    s_g_op = fn_;
 }
 pub unsafe fn call_op_3(mut x: i32) -> i32 {
-    if !(g_op).is_none() {
+    if !(s_g_op).is_none() {
         return (unsafe {
             let _arg0: i32 = x;
-            (g_op).unwrap()(_arg0)
+            (s_g_op).unwrap()(_arg0)
         });
     }
     return x;
@@ -41,8 +41,8 @@ unsafe fn main_0() -> i32 {
         let _fn: Option<unsafe fn(i32) -> i32> = Some(double_it_0);
         set_op_2(_fn)
     });
-    assert!(!((g_op).is_none()));
-    assert!(((g_op) == (Some(double_it_0))));
+    assert!(!((s_g_op).is_none()));
+    assert!(((s_g_op) == (Some(double_it_0))));
     assert!(
         ((unsafe {
             let _x: i32 = 5;
@@ -53,7 +53,7 @@ unsafe fn main_0() -> i32 {
         let _fn: Option<unsafe fn(i32) -> i32> = Some(triple_it_1);
         set_op_2(_fn)
     });
-    assert!(((g_op) == (Some(triple_it_1))));
+    assert!(((s_g_op) == (Some(triple_it_1))));
     assert!(
         ((unsafe {
             let _x: i32 = 5;
@@ -64,7 +64,7 @@ unsafe fn main_0() -> i32 {
         let _fn: Option<unsafe fn(i32) -> i32> = None;
         set_op_2(_fn)
     });
-    assert!((g_op).is_none());
+    assert!((s_g_op).is_none());
     assert!(
         ((unsafe {
             let _x: i32 = 5;

--- a/tests/unit/out/unsafe/fn_ptr_global.rs
+++ b/tests/unit/out/unsafe/fn_ptr_global.rs
@@ -12,15 +12,15 @@ pub unsafe fn double_it_0(mut x: i32) -> i32 {
 pub unsafe fn triple_it_1(mut x: i32) -> i32 {
     return ((x) * (3));
 }
-pub static mut s_g_op: Option<unsafe fn(i32) -> i32> = unsafe { None };
-pub unsafe fn set_op_2(mut fn_: Option<unsafe fn(i32) -> i32>) {
-    s_g_op = fn_;
+pub static mut g_op_2: Option<unsafe fn(i32) -> i32> = unsafe { None };
+pub unsafe fn set_op_3(mut fn_: Option<unsafe fn(i32) -> i32>) {
+    g_op_2 = fn_;
 }
-pub unsafe fn call_op_3(mut x: i32) -> i32 {
-    if !(s_g_op).is_none() {
+pub unsafe fn call_op_4(mut x: i32) -> i32 {
+    if !(g_op_2).is_none() {
         return (unsafe {
             let _arg0: i32 = x;
-            (s_g_op).unwrap()(_arg0)
+            (g_op_2).unwrap()(_arg0)
         });
     }
     return x;
@@ -34,41 +34,41 @@ unsafe fn main_0() -> i32 {
     assert!(
         ((unsafe {
             let _x: i32 = 5;
-            call_op_3(_x)
+            call_op_4(_x)
         }) == (5))
     );
     (unsafe {
         let _fn: Option<unsafe fn(i32) -> i32> = Some(double_it_0);
-        set_op_2(_fn)
+        set_op_3(_fn)
     });
-    assert!(!((s_g_op).is_none()));
-    assert!(((s_g_op) == (Some(double_it_0))));
+    assert!(!((g_op_2).is_none()));
+    assert!(((g_op_2) == (Some(double_it_0))));
     assert!(
         ((unsafe {
             let _x: i32 = 5;
-            call_op_3(_x)
+            call_op_4(_x)
         }) == (10))
     );
     (unsafe {
         let _fn: Option<unsafe fn(i32) -> i32> = Some(triple_it_1);
-        set_op_2(_fn)
+        set_op_3(_fn)
     });
-    assert!(((s_g_op) == (Some(triple_it_1))));
+    assert!(((g_op_2) == (Some(triple_it_1))));
     assert!(
         ((unsafe {
             let _x: i32 = 5;
-            call_op_3(_x)
+            call_op_4(_x)
         }) == (15))
     );
     (unsafe {
         let _fn: Option<unsafe fn(i32) -> i32> = None;
-        set_op_2(_fn)
+        set_op_3(_fn)
     });
-    assert!((s_g_op).is_none());
+    assert!((g_op_2).is_none());
     assert!(
         ((unsafe {
             let _x: i32 = 5;
-            call_op_3(_x)
+            call_op_4(_x)
         }) == (5))
     );
     return 0;

--- a/tests/unit/out/unsafe/fn_ptr_vtable.rs
+++ b/tests/unit/out/unsafe/fn_ptr_vtable.rs
@@ -22,10 +22,10 @@ impl Default for Vtable {
         }
     }
 }
-pub static mut storage: i32 = unsafe { 0_i32 };
+pub static mut s_storage: i32 = unsafe { 0_i32 };
 pub unsafe fn int_create_0(mut val: i32) -> *mut ::libc::c_void {
-    storage = val;
-    return ((&raw mut storage as *mut i32) as *mut i32 as *mut ::libc::c_void);
+    s_storage = val;
+    return ((&raw mut s_storage as *mut i32) as *mut i32 as *mut ::libc::c_void);
 }
 pub unsafe fn int_get_1(mut p: *mut ::libc::c_void) -> i32 {
     return (*(p as *mut i32));
@@ -61,7 +61,7 @@ unsafe fn main_0() -> i32 {
         let _arg0: *mut ::libc::c_void = obj;
         (vt.destroy).unwrap()(_arg0)
     });
-    assert!(((storage) == (0)));
+    assert!(((s_storage) == (0)));
     (vt.get) = None;
     assert!((vt.get).is_none());
     return 0;

--- a/tests/unit/out/unsafe/fn_ptr_vtable.rs
+++ b/tests/unit/out/unsafe/fn_ptr_vtable.rs
@@ -22,15 +22,15 @@ impl Default for Vtable {
         }
     }
 }
-pub static mut s_storage: i32 = unsafe { 0_i32 };
-pub unsafe fn int_create_0(mut val: i32) -> *mut ::libc::c_void {
-    s_storage = val;
-    return ((&raw mut s_storage as *mut i32) as *mut i32 as *mut ::libc::c_void);
+pub static mut storage_0: i32 = unsafe { 0_i32 };
+pub unsafe fn int_create_1(mut val: i32) -> *mut ::libc::c_void {
+    storage_0 = val;
+    return ((&raw mut storage_0 as *mut i32) as *mut i32 as *mut ::libc::c_void);
 }
-pub unsafe fn int_get_1(mut p: *mut ::libc::c_void) -> i32 {
+pub unsafe fn int_get_2(mut p: *mut ::libc::c_void) -> i32 {
     return (*(p as *mut i32));
 }
-pub unsafe fn int_destroy_2(mut p: *mut ::libc::c_void) {
+pub unsafe fn int_destroy_3(mut p: *mut ::libc::c_void) {
     (*(p as *mut i32)) = 0;
 }
 pub fn main() {
@@ -40,9 +40,9 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut vt: Vtable = Vtable {
-        create: Some(int_create_0),
-        get: Some(int_get_1),
-        destroy: Some(int_destroy_2),
+        create: Some(int_create_1),
+        get: Some(int_get_2),
+        destroy: Some(int_destroy_3),
     };
     assert!(!((vt.create).is_none()));
     assert!(!((vt.get).is_none()));
@@ -61,7 +61,7 @@ unsafe fn main_0() -> i32 {
         let _arg0: *mut ::libc::c_void = obj;
         (vt.destroy).unwrap()(_arg0)
     });
-    assert!(((s_storage) == (0)));
+    assert!(((storage_0) == (0)));
     (vt.get) = None;
     assert!((vt.get).is_none());
     return 0;

--- a/tests/unit/out/unsafe/global-initialization-using-global.rs
+++ b/tests/unit/out/unsafe/global-initialization-using-global.rs
@@ -6,15 +6,15 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-pub static mut first: i32 = unsafe { 0_i32 };
-pub static mut second: i32 = unsafe { ((first) + (1)) };
+pub static mut s_first: i32 = unsafe { 0_i32 };
+pub static mut s_second: i32 = unsafe { ((s_first) + (1)) };
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
     }
 }
 unsafe fn main_0() -> i32 {
-    assert!(((first) == (0)));
-    assert!(((second) == ((first) + (1))));
+    assert!(((s_first) == (0)));
+    assert!(((s_second) == ((s_first) + (1))));
     return 0;
 }

--- a/tests/unit/out/unsafe/global_pointers.rs
+++ b/tests/unit/out/unsafe/global_pointers.rs
@@ -12,13 +12,13 @@ pub struct Entry {
     pub name: *const u8,
     pub p: *mut i32,
 }
-pub static mut single_entry: Entry = unsafe {
+pub static mut s_single_entry: Entry = unsafe {
     Entry {
         name: b"alone\0".as_ptr(),
         p: std::ptr::null_mut(),
     }
 };
-pub static mut entries: [Entry; 2] = unsafe {
+pub static mut s_entries: [Entry; 2] = unsafe {
     [
         Entry {
             name: b"first\0".as_ptr(),
@@ -30,7 +30,7 @@ pub static mut entries: [Entry; 2] = unsafe {
         },
     ]
 };
-pub static mut arr_of_pointers: [*mut u8; 3] = unsafe {
+pub static mut s_arr_of_pointers: [*mut u8; 3] = unsafe {
     [
         std::ptr::null_mut(),
         std::ptr::null_mut(),
@@ -43,11 +43,11 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    assert!((single_entry.p).is_null());
+    assert!((s_single_entry.p).is_null());
     let mut i: i32 = 0;
     'loop_: while ((i) < (2)) {
-        assert!((entries[(i) as usize].p).is_null());
-        assert!((arr_of_pointers[(i) as usize]).is_null());
+        assert!((s_entries[(i) as usize].p).is_null());
+        assert!((s_arr_of_pointers[(i) as usize]).is_null());
         i.prefix_inc();
     }
     return 0;

--- a/tests/unit/out/unsafe/global_pointers.rs
+++ b/tests/unit/out/unsafe/global_pointers.rs
@@ -12,13 +12,13 @@ pub struct Entry {
     pub name: *const u8,
     pub p: *mut i32,
 }
-pub static mut s_single_entry: Entry = unsafe {
+pub static mut single_entry_0: Entry = unsafe {
     Entry {
         name: b"alone\0".as_ptr(),
         p: std::ptr::null_mut(),
     }
 };
-pub static mut s_entries: [Entry; 2] = unsafe {
+pub static mut entries_1: [Entry; 2] = unsafe {
     [
         Entry {
             name: b"first\0".as_ptr(),
@@ -30,7 +30,7 @@ pub static mut s_entries: [Entry; 2] = unsafe {
         },
     ]
 };
-pub static mut s_arr_of_pointers: [*mut u8; 3] = unsafe {
+pub static mut arr_of_pointers_2: [*mut u8; 3] = unsafe {
     [
         std::ptr::null_mut(),
         std::ptr::null_mut(),
@@ -43,11 +43,11 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    assert!((s_single_entry.p).is_null());
+    assert!((single_entry_0.p).is_null());
     let mut i: i32 = 0;
     'loop_: while ((i) < (2)) {
-        assert!((s_entries[(i) as usize].p).is_null());
-        assert!((s_arr_of_pointers[(i) as usize]).is_null());
+        assert!((entries_1[(i) as usize].p).is_null());
+        assert!((arr_of_pointers_2[(i) as usize]).is_null());
         i.prefix_inc();
     }
     return 0;

--- a/tests/unit/out/unsafe/global_without_initializer.rs
+++ b/tests/unit/out/unsafe/global_without_initializer.rs
@@ -11,17 +11,17 @@ use std::rc::Rc;
 pub struct S {
     pub a: i32,
 }
-pub static mut s: *mut S = unsafe { std::ptr::null_mut() };
-pub static mut file: *mut ::libc::FILE = unsafe { std::ptr::null_mut() };
-pub static mut size: u64 = unsafe { 0_u64 };
+pub static mut s_s: *mut S = unsafe { std::ptr::null_mut() };
+pub static mut s_file: *mut ::libc::FILE = unsafe { std::ptr::null_mut() };
+pub static mut s_size: u64 = unsafe { 0_u64 };
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
     }
 }
 unsafe fn main_0() -> i32 {
-    assert!((s).is_null());
-    assert!((file).is_null());
-    assert!(((size) == (0_u64)));
+    assert!((s_s).is_null());
+    assert!((s_file).is_null());
+    assert!(((s_size) == (0_u64)));
     return 0;
 }

--- a/tests/unit/out/unsafe/global_without_initializer.rs
+++ b/tests/unit/out/unsafe/global_without_initializer.rs
@@ -11,17 +11,17 @@ use std::rc::Rc;
 pub struct S {
     pub a: i32,
 }
-pub static mut s_s: *mut S = unsafe { std::ptr::null_mut() };
-pub static mut s_file: *mut ::libc::FILE = unsafe { std::ptr::null_mut() };
-pub static mut s_size: u64 = unsafe { 0_u64 };
+pub static mut s_0: *mut S = unsafe { std::ptr::null_mut() };
+pub static mut file_1: *mut ::libc::FILE = unsafe { std::ptr::null_mut() };
+pub static mut size_2: u64 = unsafe { 0_u64 };
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
     }
 }
 unsafe fn main_0() -> i32 {
-    assert!((s_s).is_null());
-    assert!((s_file).is_null());
-    assert!(((s_size) == (0_u64)));
+    assert!((s_0).is_null());
+    assert!((file_1).is_null());
+    assert!(((size_2) == (0_u64)));
     return 0;
 }

--- a/tests/unit/out/unsafe/null_in_statics.rs
+++ b/tests/unit/out/unsafe/null_in_statics.rs
@@ -6,35 +6,35 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-pub static mut p_mut: *mut i32 = unsafe { std::ptr::null_mut() };
-pub static mut p_const: *const i32 = unsafe { std::ptr::null() };
-pub static mut cp: *const u8 = unsafe { std::ptr::null() };
-pub static mut arr_of_ptr: [*mut i32; 4] = unsafe { [std::ptr::null_mut(); 4] };
-pub static mut pp: *mut *mut i32 = unsafe { std::ptr::null_mut() };
-pub static mut const_arr_of_ptr: [*const i32; 3] = unsafe { [std::ptr::null(); 3] };
-pub static mut cp_explicit_null: *const u8 = unsafe { std::ptr::null() };
-pub static mut p_zero: *mut i32 = unsafe { std::ptr::null_mut() };
+pub static mut s_p_mut: *mut i32 = unsafe { std::ptr::null_mut() };
+pub static mut s_p_const: *const i32 = unsafe { std::ptr::null() };
+pub static mut s_cp: *const u8 = unsafe { std::ptr::null() };
+pub static mut s_arr_of_ptr: [*mut i32; 4] = unsafe { [std::ptr::null_mut(); 4] };
+pub static mut s_pp: *mut *mut i32 = unsafe { std::ptr::null_mut() };
+pub static mut s_const_arr_of_ptr: [*const i32; 3] = unsafe { [std::ptr::null(); 3] };
+pub static mut s_cp_explicit_null: *const u8 = unsafe { std::ptr::null() };
+pub static mut s_p_zero: *mut i32 = unsafe { std::ptr::null_mut() };
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
     }
 }
 unsafe fn main_0() -> i32 {
-    assert!((p_mut).is_null());
-    assert!((p_const).is_null());
-    assert!((cp).is_null());
+    assert!((s_p_mut).is_null());
+    assert!((s_p_const).is_null());
+    assert!((s_cp).is_null());
     let mut i: i32 = 0;
     'loop_: while ((i) < (4)) {
-        assert!((arr_of_ptr[(i) as usize]).is_null());
+        assert!((s_arr_of_ptr[(i) as usize]).is_null());
         i.prefix_inc();
     }
-    assert!((pp).is_null());
+    assert!((s_pp).is_null());
     let mut i: i32 = 0;
     'loop_: while ((i) < (3)) {
-        assert!((const_arr_of_ptr[(i) as usize]).is_null());
+        assert!((s_const_arr_of_ptr[(i) as usize]).is_null());
         i.prefix_inc();
     }
-    assert!((cp_explicit_null).is_null());
-    assert!((p_zero).is_null());
+    assert!((s_cp_explicit_null).is_null());
+    assert!((s_p_zero).is_null());
     return 0;
 }

--- a/tests/unit/out/unsafe/null_in_statics.rs
+++ b/tests/unit/out/unsafe/null_in_statics.rs
@@ -6,35 +6,35 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-pub static mut s_p_mut: *mut i32 = unsafe { std::ptr::null_mut() };
-pub static mut s_p_const: *const i32 = unsafe { std::ptr::null() };
-pub static mut s_cp: *const u8 = unsafe { std::ptr::null() };
-pub static mut s_arr_of_ptr: [*mut i32; 4] = unsafe { [std::ptr::null_mut(); 4] };
-pub static mut s_pp: *mut *mut i32 = unsafe { std::ptr::null_mut() };
-pub static mut s_const_arr_of_ptr: [*const i32; 3] = unsafe { [std::ptr::null(); 3] };
-pub static mut s_cp_explicit_null: *const u8 = unsafe { std::ptr::null() };
-pub static mut s_p_zero: *mut i32 = unsafe { std::ptr::null_mut() };
+pub static mut p_mut_0: *mut i32 = unsafe { std::ptr::null_mut() };
+pub static mut p_const_1: *const i32 = unsafe { std::ptr::null() };
+pub static mut cp_2: *const u8 = unsafe { std::ptr::null() };
+pub static mut arr_of_ptr_3: [*mut i32; 4] = unsafe { [std::ptr::null_mut(); 4] };
+pub static mut pp_4: *mut *mut i32 = unsafe { std::ptr::null_mut() };
+pub static mut const_arr_of_ptr_5: [*const i32; 3] = unsafe { [std::ptr::null(); 3] };
+pub static mut cp_explicit_null_6: *const u8 = unsafe { std::ptr::null() };
+pub static mut p_zero_7: *mut i32 = unsafe { std::ptr::null_mut() };
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
     }
 }
 unsafe fn main_0() -> i32 {
-    assert!((s_p_mut).is_null());
-    assert!((s_p_const).is_null());
-    assert!((s_cp).is_null());
+    assert!((p_mut_0).is_null());
+    assert!((p_const_1).is_null());
+    assert!((cp_2).is_null());
     let mut i: i32 = 0;
     'loop_: while ((i) < (4)) {
-        assert!((s_arr_of_ptr[(i) as usize]).is_null());
+        assert!((arr_of_ptr_3[(i) as usize]).is_null());
         i.prefix_inc();
     }
-    assert!((s_pp).is_null());
+    assert!((pp_4).is_null());
     let mut i: i32 = 0;
     'loop_: while ((i) < (3)) {
-        assert!((s_const_arr_of_ptr[(i) as usize]).is_null());
+        assert!((const_arr_of_ptr_5[(i) as usize]).is_null());
         i.prefix_inc();
     }
-    assert!((s_cp_explicit_null).is_null());
-    assert!((s_p_zero).is_null());
+    assert!((cp_explicit_null_6).is_null());
+    assert!((p_zero_7).is_null());
     return 0;
 }

--- a/tests/unit/out/unsafe/static_function_vars_same_name.rs
+++ b/tests/unit/out/unsafe/static_function_vars_same_name.rs
@@ -6,15 +6,21 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-pub static mut first_0: i32 = unsafe { 0_i32 };
-pub static mut second_1: i32 = unsafe { ((first_0) + (1)) };
+pub unsafe fn a_0() -> i32 {
+    static mut i_1: i32 = unsafe { 1 };;
+    return i_1;
+}
+pub unsafe fn b_2() -> i32 {
+    static mut i_3: i32 = unsafe { 2 };;
+    return i_3;
+}
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
     }
 }
 unsafe fn main_0() -> i32 {
-    assert!(((first_0) == (0)));
-    assert!(((second_1) == ((first_0) + (1))));
+    assert!(((unsafe { a_0() }) == (1)));
+    assert!(((unsafe { b_2() }) == (2)));
     return 0;
 }

--- a/tests/unit/out/unsafe/static_local.rs
+++ b/tests/unit/out/unsafe/static_local.rs
@@ -7,13 +7,13 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn foo_0() -> i32 {
-    static mut static_i: i32 = unsafe { 0_i32 };;
-    static mut static_f: f32 = unsafe { 0.0_f32 };;
-    static mut static_b: bool = unsafe { false };;
-    static mut kX1: i32 = unsafe { 1 };;
-    static mut kX2: i32 = unsafe { 2 };;
-    kX1 += 1;
-    return (((kX1) + (kX2)) + (static_i));
+    static mut s_static_i: i32 = unsafe { 0_i32 };;
+    static mut s_static_f: f32 = unsafe { 0.0_f32 };;
+    static mut s_static_b: bool = unsafe { false };;
+    static mut s_kX1: i32 = unsafe { 1 };;
+    static mut s_kX2: i32 = unsafe { 2 };;
+    s_kX1 += 1;
+    return (((s_kX1) + (s_kX2)) + (s_static_i));
 }
 pub fn main() {
     unsafe {

--- a/tests/unit/out/unsafe/static_local.rs
+++ b/tests/unit/out/unsafe/static_local.rs
@@ -7,13 +7,13 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn foo_0() -> i32 {
-    static mut s_static_i: i32 = unsafe { 0_i32 };;
-    static mut s_static_f: f32 = unsafe { 0.0_f32 };;
-    static mut s_static_b: bool = unsafe { false };;
-    static mut s_kX1: i32 = unsafe { 1 };;
-    static mut s_kX2: i32 = unsafe { 2 };;
-    s_kX1 += 1;
-    return (((s_kX1) + (s_kX2)) + (s_static_i));
+    static mut static_i_1: i32 = unsafe { 0_i32 };;
+    static mut static_f_2: f32 = unsafe { 0.0_f32 };;
+    static mut static_b_3: bool = unsafe { false };;
+    static mut kX1_4: i32 = unsafe { 1 };;
+    static mut kX2_5: i32 = unsafe { 2 };;
+    kX1_4 += 1;
+    return (((kX1_4) + (kX2_5)) + (static_i_1));
 }
 pub fn main() {
     unsafe {

--- a/tests/unit/out/unsafe/static_shadow.rs
+++ b/tests/unit/out/unsafe/static_shadow.rs
@@ -1,0 +1,36 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub static mut s_value: i32 = unsafe { 5 };
+pub unsafe fn param_shadow_0(mut value: i32) -> i32 {
+    return ((value) + (1));
+}
+pub unsafe fn local_shadow_1() -> i32 {
+    let mut value: i32 = 99;
+    return value;
+}
+pub unsafe fn read_global_2() -> i32 {
+    return s_value;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((((unsafe {
+            let _value: i32 = 10;
+            param_shadow_0(_value)
+        }) == (11)) as i32)
+            != 0)
+    );
+    assert!(((((unsafe { local_shadow_1() }) == (99)) as i32) != 0));
+    assert!(((((unsafe { read_global_2() }) == (5)) as i32) != 0));
+    return 0;
+}

--- a/tests/unit/out/unsafe/static_shadow.rs
+++ b/tests/unit/out/unsafe/static_shadow.rs
@@ -6,16 +6,16 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-pub static mut s_value: i32 = unsafe { 5 };
-pub unsafe fn param_shadow_0(mut value: i32) -> i32 {
+pub static mut value_0: i32 = unsafe { 5 };
+pub unsafe fn param_shadow_1(mut value: i32) -> i32 {
     return ((value) + (1));
 }
-pub unsafe fn local_shadow_1() -> i32 {
+pub unsafe fn local_shadow_2() -> i32 {
     let mut value: i32 = 99;
     return value;
 }
-pub unsafe fn read_global_2() -> i32 {
-    return s_value;
+pub unsafe fn read_global_3() -> i32 {
+    return value_0;
 }
 pub fn main() {
     unsafe {
@@ -26,11 +26,11 @@ unsafe fn main_0() -> i32 {
     assert!(
         ((((unsafe {
             let _value: i32 = 10;
-            param_shadow_0(_value)
+            param_shadow_1(_value)
         }) == (11)) as i32)
             != 0)
     );
-    assert!(((((unsafe { local_shadow_1() }) == (99)) as i32) != 0));
-    assert!(((((unsafe { read_global_2() }) == (5)) as i32) != 0));
+    assert!(((((unsafe { local_shadow_2() }) == (99)) as i32) != 0));
+    assert!(((((unsafe { read_global_3() }) == (5)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/static_var_in_class.rs
+++ b/tests/unit/out/unsafe/static_var_in_class.rs
@@ -6,16 +6,16 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-static mut C_inner_const: i32 = unsafe { 1 };
+static mut s_C_inner_const: i32 = unsafe { 1 };
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct C {}
 impl C {
     pub unsafe fn get(&mut self) -> i32 {
-        return C_inner_const;
+        return s_C_inner_const;
     }
 }
-pub static mut S_inner_const: i32 = unsafe { 2 };
+pub static mut s_S_inner_const: i32 = unsafe { 2 };
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct S {}
@@ -27,6 +27,6 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut c: C = <C>::default();
     assert!(((unsafe { c.get() }) == (1)));
-    assert!(((S_inner_const) == (2)));
+    assert!(((s_S_inner_const) == (2)));
     return 0;
 }

--- a/tests/unit/out/unsafe/static_var_in_class.rs
+++ b/tests/unit/out/unsafe/static_var_in_class.rs
@@ -6,16 +6,16 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-static mut s_C_inner_const: i32 = unsafe { 1 };
+static mut inner_const_0: i32 = unsafe { 1 };
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct C {}
 impl C {
     pub unsafe fn get(&mut self) -> i32 {
-        return s_C_inner_const;
+        return inner_const_0;
     }
 }
-pub static mut s_S_inner_const: i32 = unsafe { 2 };
+pub static mut inner_const_1: i32 = unsafe { 2 };
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct S {}
@@ -27,6 +27,6 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut c: C = <C>::default();
     assert!(((unsafe { c.get() }) == (1)));
-    assert!(((s_S_inner_const) == (2)));
+    assert!(((inner_const_1) == (2)));
     return 0;
 }

--- a/tests/unit/out/unsafe/string_escape.rs
+++ b/tests/unit/out/unsafe/string_escape.rs
@@ -14,7 +14,7 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut special: *const u8 =
         b"\x07\x08\t\n\x0b\x0c\r !\"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~\0".as_ptr();
-    static mut expected: [u8; 40] = unsafe {
+    static mut s_expected: [u8; 40] = unsafe {
         [
             7_u8, 8_u8, 9_u8, 10_u8, 11_u8, 12_u8, 13_u8, 32_u8, 33_u8, 34_u8, 35_u8, 36_u8, 37_u8,
             38_u8, 39_u8, 40_u8, 41_u8, 42_u8, 43_u8, 44_u8, 45_u8, 46_u8, 47_u8, 58_u8, 59_u8,
@@ -27,7 +27,7 @@ unsafe fn main_0() -> i32 {
         < (((::std::mem::size_of::<[u8; 40]>() as u64 as u64)
             .wrapping_div(::std::mem::size_of::<u8>() as u64 as u64)) as i32))
     {
-        assert!((((*special.offset((i) as isize)) as i32) == (expected[(i) as usize] as i32)));
+        assert!((((*special.offset((i) as isize)) as i32) == (s_expected[(i) as usize] as i32)));
         i.postfix_inc();
     }
     return 0;

--- a/tests/unit/out/unsafe/string_escape.rs
+++ b/tests/unit/out/unsafe/string_escape.rs
@@ -14,7 +14,7 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut special: *const u8 =
         b"\x07\x08\t\n\x0b\x0c\r !\"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~\0".as_ptr();
-    static mut s_expected: [u8; 40] = unsafe {
+    static mut expected_0: [u8; 40] = unsafe {
         [
             7_u8, 8_u8, 9_u8, 10_u8, 11_u8, 12_u8, 13_u8, 32_u8, 33_u8, 34_u8, 35_u8, 36_u8, 37_u8,
             38_u8, 39_u8, 40_u8, 41_u8, 42_u8, 43_u8, 44_u8, 45_u8, 46_u8, 47_u8, 58_u8, 59_u8,
@@ -27,7 +27,7 @@ unsafe fn main_0() -> i32 {
         < (((::std::mem::size_of::<[u8; 40]>() as u64 as u64)
             .wrapping_div(::std::mem::size_of::<u8>() as u64 as u64)) as i32))
     {
-        assert!((((*special.offset((i) as isize)) as i32) == (s_expected[(i) as usize] as i32)));
+        assert!((((*special.offset((i) as isize)) as i32) == (expected_0[(i) as usize] as i32)));
         i.postfix_inc();
     }
     return 0;

--- a/tests/unit/out/unsafe/union_tagged_struct_arms.rs
+++ b/tests/unit/out/unsafe/union_tagged_struct_arms.rs
@@ -23,6 +23,7 @@ impl From<i32> for Choice {
         }
     }
 }
+libcc2rs::impl_enum_inc_dec!(Choice);
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Branch_anon_0_anon_0 {

--- a/tests/unit/out/unsafe/union_tagged_struct_arms.rs
+++ b/tests/unit/out/unsafe/union_tagged_struct_arms.rs
@@ -73,7 +73,7 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    static mut items: [*mut u8; 3] = unsafe {
+    static mut s_items: [*mut u8; 3] = unsafe {
         [
             b"a\0".as_ptr().cast_mut(),
             b"b\0".as_ptr().cast_mut(),
@@ -83,7 +83,7 @@ unsafe fn main_0() -> i32 {
     let mut p_list: Branch = <Branch>::default();
     p_list.choice = Choice::C_LIST;
     p_list.index = 0;
-    p_list.v.list.items = items.as_mut_ptr();
+    p_list.v.list.items = s_items.as_mut_ptr();
     p_list.v.list.count = 3_i64;
     p_list.v.list.cursor = 1_i64;
     assert!(((((p_list.v.list.count) == (3_i64)) as i32) != 0));

--- a/tests/unit/out/unsafe/union_tagged_struct_arms.rs
+++ b/tests/unit/out/unsafe/union_tagged_struct_arms.rs
@@ -73,7 +73,7 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    static mut s_items: [*mut u8; 3] = unsafe {
+    static mut items_0: [*mut u8; 3] = unsafe {
         [
             b"a\0".as_ptr().cast_mut(),
             b"b\0".as_ptr().cast_mut(),
@@ -83,7 +83,7 @@ unsafe fn main_0() -> i32 {
     let mut p_list: Branch = <Branch>::default();
     p_list.choice = Choice::C_LIST;
     p_list.index = 0;
-    p_list.v.list.items = s_items.as_mut_ptr();
+    p_list.v.list.items = items_0.as_mut_ptr();
     p_list.v.list.count = 3_i64;
     p_list.v.list.cursor = 1_i64;
     assert!(((((p_list.v.list.count) == (3_i64)) as i32) != 0));

--- a/tests/unit/out/unsafe/union_tagged_struct_arms.rs
+++ b/tests/unit/out/unsafe/union_tagged_struct_arms.rs
@@ -23,7 +23,6 @@ impl From<i32> for Choice {
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Choice);
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Branch_anon_0_anon_0 {

--- a/tests/unit/out/unsafe/void_cast.rs
+++ b/tests/unit/out/unsafe/void_cast.rs
@@ -20,10 +20,10 @@ pub unsafe fn unused_ref_param_1(x: *const NonTrivial) {
 pub unsafe fn unused_ptr_param_2(mut p: *const NonTrivial) {
     &(*p);
 }
-pub static mut side_effect_counter: i32 = unsafe { 0 };
+pub static mut s_side_effect_counter: i32 = unsafe { 0 };
 pub unsafe fn bump_and_return_3() -> i32 {
-    side_effect_counter.prefix_inc();
-    return side_effect_counter;
+    s_side_effect_counter.prefix_inc();
+    return s_side_effect_counter;
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
@@ -56,12 +56,12 @@ unsafe fn main_0() -> i32 {
     assert!(((w) == (3)));
     assert!(((counter) == (3)));
     &(unsafe { bump_and_return_3() });
-    assert!(((side_effect_counter) == (1)));
+    assert!(((s_side_effect_counter) == (1)));
     let mut v: i32 = {
         &(unsafe { bump_and_return_3() });
         99
     };
-    assert!(((side_effect_counter) == (2)));
+    assert!(((s_side_effect_counter) == (2)));
     assert!(((v) == (99)));
     &(0);
     &(0);
@@ -78,13 +78,13 @@ unsafe fn main_0() -> i32 {
     assert!(((err) == (7)));
     assert!(((chosen) == (123)));
     &(bump_and_return_3);
-    assert!(((side_effect_counter) == (2)));
+    assert!(((s_side_effect_counter) == (2)));
     &(Some(bump_and_return_3));
-    assert!(((side_effect_counter) == (2)));
+    assert!(((s_side_effect_counter) == (2)));
     &(std::mem::transmute::<Option<unsafe fn() -> i32>, Option<unsafe fn() -> i32>>(
         (Some(bump_and_return_3)),
     ));
-    assert!(((side_effect_counter) == (2)));
+    assert!(((s_side_effect_counter) == (2)));
     let mut storage: i32 = 11;
     let mut p: *mut i32 = (&mut storage as *mut i32);
     &(*p);

--- a/tests/unit/out/unsafe/void_cast.rs
+++ b/tests/unit/out/unsafe/void_cast.rs
@@ -20,10 +20,10 @@ pub unsafe fn unused_ref_param_1(x: *const NonTrivial) {
 pub unsafe fn unused_ptr_param_2(mut p: *const NonTrivial) {
     &(*p);
 }
-pub static mut s_side_effect_counter: i32 = unsafe { 0 };
-pub unsafe fn bump_and_return_3() -> i32 {
-    s_side_effect_counter.prefix_inc();
-    return s_side_effect_counter;
+pub static mut side_effect_counter_3: i32 = unsafe { 0 };
+pub unsafe fn bump_and_return_4() -> i32 {
+    side_effect_counter_3.prefix_inc();
+    return side_effect_counter_3;
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
@@ -55,13 +55,13 @@ unsafe fn main_0() -> i32 {
     };
     assert!(((w) == (3)));
     assert!(((counter) == (3)));
-    &(unsafe { bump_and_return_3() });
-    assert!(((s_side_effect_counter) == (1)));
+    &(unsafe { bump_and_return_4() });
+    assert!(((side_effect_counter_3) == (1)));
     let mut v: i32 = {
-        &(unsafe { bump_and_return_3() });
+        &(unsafe { bump_and_return_4() });
         99
     };
-    assert!(((s_side_effect_counter) == (2)));
+    assert!(((side_effect_counter_3) == (2)));
     assert!(((v) == (99)));
     &(0);
     &(0);
@@ -77,14 +77,14 @@ unsafe fn main_0() -> i32 {
     };
     assert!(((err) == (7)));
     assert!(((chosen) == (123)));
-    &(bump_and_return_3);
-    assert!(((s_side_effect_counter) == (2)));
-    &(Some(bump_and_return_3));
-    assert!(((s_side_effect_counter) == (2)));
+    &(bump_and_return_4);
+    assert!(((side_effect_counter_3) == (2)));
+    &(Some(bump_and_return_4));
+    assert!(((side_effect_counter_3) == (2)));
     &(std::mem::transmute::<Option<unsafe fn() -> i32>, Option<unsafe fn() -> i32>>(
-        (Some(bump_and_return_3)),
+        (Some(bump_and_return_4)),
     ));
-    assert!(((s_side_effect_counter) == (2)));
+    assert!(((side_effect_counter_3) == (2)));
     let mut storage: i32 = 11;
     let mut p: *mut i32 = (&mut storage as *mut i32);
     &(*p);

--- a/tests/unit/static_function_vars_same_name.cpp
+++ b/tests/unit/static_function_vars_same_name.cpp
@@ -1,0 +1,17 @@
+#include <assert.h>
+
+int a() {
+  static int i = 1;
+  return i;
+}
+
+int b() {
+  static int i = 2;
+  return i;
+}
+
+int main() {
+  assert(a() == 1);
+  assert(b() == 2);
+  return 0;
+}

--- a/tests/unit/static_shadow.c
+++ b/tests/unit/static_shadow.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+
+static int value = 5;
+
+int param_shadow(int value) { return value + 1; }
+
+int local_shadow(void) {
+  int value = 99;
+  return value;
+}
+
+int read_global(void) { return value; }
+
+int main() {
+  assert(param_shadow(10) == 11);
+  assert(local_shadow() == 99);
+  assert(read_global() == 5);
+  return 0;
+}


### PR DESCRIPTION
This PR extends GetNamedDeclAsString to handle variables with static linkage. This fixes:
* shadowing between global variables and local variables (tests/unit/static_shadow.c)
* name collisions beween static variables declared in different functions (tests/unit/static_function_vars_same_name.cpp)
* name collisions between global static variables declared in different TUs (tests/multi-file/static_name_collision)