### PR TITLE
Add goto support in libcc2rs-macros

### DIFF
--- a/libcc2rs-macros/src/goto.rs
+++ b/libcc2rs-macros/src/goto.rs
@@ -2,14 +2,16 @@
 // Distributed under the MIT license that can be found in the LICENSE file.
 
 use proc_macro::TokenStream;
+use proc_macro2::Span;
 use syn::parse::{Parse, ParseStream};
-use syn::{Expr, Lifetime, Token, parse_macro_input};
+use syn::{Block, Expr, ExprBlock, Lifetime, Stmt, parse_macro_input};
 
-use crate::state_machine::{Arm, GotoStateMachine, StateMachine};
+use crate::state_machine::{Arm, GotoStateMachine, StateMachineNames, StateMachine};
 
 pub fn expand(input: TokenStream) -> TokenStream {
     let GotoBlockInput { arms } = parse_macro_input!(input as GotoBlockInput);
     GotoStateMachine {
+        names: StateMachineNames::fresh(),
         arms: arms
             .into_iter()
             .map(|a| Arm {

--- a/libcc2rs-macros/src/goto.rs
+++ b/libcc2rs-macros/src/goto.rs
@@ -33,15 +33,29 @@ struct GotoArm {
 
 impl Parse for GotoBlockInput {
     fn parse(input: ParseStream) -> syn::Result<Self> {
+        let block: Block = input.parse()?;
         let mut arms = Vec::new();
-        while !input.is_empty() {
-            let label: Lifetime = input.parse()?;
-            input.parse::<Token![=>]>()?;
-            let body: Expr = input.parse()?;
-            arms.push(GotoArm { label, body });
-            if input.peek(Token![,]) {
-                input.parse::<Token![,]>()?;
-            }
+        for stmt in block.stmts {
+            let Stmt::Expr(Expr::Block(eb), _) = stmt else {
+                return Err(syn::Error::new(
+                    Span::call_site(),
+                    "goto_block! body must be a sequence of labeled blocks",
+                ));
+            };
+            let Some(label) = eb.label else {
+                return Err(syn::Error::new(
+                    Span::call_site(),
+                    "goto_block! arm must be a labeled block",
+                ));
+            };
+            arms.push(GotoArm {
+                label: label.name,
+                body: Expr::Block(ExprBlock {
+                    attrs: eb.attrs,
+                    label: None,
+                    block: eb.block,
+                }),
+            });
         }
         Ok(Self { arms })
     }

--- a/libcc2rs-macros/src/goto.rs
+++ b/libcc2rs-macros/src/goto.rs
@@ -6,7 +6,7 @@ use proc_macro2::Span;
 use syn::parse::{Parse, ParseStream};
 use syn::{Block, Expr, ExprBlock, Lifetime, Stmt, parse_macro_input};
 
-use crate::state_machine::{Arm, GotoStateMachine, StateMachineNames, StateMachine};
+use crate::state_machine::{Arm, GotoStateMachine, StateMachine, StateMachineNames};
 
 pub fn expand(input: TokenStream) -> TokenStream {
     let GotoBlockInput { arms } = parse_macro_input!(input as GotoBlockInput);

--- a/libcc2rs-macros/src/lib.rs
+++ b/libcc2rs-macros/src/lib.rs
@@ -36,10 +36,10 @@ pub fn switch(input: TokenStream) -> TokenStream {
     switch::expand(input)
 }
 
-//     goto_block! {
-//         '<label> => { /* body; may contain `break` or `continue` */ },
+//     goto_block!({
+//         '<label>: { /* body; may contain `break`, `continue`, or goto!('other) */ }
 //         ...
-//     };
+//     });
 //
 // Expands to
 //

--- a/libcc2rs-macros/src/state_machine.rs
+++ b/libcc2rs-macros/src/state_machine.rs
@@ -1,10 +1,13 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
 use syn::visit_mut::{self, VisitMut};
-use syn::{Expr, ExprBreak, ExprContinue, Lifetime, Pat};
+use syn::{Expr, ExprBreak, ExprContinue, Lifetime, Pat, Stmt, parse_quote};
 
 pub struct Arm {
     pub label: String,
@@ -21,12 +24,29 @@ pub trait StateMachine {
     fn emit(self) -> TokenStream2;
 }
 
-fn sm_label() -> Lifetime {
-    Lifetime::new("'__sm", Span::call_site())
+pub(crate) struct StateMachineNames {
+    pub label: Lifetime,
+    pub state: Ident,
+    pub break_flag: Ident,
+    pub cont_flag: Ident,
+}
+
+impl StateMachineNames {
+    pub fn fresh() -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        Self {
+            label: Lifetime::new(&format!("'__sm{id}"), Span::call_site()),
+            state: format_ident!("__s{}", id),
+            break_flag: format_ident!("__user_break{}", id),
+            cont_flag: format_ident!("__user_continue{}", id),
+        }
+    }
 }
 
 // Collection of labeled arms that fall-through by default
 pub struct GotoStateMachine {
+    pub names: StateMachineNames,
     pub arms: Vec<Arm>,
 }
 
@@ -87,10 +107,7 @@ impl GotoStateMachine {
 
 impl StateMachine for GotoStateMachine {
     fn emit(self) -> TokenStream2 {
-        let lbl = sm_label();
-        let s = format_ident!("__s");
-        let break_flag = format_ident!("__user_break");
-        let cont_flag = format_ident!("__user_continue");
+        let StateMachineNames { label: lbl, state: s, break_flag, cont_flag } = self.names;
 
         let n = self.arms.len();
         let mut arms_have_break = false;
@@ -186,17 +203,16 @@ impl SwitchStateMachine {
 
 impl StateMachine for SwitchStateMachine {
     fn emit(self) -> TokenStream2 {
-        let lbl = sm_label();
-        let s = format_ident!("__s");
+        let names = StateMachineNames::fresh();
 
-        let user_arms = Self::convert_break_to_switch_exit(&self.goto.arms, &lbl);
-        let dispatch = self.build_dispatch_arm(&user_arms, &lbl, &s);
+        let user_arms = Self::convert_break_to_switch_exit(&self.goto.arms, &names.label);
+        let dispatch = self.build_dispatch_arm(&user_arms, &names.label, &names.state);
 
         let mut arms = Vec::new();
         arms.push(dispatch);
         arms.extend(user_arms);
 
-        GotoStateMachine { arms }.emit()
+        GotoStateMachine { names, arms }.emit()
     }
 }
 

--- a/libcc2rs-macros/src/state_machine.rs
+++ b/libcc2rs-macros/src/state_machine.rs
@@ -107,7 +107,12 @@ impl GotoStateMachine {
 
 impl StateMachine for GotoStateMachine {
     fn emit(self) -> TokenStream2 {
-        let StateMachineNames { label: lbl, state: s, break_flag, cont_flag } = self.names;
+        let StateMachineNames {
+            label: lbl,
+            state: s,
+            break_flag,
+            cont_flag,
+        } = self.names;
 
         let n = self.arms.len();
         let mut arms_have_break = false;
@@ -118,6 +123,17 @@ impl StateMachine for GotoStateMachine {
             .enumerate()
             .map(|(i, arm)| {
                 let mut body = arm.body.clone();
+                GotoRewriter {
+                    map: &self
+                        .arms
+                        .iter()
+                        .enumerate()
+                        .map(|(i, a)| (a.label.clone(), i as u32))
+                        .collect(),
+                    state: s.clone(),
+                    sm_label: lbl.clone(),
+                }
+                .visit_expr_mut(&mut body);
                 let (had_br, had_cn) =
                     Self::propagate_rewrite(&mut body, &lbl, &break_flag, &cont_flag);
                 arms_have_break |= had_br;
@@ -145,6 +161,58 @@ impl StateMachine for GotoStateMachine {
             #brk_bailout
             #cnt_bailout
         }}
+    }
+}
+
+// Rewrites `goto!('label)` into `{ __s = <target index>; continue '__sm; }`.
+struct GotoRewriter<'a> {
+    // Map with labels and their indices inside the current state machine. Used to check if the
+    // label the goto jumps to is part of the current state machine. If it is, emit
+    // `__s = map[label]`
+    map: &'a HashMap<String, u32>,
+    state: Ident,
+    sm_label: Lifetime,
+}
+
+impl GotoRewriter<'_> {
+    fn expand_goto_into_state_machine_jump(&self, tokens: &TokenStream2) -> Option<Expr> {
+        let idx = *self.map.get(
+            &syn::parse2::<Lifetime>(tokens.clone())
+                .expect("goto! expects a lifetime label")
+                .ident
+                .to_string(),
+        )?;
+        let state = &self.state;
+        let sm_label = &self.sm_label;
+        Some(parse_quote!({ #state = #idx; continue #sm_label; }))
+    }
+
+    fn recurse_into_inner_goto_block(&mut self, mac: &mut syn::Macro) -> bool {
+        if mac.path.is_ident("switch") || mac.path.is_ident("goto_block") {
+            if let Ok(mut inner) = syn::parse2::<Expr>(mac.tokens.clone()) {
+                self.visit_expr_mut(&mut inner);
+                mac.tokens = quote!(#inner);
+            }
+            return true;
+        }
+        false
+    }
+}
+
+impl VisitMut for GotoRewriter<'_> {
+    fn visit_stmt_mut(&mut self, stmt: &mut Stmt) {
+        if let Stmt::Macro(sm) = stmt {
+            if sm.mac.path.is_ident("goto") {
+                if let Some(jump) = self.expand_goto_into_state_machine_jump(&sm.mac.tokens) {
+                    *stmt = Stmt::Expr(jump, Some(Default::default()));
+                }
+                return;
+            }
+            if self.recurse_into_inner_goto_block(&mut sm.mac) {
+                return;
+            }
+        }
+        visit_mut::visit_stmt_mut(self, stmt);
     }
 }
 

--- a/libcc2rs-macros/src/switch.rs
+++ b/libcc2rs-macros/src/switch.rs
@@ -5,7 +5,9 @@ use proc_macro::TokenStream;
 use syn::parse::{Parse, ParseStream};
 use syn::{Expr, Pat, parse_macro_input};
 
-use crate::state_machine::{Arm, DispatchCase, GotoStateMachine, StateMachine, SwitchStateMachine};
+use crate::state_machine::{
+    Arm, DispatchCase, GotoStateMachine, StateMachineNames, StateMachine, SwitchStateMachine,
+};
 
 pub fn expand(input: TokenStream) -> TokenStream {
     let SwitchInput { condition, arms } = parse_macro_input!(input as SwitchInput);
@@ -24,7 +26,10 @@ pub fn expand(input: TokenStream) -> TokenStream {
         });
     }
     SwitchStateMachine {
-        goto: GotoStateMachine { arms: cfg_arms },
+        goto: GotoStateMachine {
+            names: StateMachineNames::fresh(),
+            arms: cfg_arms,
+        },
         condition,
         cases,
     }

--- a/libcc2rs-macros/src/switch.rs
+++ b/libcc2rs-macros/src/switch.rs
@@ -6,7 +6,7 @@ use syn::parse::{Parse, ParseStream};
 use syn::{Expr, Pat, parse_macro_input};
 
 use crate::state_machine::{
-    Arm, DispatchCase, GotoStateMachine, StateMachineNames, StateMachine, SwitchStateMachine,
+    Arm, DispatchCase, GotoStateMachine, StateMachine, StateMachineNames, SwitchStateMachine,
 };
 
 pub fn expand(input: TokenStream) -> TokenStream {

--- a/libcc2rs-macros/tests/control_flow.rs
+++ b/libcc2rs-macros/tests/control_flow.rs
@@ -269,11 +269,17 @@ fn switch_in_loop() {
 #[test]
 fn goto_block_linear_fallthrough() {
     let mut v = 0;
-    goto_block! {
-        'a => { v += 1; },
-        'b => { v += 10; },
-        'c => { v += 100; },
-    };
+    goto_block!({
+        'a: {
+            v += 1;
+        }
+        'b: {
+            v += 10;
+        }
+        'c: {
+            v += 100;
+        }
+    });
     assert_eq!(v, 111);
 }
 
@@ -281,11 +287,21 @@ fn goto_block_linear_fallthrough() {
 fn goto_block_return_from_arm() {
     #[allow(unreachable_code)]
     fn run(start: u32) -> &'static str {
-        goto_block! {
-            'a => { if start == 0 { return "a"; } },
-            'b => { if start == 1 { return "b"; } },
-            'c => { return "c"; },
-        };
+        goto_block!({
+            'a: {
+                if start == 0 {
+                    return "a";
+                }
+            }
+            'b: {
+                if start == 1 {
+                    return "b";
+                }
+            }
+            'c: {
+                return "c";
+            }
+        });
         "fallthrough"
     }
     assert_eq!(run(0), "a");
@@ -294,16 +310,176 @@ fn goto_block_return_from_arm() {
 }
 
 #[test]
+fn goto_block_forward_goto_skips_block() {
+    fn skip(n: i32) -> i32 {
+        let mut x: i32 = 0;
+        goto_block!({
+            '__entry: {
+                x = 0;
+                if n > 0 {
+                    goto!('mid);
+                }
+                x += 10;
+            }
+            'mid: {
+                x += 1;
+            }
+        });
+        x
+    }
+    assert_eq!(skip(1), 1);
+    assert_eq!(skip(-1), 11);
+}
+
+#[test]
+fn goto_block_local_visible_across_label() {
+    fn early(n: i32) -> i32 {
+        let mut ret: i32 = 0;
+        goto_block!({
+            '__entry: {
+                if n < 0 {
+                    ret = -1;
+                    goto!('out);
+                }
+                ret = 100;
+            }
+            'out: {
+                return ret;
+            }
+        });
+        #[allow(unreachable_code)]
+        0
+    }
+    assert_eq!(early(-1), -1);
+    assert_eq!(early(5), 100);
+}
+
+#[test]
+fn goto_block_backward_goto_retry() {
+    fn f() -> i32 {
+        let mut sum: i32 = 0;
+        let mut i: i32 = 0;
+        goto_block!({
+            'again: {
+                let local: i32 = i;
+                sum += local;
+                i += 1;
+                if i < 4 {
+                    goto!('again);
+                }
+                return sum;
+            }
+        });
+        #[allow(unreachable_code)]
+        0
+    }
+    assert_eq!(f(), 6);
+}
+
+#[test]
+fn goto_block_multi_label_fallthrough() {
+    fn classify(n: i32) -> i32 {
+        let mut ret: i32 = 0;
+        goto_block!({
+            '__entry: {
+                if n < 0 {
+                    goto!('error);
+                }
+                if n == 0 {
+                    goto!('out);
+                }
+                ret = n;
+                goto!('out);
+            }
+            'error: {
+                ret = -1;
+            }
+            'out: {
+                return ret;
+            }
+        });
+        #[allow(unreachable_code)]
+        0
+    }
+    assert_eq!(classify(5), 5);
+    assert_eq!(classify(0), 0);
+    assert_eq!(classify(-2), -1);
+}
+
+#[test]
+fn goto_block_goto_out_of_switch() {
+    fn sm(n: i32) -> i32 {
+        let mut ret: i32 = 0;
+        goto_block!({
+            '__entry: {
+                switch!(match n {
+                    0 => {
+                        ret += 1;
+                    }
+                    1 => {
+                        ret += 10;
+                        goto!('out);
+                    }
+                    _ => {
+                        ret += 100;
+                        break;
+                    }
+                });
+                ret += 1000;
+            }
+            'out: {
+                return ret;
+            }
+        });
+        #[allow(unreachable_code)]
+        0
+    }
+    assert_eq!(sm(0), 11);
+    assert_eq!(sm(1), 10);
+    assert_eq!(sm(9), 1100);
+}
+
+#[test]
+fn goto_block_goto_out_of_nested_block() {
+    fn f(n: i32) -> i32 {
+        let mut ret: i32 = 0;
+        goto_block!({
+            '__entry: {
+                goto_block!({
+                    'inner: {
+                        ret = 1;
+                        if n > 0 {
+                            goto!('out);
+                        }
+                        ret = 2;
+                    }
+                });
+                ret += 10;
+            }
+            'out: {
+                return ret;
+            }
+        });
+        #[allow(unreachable_code)]
+        0
+    }
+    assert_eq!(f(1), 1);
+    assert_eq!(f(-1), 12);
+}
+
+#[test]
 fn goto_block_nested_loop_break_targets_inner() {
     let mut sum = 0;
-    goto_block! {
-        'entry => {
+    goto_block!({
+        'entry: {
             for i in 0..10 {
-                if i == 3 { break; } // targets the for loop
+                if i == 3 {
+                    break;
+                } // targets the for loop
                 sum += i;
             }
             sum += 100;
-        },
-    };
+        }
+    });
     assert_eq!(sum, 103);
 }

--- a/libcc2rs-macros/tests/control_flow.rs
+++ b/libcc2rs-macros/tests/control_flow.rs
@@ -229,7 +229,6 @@ fn switch_nested_loop_break_targets_inner() {
 
 #[test]
 fn switch_return_from_case() {
-    #[allow(unreachable_code)]
     fn classify(x: i32) -> &'static str {
         switch!(match x {
             0 => {
@@ -242,7 +241,7 @@ fn switch_return_from_case() {
                 return "other";
             }
         });
-        "unreachable"
+        panic!("ub: non-void function does not return a value");
     }
     assert_eq!(classify(0), "zero");
     assert_eq!(classify(1), "one");
@@ -285,7 +284,6 @@ fn goto_block_linear_fallthrough() {
 
 #[test]
 fn goto_block_return_from_arm() {
-    #[allow(unreachable_code)]
     fn run(start: u32) -> &'static str {
         goto_block!({
             'a: {
@@ -302,7 +300,7 @@ fn goto_block_return_from_arm() {
                 return "c";
             }
         });
-        "fallthrough"
+        panic!("ub: non-void function does not return a value");
     }
     assert_eq!(run(0), "a");
     assert_eq!(run(1), "b");
@@ -347,8 +345,7 @@ fn goto_block_local_visible_across_label() {
                 return ret;
             }
         });
-        #[allow(unreachable_code)]
-        0
+        panic!("ub: non-void function does not return a value");
     }
     assert_eq!(early(-1), -1);
     assert_eq!(early(5), 100);
@@ -370,8 +367,7 @@ fn goto_block_backward_goto_retry() {
                 return sum;
             }
         });
-        #[allow(unreachable_code)]
-        0
+        panic!("ub: non-void function does not return a value");
     }
     assert_eq!(f(), 6);
 }
@@ -398,8 +394,7 @@ fn goto_block_multi_label_fallthrough() {
                 return ret;
             }
         });
-        #[allow(unreachable_code)]
-        0
+        panic!("ub: non-void function does not return a value");
     }
     assert_eq!(classify(5), 5);
     assert_eq!(classify(0), 0);
@@ -431,8 +426,7 @@ fn goto_block_goto_out_of_switch() {
                 return ret;
             }
         });
-        #[allow(unreachable_code)]
-        0
+        panic!("ub: non-void function does not return a value");
     }
     assert_eq!(sm(0), 11);
     assert_eq!(sm(1), 10);
@@ -460,8 +454,7 @@ fn goto_block_goto_out_of_nested_block() {
                 return ret;
             }
         });
-        #[allow(unreachable_code)]
-        0
+        panic!("ub: non-void function does not return a value");
     }
     assert_eq!(f(1), 1);
     assert_eq!(f(-1), 12);


### PR DESCRIPTION
This PR adds support for writing goto and goto_block in the following form:

```rs
let mut ret: i32 = 0;
goto_block!({
     '__entry: {
         if n < 0 {
             ret = -1;
             goto!('out);
         }
         ret = 100;
     }
     'out: {
         return ret;
     }
});
```

This is equivalent to the following C code:

```c
int f() {
  int ret;
  if (n < 0) {
    ret = -1;
    goto out;
  }
  ret = 100;
out:
  return ret;
}
```

goto_block is already used by the switch-with-fallthrough macro internally. I modified its syntax from a list of `label = { ... }` to `label: { ... }` so that rustfmt can format it properly.

Then, I added GotoRewriter to rewrite each `goto!('label)` into `{ __s = <target index>; continue '__sm; }`. Whenever GotoStateMachine hits a goto macro, it calls GotoRewriter to generate the following state machine:

```rs
{
    let mut __s: u32 = 0;
    '__sm: loop {
        match __s {
            0u32 => {
                if n < 0 {
                    ret = -1;
                    __s = 1; continue '__sm;   // <- was goto!('out)
                }
                ret = 100;
                __s = 1; continue '__sm;       // fall-through to next arm
            }
            1u32 => {
                return ret;
                break '__sm;                   // last arm: exit
            }
            _ => break '__sm,                  // match exhaustiveness
        }
    }
}
```

Finally, to support nested goto_blocks, for example a switch inside a goto_block, I added StateMachineNames which gives a unique name to each state machine so that each goto targets the correct state machine.

After this PR is merged, I will add the codegen counterpart in the `cpp2rust/` dir.

A few limitations about how goto will work:
* local variables of a function that contains goto will be hoisted outside the goto_block so that all arms of the goto_block macro can see them. c2rust also does this. All hoisted variables will be default initialized.
* the rust compiler cannot prove that all paths of the code inside the loop of the state machine return. I reality the loop always returns because the C behavior is preserved. To suppress the rustc error, I added a panic at the end of the function: `panic!("ub: non-void function does not return a value");`