### PR TITLE
Make Rust type rules standalone functions

### DIFF
--- a/rule-preprocessor/src/syntactic.rs
+++ b/rule-preprocessor/src/syntactic.rs
@@ -537,17 +537,22 @@ impl<'a> TypeIrBuilder<'a> {
             .fn_item
             .ret_type()
             .and_then(|rt| rt.ty())
-            .expect("type rule must declare a return type");
+            .expect("Type rules must declare a return type");
         let (is_refcount_pointer, is_unsafe_pointer) = pointer_flags(&ty);
 
-        let body = self.fn_item.body().expect("type rule must have a body");
-        let init = body
-            .syntax()
-            .descendants()
-            .find_map(ast::ReturnExpr::cast)
-            .and_then(|ret| ret.expr())
-            .or_else(|| body.stmt_list().and_then(|sl| sl.tail_expr()))
-            .expect("type rule must yield an initializer");
+        let stmts = self
+            .fn_item
+            .body()
+            .and_then(|bd| bd.stmt_list())
+            .expect("Types rule must have a body");
+        assert!(
+            stmts.statements().count() == 0,
+            "Type rules mustn't contain anything in the body besides the tail expression"
+        );
+
+        let init = stmts
+            .tail_expr()
+            .expect("Type rules must yield an initializer");
 
         TypeIr {
             init: init.syntax().text().to_string(),

--- a/rule-preprocessor/src/syntactic.rs
+++ b/rule-preprocessor/src/syntactic.rs
@@ -124,10 +124,11 @@ impl SyntacticAnalysis {
             let Some(name) = fn_item.name() else { continue };
             let fn_name = name.text().to_string();
 
-            if fn_name == "types" {
-                for (name, ir) in TypeIrBuilder::new(&fn_item).build() {
-                    file_ir.insert(name, RuleIr::Type(ir));
-                }
+            if fn_name.starts_with('t') {
+                file_ir.insert(
+                    fn_name.clone(),
+                    RuleIr::Type(TypeIrBuilder::new(&fn_item).build()),
+                );
             } else if fn_name.starts_with('f') {
                 if !cfg_matches_host(&fn_item) {
                     continue;
@@ -531,35 +532,30 @@ impl<'a> TypeIrBuilder<'a> {
         Self { fn_item }
     }
 
-    fn build(&self) -> Vec<(String, TypeIr)> {
-        let Some(body) = self.fn_item.body() else {
-            return Vec::new();
-        };
-        let mut results = Vec::new();
-        for stmt in body.syntax().descendants().filter_map(ast::LetStmt::cast) {
-            let Some(pat) = stmt.pat() else { continue };
-            let pat_text = pat.syntax().text().to_string();
-            if !pat_text.starts_with('t') {
-                continue;
-            }
-            let Some(ty) = stmt.ty() else { continue };
-            let Some(init) = stmt.initializer() else {
-                continue;
-            };
+    fn build(&self) -> TypeIr {
+        let ty = self
+            .fn_item
+            .ret_type()
+            .and_then(|rt| rt.ty())
+            .expect("type rule must declare a return type");
+        let (is_refcount_pointer, is_unsafe_pointer) = pointer_flags(&ty);
 
-            let (is_refcount_pointer, is_unsafe_pointer) = pointer_flags(&ty);
-            results.push((
-                pat_text,
-                TypeIr {
-                    init: init.syntax().text().to_string(),
-                    type_info: TypeInfo {
-                        ty: ty.syntax().text().to_string(),
-                        is_refcount_pointer,
-                        is_unsafe_pointer,
-                    },
-                },
-            ));
+        let body = self.fn_item.body().expect("type rule must have a body");
+        let init = body
+            .syntax()
+            .descendants()
+            .find_map(ast::ReturnExpr::cast)
+            .and_then(|ret| ret.expr())
+            .or_else(|| body.stmt_list().and_then(|sl| sl.tail_expr()))
+            .expect("type rule must yield an initializer");
+
+        TypeIr {
+            init: init.syntax().text().to_string(),
+            type_info: TypeInfo {
+                ty: ty.syntax().text().to_string(),
+                is_refcount_pointer,
+                is_unsafe_pointer,
+            },
         }
-        results
     }
 }

--- a/rules/array/tgt_unsafe.rs
+++ b/rules/array/tgt_unsafe.rs
@@ -3,10 +3,8 @@
 
 use libcc2rs::*;
 
-struct T1;
-
-fn types() {
-    let t1: Vec<T1> = Default::default();
+fn t1<T1>() -> Vec<T1> {
+    Default::default()
 }
 
 unsafe fn f1<T1>(a0: Vec<T1>) -> *const T1 {

--- a/rules/brotli/tgt_unsafe.rs
+++ b/rules/brotli/tgt_unsafe.rs
@@ -1,12 +1,24 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-fn types() {
-    let t1: ::brotli_sys::BrotliDecoderResult = ::brotli_sys::BROTLI_DECODER_RESULT_ERROR;
-    let t2: ::brotli_sys::BrotliEncoderMode = ::brotli_sys::BROTLI_MODE_GENERIC;
-    let t3: *mut ::brotli_sys::BrotliDecoderState = std::ptr::null_mut();
-    let t4: *const ::brotli_sys::BrotliDecoderState = std::ptr::null();
-    let t5: ::brotli_sys::BrotliDecoderErrorCode = ::brotli_sys::BROTLI_DECODER_NO_ERROR;
+fn t1() -> ::brotli_sys::BrotliDecoderResult {
+    ::brotli_sys::BROTLI_DECODER_RESULT_ERROR
+}
+
+fn t2() -> ::brotli_sys::BrotliEncoderMode {
+    ::brotli_sys::BROTLI_MODE_GENERIC
+}
+
+fn t3() -> *mut ::brotli_sys::BrotliDecoderState {
+    std::ptr::null_mut()
+}
+
+fn t4() -> *const ::brotli_sys::BrotliDecoderState {
+    std::ptr::null()
+}
+
+fn t5() -> ::brotli_sys::BrotliDecoderErrorCode {
+    ::brotli_sys::BROTLI_DECODER_NO_ERROR
 }
 
 unsafe fn f1() -> ::brotli_sys::BrotliEncoderMode {

--- a/rules/carray/tgt_refcount.rs
+++ b/rules/carray/tgt_refcount.rs
@@ -3,9 +3,10 @@
 
 use libcc2rs::*;
 
-struct T1;
+fn t1<T1>() -> Box<[Value<Box<[T1]>>]> {
+    Box::new([Default::default()])
+}
 
-fn types() {
-    let t1: Box<[Value<Box<[T1]>>]> = Box::new([Default::default()]);
-    let t2: Box<[Value<Box<[Value<Box<[T1]>>]>>]> = Box::new([Default::default()]);
+fn t2<T1>() -> Box<[Value<Box<[Value<Box<[T1]>>]>>]> {
+    Box::new([Default::default()])
 }

--- a/rules/carray/tgt_unsafe.rs
+++ b/rules/carray/tgt_unsafe.rs
@@ -1,7 +1,10 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-fn types() {
-    let t1: libcc2rs::IgnoreRule = libcc2rs::IgnoreRule;
-    let t2: libcc2rs::IgnoreRule = libcc2rs::IgnoreRule;
+fn t1() -> libcc2rs::IgnoreRule {
+    libcc2rs::IgnoreRule
+}
+
+fn t2() -> libcc2rs::IgnoreRule {
+    libcc2rs::IgnoreRule
 }

--- a/rules/deque/tgt_unsafe.rs
+++ b/rules/deque/tgt_unsafe.rs
@@ -3,12 +3,10 @@
 
 use libcc2rs::*;
 
-struct T1;
-
-fn types() {
-    // TODO: it should be VecDeque, but we don't have the neccessary infrastructure in Ptr<> to
-    // make this work.
-    let t1: Vec<T1> = Default::default();
+// TODO: it should be VecDeque, but we don't have the neccessary infrastructure in Ptr<> to
+// make this work.
+fn t1<T1>() -> Vec<T1> {
+    Default::default()
 }
 
 unsafe fn f1<T1>(a0: &mut Vec<T1>) -> *const T1 {

--- a/rules/fstream/tgt_unsafe.rs
+++ b/rules/fstream/tgt_unsafe.rs
@@ -1,11 +1,16 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-fn types() -> Result<(), Box<dyn std::error::Error>> {
-    let t1: ::std::fs::File = ::std::fs::File::open("")?;
-    let t2: ::std::fs::File = ::std::fs::File::open("")?;
-    let t3: ::std::fs::File = ::std::fs::File::open("")?;
-    Ok(())
+fn t1() -> ::std::fs::File {
+    ::std::fs::File::open("").unwrap()
+}
+
+fn t2() -> ::std::fs::File {
+    ::std::fs::File::open("").unwrap()
+}
+
+fn t3() -> ::std::fs::File {
+    ::std::fs::File::open("").unwrap()
 }
 
 unsafe fn f1(a0: *const u8) -> ::std::fs::File {

--- a/rules/initializer_list/tgt_unsafe.rs
+++ b/rules/initializer_list/tgt_unsafe.rs
@@ -3,10 +3,8 @@
 
 use libcc2rs::*;
 
-struct T1;
-
-fn types() {
-    let t1: Vec<T1> = Default::default();
+fn t1<T1>() -> Vec<T1> {
+    Default::default()
 }
 
 unsafe fn f1<T1>(a0: Vec<T1>) -> u64 {

--- a/rules/iostream/tgt_refcount.rs
+++ b/rules/iostream/tgt_refcount.rs
@@ -5,9 +5,12 @@ use libcc2rs::*;
 use std::os::fd::AsFd;
 
 // TODO: t2 and t3 should be translated to Ptr<dyn Traits>
-fn types() {
-    let t2: Ptr<std::fs::File> = Ptr::null();
-    let t3: Ptr<std::fs::File> = Ptr::null();
+fn t2() -> Ptr<std::fs::File> {
+    Ptr::null()
+}
+
+fn t3() -> Ptr<std::fs::File> {
+    Ptr::null()
 }
 
 fn f1() -> ::std::fs::File {

--- a/rules/iostream/tgt_unsafe.rs
+++ b/rules/iostream/tgt_unsafe.rs
@@ -4,11 +4,17 @@
 use libcc2rs::*;
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 
+fn t1() -> std::fs::File {
+    std::fs::File::open("").unwrap()
+}
+
 // TODO: t2 and t3 should be translated to *mut dyn Traits
-unsafe fn types() {
-    let t1: std::fs::File = std::fs::File::open("").unwrap();
-    let t2: *mut std::fs::File = libcc2rs::cout_unsafe();
-    let t3: *mut std::fs::File = libcc2rs::cout_unsafe();
+unsafe fn t2() -> *mut std::fs::File {
+    libcc2rs::cout_unsafe()
+}
+
+unsafe fn t3() -> *mut std::fs::File {
+    libcc2rs::cout_unsafe()
 }
 
 unsafe fn f1() -> ::std::fs::File {

--- a/rules/map/tgt_refcount.rs
+++ b/rules/map/tgt_refcount.rs
@@ -6,14 +6,16 @@ use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::rc::Rc;
 
-#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
-struct T1;
-struct T2;
+fn t1<T1, T2>() -> BTreeMap<T1, Value<T2>> {
+    BTreeMap::new()
+}
 
-fn types() {
-    let t1: BTreeMap<T1, Value<T2>> = BTreeMap::new();
-    let t2: RefcountMapIter<T1, T2> = RefcountMapIter::null();
-    let t3: RefcountMapIter<T1, T2> = RefcountMapIter::null();
+fn t2<T1: Clone + Ord + 'static, T2: 'static>() -> RefcountMapIter<T1, T2> {
+    RefcountMapIter::null()
+}
+
+fn t3<T1: Clone + Ord + 'static, T2: 'static>() -> RefcountMapIter<T1, T2> {
+    RefcountMapIter::null()
 }
 
 fn f1<T1: Ord + Clone + ByteRepr + 'static, T2: Default + ByteRepr + 'static>(

--- a/rules/map/tgt_unsafe.rs
+++ b/rules/map/tgt_unsafe.rs
@@ -4,14 +4,16 @@
 use libcc2rs::{MapIterator, UnsafeMapIterator};
 use std::collections::BTreeMap;
 
-#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
-struct T1;
-struct T2;
+fn t1<T1, T2>() -> BTreeMap<T1, Box<T2>> {
+    BTreeMap::new()
+}
 
-fn types() {
-    let t1: BTreeMap<T1, Box<T2>> = BTreeMap::new();
-    let t2: UnsafeMapIterator<T1, T2> = UnsafeMapIterator::null();
-    let t3: UnsafeMapIterator<T1, T2> = UnsafeMapIterator::null();
+fn t2<T1: Clone + Ord, T2>() -> UnsafeMapIterator<T1, T2> {
+    UnsafeMapIterator::null()
+}
+
+fn t3<T1: Clone + Ord, T2>() -> UnsafeMapIterator<T1, T2> {
+    UnsafeMapIterator::null()
 }
 
 unsafe fn f1<T1: Ord + Clone, T2: Default>(a0: &mut BTreeMap<T1, Box<T2>>, a1: T1) -> &mut T2 {

--- a/rules/pair/tgt_refcount.rs
+++ b/rules/pair/tgt_refcount.rs
@@ -5,17 +5,11 @@ use libcc2rs::*;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-#[derive(Default)]
-struct T1;
-
-#[derive(Default)]
-struct T2;
-
-fn types() {
-    let t1: (Value<T1>, Value<T2>) = (
+fn t1<T1: Default, T2: Default>() -> (Value<T1>, Value<T2>) {
+    (
         Rc::new(RefCell::new(T1::default())),
         Rc::new(RefCell::new(T2::default())),
-    );
+    )
 }
 
 fn f1<T1, T2>(a0: (Value<T1>, Value<T2>)) -> Value<T2> {

--- a/rules/pair/tgt_unsafe.rs
+++ b/rules/pair/tgt_unsafe.rs
@@ -1,14 +1,8 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-#[derive(Default)]
-struct T1;
-
-#[derive(Default)]
-struct T2;
-
-fn types() {
-    let t1: (T1, T2) = <(T1, T2)>::default();
+fn t1<T1: Default, T2: Default>() -> (T1, T2) {
+    <(T1, T2)>::default()
 }
 
 unsafe fn f1<T1, T2>(a0: (T1, T2)) -> T2 {

--- a/rules/select/tgt_unsafe.rs
+++ b/rules/select/tgt_unsafe.rs
@@ -1,8 +1,8 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-unsafe fn types() {
-    let t1: ::libc::fd_set = std::mem::zeroed::<::libc::fd_set>();
+unsafe fn t1() -> ::libc::fd_set {
+    std::mem::zeroed::<::libc::fd_set>()
 }
 
 unsafe fn f1(

--- a/rules/stdio/tgt_refcount.rs
+++ b/rules/stdio/tgt_refcount.rs
@@ -5,9 +5,8 @@ use libcc2rs::*;
 use std::io::prelude::*;
 use std::os::fd::AsFd;
 
-fn types() -> Result<(), Box<dyn std::error::Error>> {
-    let t1: Ptr<::std::fs::File> = Ptr::null();
-    Ok(())
+fn t1() -> Ptr<::std::fs::File> {
+    Ptr::null()
 }
 
 fn f1(a0: Ptr<u8>, a1: Ptr<u8>) -> Ptr<::std::fs::File> {

--- a/rules/stdio/tgt_unsafe.rs
+++ b/rules/stdio/tgt_unsafe.rs
@@ -1,9 +1,8 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-fn types() -> Result<(), Box<dyn std::error::Error>> {
-    let t1: *mut ::libc::FILE = std::ptr::null_mut();
-    Ok(())
+fn t1() -> *mut ::libc::FILE {
+    std::ptr::null_mut()
 }
 
 unsafe fn f1(a0: *const u8, a1: *const u8) -> *mut ::libc::FILE {

--- a/rules/string/tgt_refcount.rs
+++ b/rules/string/tgt_refcount.rs
@@ -5,8 +5,8 @@ use libcc2rs::*;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-fn types() {
-    let t2: Ptr<u8> = Ptr::null();
+fn t2() -> Ptr<u8> {
+    Ptr::null()
 }
 
 fn f1(a0: Vec<u8>, a1: usize, a2: usize) -> Vec<u8> {

--- a/rules/string/tgt_unsafe.rs
+++ b/rules/string/tgt_unsafe.rs
@@ -1,9 +1,12 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-fn types() {
-    let t1: Vec<u8> = Vec::new();
-    let t2: *mut u8 = ::std::ptr::null_mut();
+fn t1() -> Vec<u8> {
+    Vec::new()
+}
+
+fn t2() -> *mut u8 {
+    ::std::ptr::null_mut()
 }
 
 unsafe fn f1(a0: Vec<u8>, a1: usize, a2: usize) -> Vec<u8> {

--- a/rules/unique_ptr/tgt_refcount.rs
+++ b/rules/unique_ptr/tgt_refcount.rs
@@ -5,11 +5,12 @@ use libcc2rs::*;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-struct T1;
+fn t1<T1>() -> Option<Value<T1>> {
+    None
+}
 
-fn types() {
-    let t1: Option<Value<T1>> = None;
-    let t2: Option<Value<Box<[T1]>>> = None;
+fn t2<T1>() -> Option<Value<Box<[T1]>>> {
+    None
 }
 
 fn f1<T1: Default>(a0: usize) -> Option<Value<Box<[T1]>>> {
@@ -51,10 +52,10 @@ fn f9<T1>(a0: &mut Option<Value<Box<[T1]>>>) {
     *a0 = None
 }
 
-fn f10() -> Option<Value<T1>> {
+fn f10<T1>() -> Option<Value<T1>> {
     None
 }
 
-fn f11() -> Option<Value<Box<[T1]>>> {
+fn f11<T1>() -> Option<Value<Box<[T1]>>> {
     None
 }

--- a/rules/unique_ptr/tgt_unsafe.rs
+++ b/rules/unique_ptr/tgt_unsafe.rs
@@ -1,12 +1,12 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-#[derive(Default)]
-struct T1;
+fn t1<T1>() -> Option<Box<T1>> {
+    None
+}
 
-fn types() {
-    let t1: Option<Box<T1>> = None;
-    let t2: Option<Box<[T1]>> = None;
+fn t2<T1>() -> Option<Box<[T1]>> {
+    None
 }
 
 unsafe fn f1<T1: Default>(a0: usize) -> Option<Box<[T1]>> {

--- a/rules/vector/tgt_refcount.rs
+++ b/rules/vector/tgt_refcount.rs
@@ -5,12 +5,16 @@ use libcc2rs::*;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-struct T1;
+fn t2<T1>() -> Ptr<T1> {
+    Ptr::null()
+}
 
-fn types() {
-    let t2: Ptr<T1> = Ptr::null();
-    let t3: Vec<Value<Vec<T1>>> = Vec::new();
-    let t4: Ptr<T1> = Ptr::null();
+fn t3<T1>() -> Vec<Value<Vec<T1>>> {
+    Vec::new()
+}
+
+fn t4<T1>() -> Ptr<T1> {
+    Ptr::null()
 }
 
 fn f1<T1: ByteRepr>(a0: Ptr<Vec<T1>>, a1: Ptr<T1>) -> Ptr<T1> {

--- a/rules/vector/tgt_unsafe.rs
+++ b/rules/vector/tgt_unsafe.rs
@@ -3,13 +3,20 @@
 
 use libcc2rs::*;
 
-struct T1;
+fn t1<T1>() -> Vec<T1> {
+    Default::default()
+}
 
-fn types() {
-    let t1: Vec<T1> = Default::default();
-    let t2: *mut T1 = Default::default();
-    let t3: Vec<Vec<T1>> = Vec::new();
-    let t4: *const T1 = Default::default();
+fn t2<T1>() -> *mut T1 {
+    Default::default()
+}
+
+fn t3<T1>() -> Vec<Vec<T1>> {
+    Vec::new()
+}
+
+fn t4<T1>() -> *const T1 {
+    Default::default()
 }
 
 unsafe fn f1<T1>(a0: &mut Vec<T1>, a1: *const T1) -> *const T1 {


### PR DESCRIPTION
Changes the format of the Rust side of type rules to:
```rust
fn t<digit>() -> TYPE {
    return DEFAULT-INITIALIZER;
}
```

Actual changes to rules:

- The initializer for the unsafe rules `t1`, `t2`, and `t3` in `fstream` was changed from `::std::fs::File::open("")?` to `::std::fs::File::open("").unwrap()`. This change was made because the `?` operator requires the function to return a value of type `Result` or `Option`. Additionally, other rules for file-related types already use `::std::fs::File::open("").unwrap()` as an initializer (for example, rule `t1` in `iostream`).

- Added a missing generic parameter to the refcount rules `f10` and `f11` in `unique_ptr`. These rules were relying on the struct defined at the top of the type.