### PR TITLE
Use explicit enum default value instead of Default trait

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -3190,6 +3190,13 @@ std::string Converter::GetDefaultAsStringFallback(clang::QualType qual_type) {
     }
   }
 
+  if (qual_type->isEnumeralType()) {
+    auto enum_decl = qual_type->castAs<clang::EnumType>()->getDecl();
+    return std::format(
+        "{}::{}", GetRecordName(enum_decl),
+        std::string_view(enum_decl->enumerator_begin()->getName()));
+  }
+
   return std::format("<{}>::default()", ToString(qual_type));
 }
 

--- a/tests/unit/enum_default_in_static.c
+++ b/tests/unit/enum_default_in_static.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+
+enum Mode {
+  MODE_NONE,
+  MODE_ONE,
+  MODE_TWO,
+};
+
+struct Config {
+  int count;
+  enum Mode mode;
+};
+
+static struct Config config;
+
+int main(void) {
+  assert(config.count == 0);
+  assert(config.mode == MODE_NONE);
+  return 0;
+}

--- a/tests/unit/out/refcount/enum_default_in_static.rs
+++ b/tests/unit/out/refcount/enum_default_in_static.rs
@@ -1,0 +1,47 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+enum Mode {
+    #[default]
+    MODE_NONE = 0,
+    MODE_ONE = 1,
+    MODE_TWO = 2,
+}
+impl From<i32> for Mode {
+    fn from(n: i32) -> Mode {
+        match n {
+            0 => Mode::MODE_NONE,
+            1 => Mode::MODE_ONE,
+            2 => Mode::MODE_TWO,
+            _ => panic!("invalid Mode value: {}", n),
+        }
+    }
+}
+libcc2rs::impl_enum_inc_dec!(Mode);
+#[derive(Default)]
+pub struct Config {
+    pub count: Value<i32>,
+    pub mode: Value<Mode>,
+}
+impl ByteRepr for Config {}
+thread_local!(
+    pub static config_0: Value<Config> = <Value<Config>>::default();
+);
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(((((*(*config_0.with(Value::clone).borrow()).count.borrow()) == 0) as i32) != 0));
+    assert!(
+        (((((*(*config_0.with(Value::clone).borrow()).mode.borrow()) as u32)
+            == ((Mode::MODE_NONE as i32) as u32)) as i32)
+            != 0)
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/enum_default_in_static.rs
+++ b/tests/unit/out/unsafe/enum_default_in_static.rs
@@ -1,0 +1,48 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+enum Mode {
+    #[default]
+    MODE_NONE = 0,
+    MODE_ONE = 1,
+    MODE_TWO = 2,
+}
+impl From<i32> for Mode {
+    fn from(n: i32) -> Mode {
+        match n {
+            0 => Mode::MODE_NONE,
+            1 => Mode::MODE_ONE,
+            2 => Mode::MODE_TWO,
+            _ => panic!("invalid Mode value: {}", n),
+        }
+    }
+}
+libcc2rs::impl_enum_inc_dec!(Mode);
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct Config {
+    pub count: i32,
+    pub mode: Mode,
+}
+pub static mut config_0: Config = unsafe {
+    Config {
+        count: 0_i32,
+        mode: Mode::MODE_NONE,
+    }
+};
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(((((config_0.count) == (0)) as i32) != 0));
+    assert!(((((config_0.mode as u32) == ((Mode::MODE_NONE as i32) as u32)) as i32) != 0));
+    return 0;
+}


### PR DESCRIPTION
`Default::default()` cannot be used in const context, for example initializing a global variable. For this reason, switch the initialization of enum from `<EnumName>::default()` to `<EnumName>::EXPLICIT_DEFAULT_VALUE`.