### PR TITLE
Avoid collision between tag and typedef identifier

### DIFF
--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -380,7 +380,7 @@ std::string DisambiguateAnonymousTag(const clang::TagDecl *tag) {
           tag->getLocation())) {
     return "";
   }
-  return typedef_decl->getName().str() + "_" + tag->getKindName().str();
+  return typedef_decl->getName().str() + '_' + tag->getKindName().str();
 }
 
 static std::unordered_map<std::string, size_t> type_mapping;

--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -358,6 +358,31 @@ std::string GetID(const clang::Decl *decl) {
   return GetLocationID(decl) + GetParamSignature(decl);
 }
 
+std::string DisambiguateAnonymousTag(const clang::TagDecl *tag) {
+  if (!tag) {
+    return "";
+  }
+  // C++ does not allow collision between tags and typedef identifiers.
+  if (tag->getASTContext().getLangOpts().CPlusPlus) {
+    return "";
+  }
+  // Tag has an identifier, nothing to disambiguate.
+  if (tag->getIdentifier()) {
+    return "";
+  }
+  // The anonymous decl is named through a typedef; guards getName() below.
+  auto typedef_decl = tag->getTypedefNameForAnonDecl();
+  if (!typedef_decl || !typedef_decl->getDeclName().isIdentifier()) {
+    return "";
+  }
+  // Only disambiguate user-defined types.
+  if (tag->getASTContext().getSourceManager().isInSystemHeader(
+          tag->getLocation())) {
+    return "";
+  }
+  return typedef_decl->getName().str() + "_" + tag->getKindName().str();
+}
+
 static std::unordered_map<std::string, size_t> type_mapping;
 
 static size_t GetDeclId(const clang::NamedDecl *decl, bool internal) {

--- a/cpp2rust/converter/converter_lib.h
+++ b/cpp2rust/converter/converter_lib.h
@@ -89,6 +89,8 @@ std::string GetID(const clang::Decl *decl);
 
 std::string GetNamedDeclAsString(const clang::NamedDecl *decl);
 
+std::string DisambiguateAnonymousTag(const clang::TagDecl *tag);
+
 const char *AccessSpecifierAsString(clang::AccessSpecifier spec);
 
 template <class T> llvm::SmallString<16> GetNumAsString(const T &num) {

--- a/cpp2rust/converter/mapper.cpp
+++ b/cpp2rust/converter/mapper.cpp
@@ -736,6 +736,11 @@ std::string ToString(clang::QualType qual_type) {
     return ToString(clang::cast<clang::NamedDecl>(tag));
   }
 
+  if (auto renamed = DisambiguateAnonymousTag(qual_type->getAsTagDecl());
+      !renamed.empty()) {
+    return renamed;
+  }
+
   std::string type;
   llvm::raw_string_ostream os(type);
   normalizeQualType(qual_type).print(os, getPrintPolicy());
@@ -745,16 +750,23 @@ std::string ToString(clang::QualType qual_type) {
 std::string ToString(const clang::NamedDecl *decl) {
   if (auto *record = clang::dyn_cast<clang::RecordDecl>(decl);
       record && !record->getIdentifier()) {
+    if (auto renamed = DisambiguateAnonymousTag(record); !renamed.empty()) {
+      return renamed;
+    }
     if (auto *typedef_decl = record->getTypedefNameForAnonDecl()) {
       return ToString(clang::cast<clang::NamedDecl>(typedef_decl));
     }
     return GetNamedDeclAsString(record);
   }
 
-  if (auto *enum_decl = clang::dyn_cast<clang::EnumDecl>(decl);
-      enum_decl && !enum_decl->getIdentifier() &&
-      !enum_decl->getTypedefNameForAnonDecl()) {
-    return std::format("anon_enum_{}", GetLineNumber(enum_decl));
+  if (auto *enum_decl = clang::dyn_cast<clang::EnumDecl>(decl)) {
+    if (auto renamed = DisambiguateAnonymousTag(enum_decl); !renamed.empty()) {
+      return renamed;
+    }
+    if (!enum_decl->getIdentifier() &&
+        !enum_decl->getTypedefNameForAnonDecl()) {
+      return std::format("anon_enum_{}", GetLineNumber(enum_decl));
+    }
   }
 
   std::string out;

--- a/tests/multi-file/cross_tu_tag_collision/CMakeLists.txt
+++ b/tests/multi-file/cross_tu_tag_collision/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.16)
+project(cross_tu_tag_collision LANGUAGES C)
+add_executable(app a.c b.c)

--- a/tests/multi-file/cross_tu_tag_collision/a.c
+++ b/tests/multi-file/cross_tu_tag_collision/a.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+
+struct widget {
+  int id;
+};
+
+int b_value(void);
+
+int a_value(void) {
+  struct widget w;
+  w.id = 11;
+  return w.id;
+}
+
+int main(void) {
+  assert(a_value() == 11);
+  assert(b_value() == 2);
+  return 0;
+}

--- a/tests/multi-file/cross_tu_tag_collision/b.c
+++ b/tests/multi-file/cross_tu_tag_collision/b.c
@@ -1,0 +1,6 @@
+typedef enum { WIDGET_A, WIDGET_B, WIDGET_C } widget;
+
+int b_value(void) {
+  widget w = WIDGET_C;
+  return (int)w;
+}

--- a/tests/multi-file/cross_tu_tag_collision/out/refcount/cross_tu_tag_collision.rs
+++ b/tests/multi-file/cross_tu_tag_collision/out/refcount/cross_tu_tag_collision.rs
@@ -1,0 +1,57 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+#[derive(Default)]
+pub struct widget {
+    pub id: Value<i32>,
+}
+impl ByteRepr for widget {
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.id.borrow()).to_bytes(&mut buf[0..4]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            id: Rc::new(RefCell::new(<i32>::from_bytes(&buf[0..4]))),
+        }
+    }
+}
+pub fn a_value_0() -> i32 {
+    let w: Value<widget> = <Value<widget>>::default();
+    (*(*w.borrow()).id.borrow_mut()) = 11;
+    return (*(*w.borrow()).id.borrow());
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!((((({ a_value_0() }) == 11) as i32) != 0));
+    assert!((((({ b_value_1() }) == 2) as i32) != 0));
+    return 0;
+}
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+enum widget_enum {
+    #[default]
+    WIDGET_A = 0,
+    WIDGET_B = 1,
+    WIDGET_C = 2,
+}
+impl From<i32> for widget_enum {
+    fn from(n: i32) -> widget_enum {
+        match n {
+            0 => widget_enum::WIDGET_A,
+            1 => widget_enum::WIDGET_B,
+            2 => widget_enum::WIDGET_C,
+            _ => panic!("invalid widget_enum value: {}", n),
+        }
+    }
+}
+libcc2rs::impl_enum_inc_dec!(widget_enum);
+pub fn b_value_1() -> i32 {
+    let w: Value<widget_enum> = Rc::new(RefCell::new(widget_enum::WIDGET_C));
+    return ((*w.borrow()) as i32).clone();
+}

--- a/tests/multi-file/cross_tu_tag_collision/out/unsafe/cross_tu_tag_collision.rs
+++ b/tests/multi-file/cross_tu_tag_collision/out/unsafe/cross_tu_tag_collision.rs
@@ -1,0 +1,50 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct widget {
+    pub id: i32,
+}
+pub unsafe fn a_value_0() -> i32 {
+    let mut w: widget = <widget>::default();
+    w.id = 11;
+    return w.id;
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(((((unsafe { a_value_0() }) == (11)) as i32) != 0));
+    assert!(((((unsafe { b_value_1() }) == (2)) as i32) != 0));
+    return 0;
+}
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+enum widget_enum {
+    #[default]
+    WIDGET_A = 0,
+    WIDGET_B = 1,
+    WIDGET_C = 2,
+}
+impl From<i32> for widget_enum {
+    fn from(n: i32) -> widget_enum {
+        match n {
+            0 => widget_enum::WIDGET_A,
+            1 => widget_enum::WIDGET_B,
+            2 => widget_enum::WIDGET_C,
+            _ => panic!("invalid widget_enum value: {}", n),
+        }
+    }
+}
+libcc2rs::impl_enum_inc_dec!(widget_enum);
+pub unsafe fn b_value_1() -> i32 {
+    let mut w: widget_enum = widget_enum::WIDGET_C;
+    return (w as i32);
+}

--- a/tests/unit/out/refcount/anonymous_enum_c.rs
+++ b/tests/unit/out/refcount/anonymous_enum_c.rs
@@ -53,21 +53,21 @@ impl ByteRepr for S {
     }
 }
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum TdEnum {
+enum TdEnum_enum {
     #[default]
     TD_A = 0,
     TD_B = 1,
 }
-impl From<i32> for TdEnum {
-    fn from(n: i32) -> TdEnum {
+impl From<i32> for TdEnum_enum {
+    fn from(n: i32) -> TdEnum_enum {
         match n {
-            0 => TdEnum::TD_A,
-            1 => TdEnum::TD_B,
-            _ => panic!("invalid TdEnum value: {}", n),
+            0 => TdEnum_enum::TD_A,
+            1 => TdEnum_enum::TD_B,
+            _ => panic!("invalid TdEnum_enum value: {}", n),
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(TdEnum);
+libcc2rs::impl_enum_inc_dec!(TdEnum_enum);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum anon_enum_24 {
     #[default]
@@ -113,10 +113,10 @@ fn main_0() -> i32 {
     assert!(((((anon_enum_3::FIRST_A as i32) != (anon_enum_3::FIRST_B as i32)) as i32) != 0));
     assert!(((((anon_enum_11::SECOND_A as i32) != (anon_enum_11::SECOND_B as i32)) as i32) != 0));
     assert!(((((anon_enum_31::THIRD_A as i32) != (anon_enum_31::THIRD_B as i32)) as i32) != 0));
-    let td: Value<TdEnum> = Rc::new(RefCell::new(TdEnum::TD_A));
-    assert!((((((*td.borrow()) as u32) == ((TdEnum::TD_A as i32) as u32)) as i32) != 0));
-    (*td.borrow_mut()) = TdEnum::TD_B;
-    assert!((((((*td.borrow()) as u32) == ((TdEnum::TD_B as i32) as u32)) as i32) != 0));
+    let td: Value<TdEnum_enum> = Rc::new(RefCell::new(TdEnum_enum::TD_A));
+    assert!((((((*td.borrow()) as u32) == ((TdEnum_enum::TD_A as i32) as u32)) as i32) != 0));
+    (*td.borrow_mut()) = TdEnum_enum::TD_B;
+    assert!((((((*td.borrow()) as u32) == ((TdEnum_enum::TD_B as i32) as u32)) as i32) != 0));
     let w: Value<WithAnonField> = <Value<WithAnonField>>::default();
     (*(*w.borrow()).field.borrow_mut()) = anon_enum_24::FIELD_A;
     assert!(

--- a/tests/unit/out/refcount/enum_int_interop_c.rs
+++ b/tests/unit/out/refcount/enum_int_interop_c.rs
@@ -45,23 +45,23 @@ impl From<i32> for Option {
 }
 libcc2rs::impl_enum_inc_dec!(Option);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Tag {
+enum Tag_enum {
     #[default]
     TAG_ZERO = 0,
     TAG_ONE = 1,
     TAG_TWO = 2,
 }
-impl From<i32> for Tag {
-    fn from(n: i32) -> Tag {
+impl From<i32> for Tag_enum {
+    fn from(n: i32) -> Tag_enum {
         match n {
-            0 => Tag::TAG_ZERO,
-            1 => Tag::TAG_ONE,
-            2 => Tag::TAG_TWO,
-            _ => panic!("invalid Tag value: {}", n),
+            0 => Tag_enum::TAG_ZERO,
+            1 => Tag_enum::TAG_ONE,
+            2 => Tag_enum::TAG_TWO,
+            _ => panic!("invalid Tag_enum value: {}", n),
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Tag);
+libcc2rs::impl_enum_inc_dec!(Tag_enum);
 #[derive(Default)]
 pub struct Entry {
     pub name: Value<Ptr<u8>>,
@@ -76,7 +76,7 @@ thread_local!(
     pub static global_opt_1: Value<Option> = Rc::new(RefCell::new(Option::OPT_B));
 );
 thread_local!(
-    pub static global_tag_2: Value<Tag> = Rc::new(RefCell::new(Tag::TAG_TWO));
+    pub static global_tag_2: Value<Tag_enum> = Rc::new(RefCell::new(Tag_enum::TAG_TWO));
 );
 thread_local!(
     pub static entries_3: Value<Box<[Entry]>> = Rc::new(RefCell::new(Box::new([
@@ -199,17 +199,17 @@ fn main_0() -> i32 {
         classify_option_5(_option)
     });
     assert!(((((*rc.borrow()) == 3) as i32) != 0));
-    let t: Value<Tag> = Rc::new(RefCell::new(Tag::TAG_ONE));
+    let t: Value<Tag_enum> = Rc::new(RefCell::new(Tag_enum::TAG_ONE));
     assert!((((((*t.borrow()) as u32) == 1_u32) as i32) != 0));
-    assert!((((((*t.borrow()) as u32) == ((Tag::TAG_ONE as i32) as u32)) as i32) != 0));
+    assert!((((((*t.borrow()) as u32) == ((Tag_enum::TAG_ONE as i32) as u32)) as i32) != 0));
     let ti: Value<i32> = Rc::new(RefCell::new(((*t.borrow()) as i32).clone()));
     assert!(((((*ti.borrow()) == 1) as i32) != 0));
-    (*t.borrow_mut()) = Tag::from(2);
-    assert!((((((*t.borrow()) as u32) == ((Tag::TAG_TWO as i32) as u32)) as i32) != 0));
+    (*t.borrow_mut()) = Tag_enum::from(2);
+    assert!((((((*t.borrow()) as u32) == ((Tag_enum::TAG_TWO as i32) as u32)) as i32) != 0));
     'switch: {
         let __match_cond = ((*t.borrow()) as u32);
         match __match_cond {
-            v if v == ((Tag::TAG_ZERO as i32) as u32) => {
+            v if v == ((Tag_enum::TAG_ZERO as i32) as u32) => {
                 return 90;
             }
             v if v == (1 as u32) => {
@@ -236,8 +236,8 @@ fn main_0() -> i32 {
             != 0)
     );
     assert!(
-        (((((*global_tag_2.with(Value::clone).borrow()) as u32) == ((Tag::TAG_TWO as i32) as u32))
-            as i32)
+        (((((*global_tag_2.with(Value::clone).borrow()) as u32)
+            == ((Tag_enum::TAG_TWO as i32) as u32)) as i32)
             != 0)
     );
     assert!(

--- a/tests/unit/out/unsafe/anonymous_enum_c.rs
+++ b/tests/unit/out/unsafe/anonymous_enum_c.rs
@@ -44,21 +44,21 @@ pub struct S {
     pub a: i32,
 }
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum TdEnum {
+enum TdEnum_enum {
     #[default]
     TD_A = 0,
     TD_B = 1,
 }
-impl From<i32> for TdEnum {
-    fn from(n: i32) -> TdEnum {
+impl From<i32> for TdEnum_enum {
+    fn from(n: i32) -> TdEnum_enum {
         match n {
-            0 => TdEnum::TD_A,
-            1 => TdEnum::TD_B,
-            _ => panic!("invalid TdEnum value: {}", n),
+            0 => TdEnum_enum::TD_A,
+            1 => TdEnum_enum::TD_B,
+            _ => panic!("invalid TdEnum_enum value: {}", n),
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(TdEnum);
+libcc2rs::impl_enum_inc_dec!(TdEnum_enum);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum anon_enum_24 {
     #[default]
@@ -106,10 +106,10 @@ unsafe fn main_0() -> i32 {
     assert!(((((anon_enum_3::FIRST_A as i32) != (anon_enum_3::FIRST_B as i32)) as i32) != 0));
     assert!(((((anon_enum_11::SECOND_A as i32) != (anon_enum_11::SECOND_B as i32)) as i32) != 0));
     assert!(((((anon_enum_31::THIRD_A as i32) != (anon_enum_31::THIRD_B as i32)) as i32) != 0));
-    let mut td: TdEnum = TdEnum::TD_A;
-    assert!(((((td as u32) == ((TdEnum::TD_A as i32) as u32)) as i32) != 0));
-    td = (TdEnum::TD_B).clone();
-    assert!(((((td as u32) == ((TdEnum::TD_B as i32) as u32)) as i32) != 0));
+    let mut td: TdEnum_enum = TdEnum_enum::TD_A;
+    assert!(((((td as u32) == ((TdEnum_enum::TD_A as i32) as u32)) as i32) != 0));
+    td = (TdEnum_enum::TD_B).clone();
+    assert!(((((td as u32) == ((TdEnum_enum::TD_B as i32) as u32)) as i32) != 0));
     let mut w: WithAnonField = <WithAnonField>::default();
     w.field = anon_enum_24::FIELD_A;
     assert!(((((w.field as u32) == ((anon_enum_24::FIELD_A as i32) as u32)) as i32) != 0));

--- a/tests/unit/out/unsafe/enum_int_interop_c.rs
+++ b/tests/unit/out/unsafe/enum_int_interop_c.rs
@@ -45,23 +45,23 @@ impl From<i32> for Option {
 }
 libcc2rs::impl_enum_inc_dec!(Option);
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Tag {
+enum Tag_enum {
     #[default]
     TAG_ZERO = 0,
     TAG_ONE = 1,
     TAG_TWO = 2,
 }
-impl From<i32> for Tag {
-    fn from(n: i32) -> Tag {
+impl From<i32> for Tag_enum {
+    fn from(n: i32) -> Tag_enum {
         match n {
-            0 => Tag::TAG_ZERO,
-            1 => Tag::TAG_ONE,
-            2 => Tag::TAG_TWO,
-            _ => panic!("invalid Tag value: {}", n),
+            0 => Tag_enum::TAG_ZERO,
+            1 => Tag_enum::TAG_ONE,
+            2 => Tag_enum::TAG_TWO,
+            _ => panic!("invalid Tag_enum value: {}", n),
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Tag);
+libcc2rs::impl_enum_inc_dec!(Tag_enum);
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Entry {
@@ -71,7 +71,7 @@ pub struct Entry {
 }
 pub static mut global_color_0: Color = unsafe { Color::GREEN };
 pub static mut global_opt_1: Option = unsafe { Option::OPT_B };
-pub static mut global_tag_2: Tag = unsafe { Tag::TAG_TWO };
+pub static mut global_tag_2: Tag_enum = unsafe { Tag_enum::TAG_TWO };
 pub static mut entries_3: [Entry; 3] = unsafe {
     [
         Entry {
@@ -186,17 +186,17 @@ unsafe fn main_0() -> i32 {
         classify_option_5(_option)
     });
     assert!(((((rc) == (3)) as i32) != 0));
-    let mut t: Tag = Tag::TAG_ONE;
+    let mut t: Tag_enum = Tag_enum::TAG_ONE;
     assert!(((((t as u32) == (1_u32)) as i32) != 0));
-    assert!(((((t as u32) == ((Tag::TAG_ONE as i32) as u32)) as i32) != 0));
+    assert!(((((t as u32) == ((Tag_enum::TAG_ONE as i32) as u32)) as i32) != 0));
     let mut ti: i32 = (t as i32);
     assert!(((((ti) == (1)) as i32) != 0));
-    t = Tag::from(2);
-    assert!(((((t as u32) == ((Tag::TAG_TWO as i32) as u32)) as i32) != 0));
+    t = Tag_enum::from(2);
+    assert!(((((t as u32) == ((Tag_enum::TAG_TWO as i32) as u32)) as i32) != 0));
     'switch: {
         let __match_cond = (t as u32);
         match __match_cond {
-            v if v == ((Tag::TAG_ZERO as i32) as u32) => {
+            v if v == ((Tag_enum::TAG_ZERO as i32) as u32) => {
                 return 90;
             }
             v if v == (1 as u32) => {
@@ -212,7 +212,7 @@ unsafe fn main_0() -> i32 {
     assert!(((((extra) == (((0) + (1)) + (2))) as i32) != 0));
     assert!(((((global_color_0 as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0));
     assert!(((((global_opt_1 as u32) == ((Option::OPT_B as i32) as u32)) as i32) != 0));
-    assert!(((((global_tag_2 as u32) == ((Tag::TAG_TWO as i32) as u32)) as i32) != 0));
+    assert!(((((global_tag_2 as u32) == ((Tag_enum::TAG_TWO as i32) as u32)) as i32) != 0));
     assert!(
         ((((entries_3[(0) as usize].color as u32) == ((Color::RED as i32) as u32)) as i32) != 0)
     );

--- a/tests/unit/out/unsafe/tag_vs_identifier_collision.rs
+++ b/tests/unit/out/unsafe/tag_vs_identifier_collision.rs
@@ -1,0 +1,134 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+enum widget_enum {
+    #[default]
+    MODE_IDLE = 0,
+    MODE_ACTIVE = 1,
+    MODE_DONE = 2,
+}
+impl From<i32> for widget_enum {
+    fn from(n: i32) -> widget_enum {
+        match n {
+            0 => widget_enum::MODE_IDLE,
+            1 => widget_enum::MODE_ACTIVE,
+            2 => widget_enum::MODE_DONE,
+            _ => panic!("invalid widget_enum value: {}", n),
+        }
+    }
+}
+libcc2rs::impl_enum_inc_dec!(widget_enum);
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct widget {
+    pub id: i32,
+    pub mode: widget_enum,
+}
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct point_struct {
+    pub x: i32,
+    pub y: i32,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union point {
+    pub whole: i32,
+    pub half: i16,
+}
+impl Default for point {
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union slot_union {
+    pub i: i32,
+    pub u: u32,
+}
+impl Default for slot_union {
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+enum slot {
+    #[default]
+    SLOT_A = 0,
+    SLOT_B = 1,
+}
+impl From<i32> for slot {
+    fn from(n: i32) -> slot {
+        match n {
+            0 => slot::SLOT_A,
+            1 => slot::SLOT_B,
+            _ => panic!("invalid slot value: {}", n),
+        }
+    }
+}
+libcc2rs::impl_enum_inc_dec!(slot);
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct Inner {
+    pub tag_field: i32,
+}
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct Outer {
+    pub field: Inner,
+}
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct Inner_struct {
+    pub typedef_field: i32,
+}
+pub unsafe fn is_active_0(mut w: *mut widget) -> i32 {
+    return ((((*w).mode as u32) == ((widget_enum::MODE_ACTIVE as i32) as u32)) as i32);
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut w: widget = <widget>::default();
+    w.id = 7;
+    w.mode = widget_enum::MODE_ACTIVE;
+    assert!(
+        ((unsafe {
+            let _w: *mut widget = (&mut w as *mut widget);
+            is_active_0(_w)
+        }) != 0)
+    );
+    w.mode = widget_enum::MODE_DONE;
+    assert!(((((w.mode as u32) == ((widget_enum::MODE_DONE as i32) as u32)) as i32) != 0));
+    let mut p: point_struct = <point_struct>::default();
+    p.x = 3;
+    p.y = 4;
+    assert!((((((p.x) + (p.y)) == (7)) as i32) != 0));
+    let mut up: point = <point>::default();
+    up.whole = 5;
+    assert!(((((up.whole) == (5)) as i32) != 0));
+    let mut b: slot_union = <slot_union>::default();
+    b.i = 9;
+    assert!(((((b.i) == (9)) as i32) != 0));
+    let mut e: slot = slot::SLOT_B;
+    assert!(((((e as u32) == ((slot::SLOT_B as i32) as u32)) as i32) != 0));
+    let mut inner_tag: Inner = <Inner>::default();
+    inner_tag.tag_field = 11;
+    assert!(((((inner_tag.tag_field) == (11)) as i32) != 0));
+    let mut inner_typedef: Inner_struct = <Inner_struct>::default();
+    inner_typedef.typedef_field = 22;
+    assert!(((((inner_typedef.typedef_field) == (22)) as i32) != 0));
+    let mut o: Outer = <Outer>::default();
+    o.field.tag_field = 33;
+    assert!(((((o.field.tag_field) == (33)) as i32) != 0));
+    return w.id;
+}

--- a/tests/unit/out/unsafe/union_tagged_many_arms.rs
+++ b/tests/unit/out/unsafe/union_tagged_many_arms.rs
@@ -7,7 +7,7 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Tag {
+enum Tag_enum {
     #[default]
     T_NUM_S = 0,
     T_NUM_U = 1,
@@ -15,19 +15,19 @@ enum Tag {
     T_FLOAT = 3,
     T_REF = 4,
 }
-impl From<i32> for Tag {
-    fn from(n: i32) -> Tag {
+impl From<i32> for Tag_enum {
+    fn from(n: i32) -> Tag_enum {
         match n {
-            0 => Tag::T_NUM_S,
-            1 => Tag::T_NUM_U,
-            2 => Tag::T_TEXT,
-            3 => Tag::T_FLOAT,
-            4 => Tag::T_REF,
-            _ => panic!("invalid Tag value: {}", n),
+            0 => Tag_enum::T_NUM_S,
+            1 => Tag_enum::T_NUM_U,
+            2 => Tag_enum::T_TEXT,
+            3 => Tag_enum::T_FLOAT,
+            4 => Tag_enum::T_REF,
+            _ => panic!("invalid Tag_enum value: {}", n),
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Tag);
+libcc2rs::impl_enum_inc_dec!(Tag_enum);
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union anon_0 {
@@ -45,7 +45,7 @@ impl Default for anon_0 {
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Slot {
-    pub tag: Tag,
+    pub tag: Tag_enum,
     pub payload: anon_0,
 }
 pub fn main() {
@@ -55,24 +55,24 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut a: Slot = <Slot>::default();
-    a.tag = Tag::T_NUM_S;
+    a.tag = Tag_enum::T_NUM_S;
     a.payload.signed_n = (-7_i32 as i64);
     assert!(((((a.payload.signed_n) == (-7_i32 as i64)) as i32) != 0));
     let mut b: Slot = <Slot>::default();
-    b.tag = Tag::T_NUM_U;
+    b.tag = Tag_enum::T_NUM_U;
     b.payload.unsigned_n = 3735928559_u64;
     assert!(((((b.payload.unsigned_n) == (3735928559_u64)) as i32) != 0));
     let mut c: Slot = <Slot>::default();
-    c.tag = Tag::T_TEXT;
+    c.tag = Tag_enum::T_TEXT;
     c.payload.text = (b"hello\0".as_ptr().cast_mut()).cast_const();
     assert!((((((*c.payload.text.offset((0) as isize)) as i32) == ('h' as i32)) as i32) != 0));
     let mut d: Slot = <Slot>::default();
-    d.tag = Tag::T_FLOAT;
+    d.tag = Tag_enum::T_FLOAT;
     d.payload.f = 1.5E+0;
     assert!(((((d.payload.f) == (1.5E+0)) as i32) != 0));
     let mut x: i32 = 0;
     let mut e: Slot = <Slot>::default();
-    e.tag = Tag::T_REF;
+    e.tag = Tag_enum::T_REF;
     e.payload.handle = ((&mut x as *mut i32) as *mut i32 as *mut ::libc::c_void);
     assert!(
         ((((e.payload.handle) == ((&mut x as *mut i32) as *mut i32 as *mut ::libc::c_void))

--- a/tests/unit/out/unsafe/union_tagged_simple.rs
+++ b/tests/unit/out/unsafe/union_tagged_simple.rs
@@ -7,21 +7,21 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Kind {
+enum Kind_enum {
     #[default]
     KIND_NONE = 0,
     KIND_DONE = 1,
 }
-impl From<i32> for Kind {
-    fn from(n: i32) -> Kind {
+impl From<i32> for Kind_enum {
+    fn from(n: i32) -> Kind_enum {
         match n {
-            0 => Kind::KIND_NONE,
-            1 => Kind::KIND_DONE,
-            _ => panic!("invalid Kind value: {}", n),
+            0 => Kind_enum::KIND_NONE,
+            1 => Kind_enum::KIND_DONE,
+            _ => panic!("invalid Kind_enum value: {}", n),
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Kind);
+libcc2rs::impl_enum_inc_dec!(Kind_enum);
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union anon_0 {
@@ -36,7 +36,7 @@ impl Default for anon_0 {
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Event {
-    pub kind: Kind,
+    pub kind: Kind_enum,
     pub handle: *mut ::libc::c_void,
     pub payload: anon_0,
 }
@@ -48,13 +48,13 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut dummy: i32 = 0;
     let mut m1: Event = <Event>::default();
-    m1.kind = Kind::KIND_DONE;
+    m1.kind = Kind_enum::KIND_DONE;
     m1.handle = ((&mut dummy as *mut i32) as *mut i32 as *mut ::libc::c_void);
     m1.payload.code = 42;
-    assert!(((((m1.kind as u32) == ((Kind::KIND_DONE as i32) as u32)) as i32) != 0));
+    assert!(((((m1.kind as u32) == ((Kind_enum::KIND_DONE as i32) as u32)) as i32) != 0));
     assert!(((((m1.payload.code) == (42)) as i32) != 0));
     let mut m2: Event = <Event>::default();
-    m2.kind = Kind::KIND_NONE;
+    m2.kind = Kind_enum::KIND_NONE;
     m2.handle = ((&mut dummy as *mut i32) as *mut i32 as *mut ::libc::c_void);
     m2.payload.obj = ((&mut dummy as *mut i32) as *mut i32 as *mut ::libc::c_void);
     assert!(

--- a/tests/unit/out/unsafe/union_tagged_struct_arms.rs
+++ b/tests/unit/out/unsafe/union_tagged_struct_arms.rs
@@ -7,23 +7,23 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Choice {
+enum Choice_enum {
     #[default]
     C_LIST = 1,
     C_LETTERS = 2,
     C_INTEGERS = 3,
 }
-impl From<i32> for Choice {
-    fn from(n: i32) -> Choice {
+impl From<i32> for Choice_enum {
+    fn from(n: i32) -> Choice_enum {
         match n {
-            1 => Choice::C_LIST,
-            2 => Choice::C_LETTERS,
-            3 => Choice::C_INTEGERS,
-            _ => panic!("invalid Choice value: {}", n),
+            1 => Choice_enum::C_LIST,
+            2 => Choice_enum::C_LETTERS,
+            3 => Choice_enum::C_INTEGERS,
+            _ => panic!("invalid Choice_enum value: {}", n),
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Choice);
+libcc2rs::impl_enum_inc_dec!(Choice_enum);
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct anon_1 {
@@ -63,7 +63,7 @@ impl Default for anon_0 {
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Branch {
-    pub choice: Choice,
+    pub choice: Choice_enum,
     pub index: i32,
     pub v: anon_0,
 }
@@ -81,7 +81,7 @@ unsafe fn main_0() -> i32 {
         ]
     };;
     let mut p_list: Branch = <Branch>::default();
-    p_list.choice = Choice::C_LIST;
+    p_list.choice = Choice_enum::C_LIST;
     p_list.index = 0;
     p_list.v.list.items = items_4.as_mut_ptr();
     p_list.v.list.count = 3_i64;
@@ -93,7 +93,7 @@ unsafe fn main_0() -> i32 {
             != 0)
     );
     let mut p_letters: Branch = <Branch>::default();
-    p_letters.choice = Choice::C_LETTERS;
+    p_letters.choice = Choice_enum::C_LETTERS;
     p_letters.index = 1;
     p_letters.v.letters.lo = ('a' as i32);
     p_letters.v.letters.hi = ('z' as i32);
@@ -101,7 +101,7 @@ unsafe fn main_0() -> i32 {
     p_letters.v.letters.step = 1_u8;
     assert!((((((p_letters.v.letters.hi) - (p_letters.v.letters.lo)) == (25)) as i32) != 0));
     let mut p_integers: Branch = <Branch>::default();
-    p_integers.choice = Choice::C_INTEGERS;
+    p_integers.choice = Choice_enum::C_INTEGERS;
     p_integers.index = 2;
     p_integers.v.integers.lo = 1_i64;
     p_integers.v.integers.hi = 100_i64;

--- a/tests/unit/out/unsafe/union_void_ptr_sized_deref.rs
+++ b/tests/unit/out/unsafe/union_void_ptr_sized_deref.rs
@@ -7,23 +7,23 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Width {
+enum Width_enum {
     #[default]
     W_64 = 0,
     W_32 = 1,
     W_16 = 2,
 }
-impl From<i32> for Width {
-    fn from(n: i32) -> Width {
+impl From<i32> for Width_enum {
+    fn from(n: i32) -> Width_enum {
         match n {
-            0 => Width::W_64,
-            1 => Width::W_32,
-            2 => Width::W_16,
-            _ => panic!("invalid Width value: {}", n),
+            0 => Width_enum::W_64,
+            1 => Width_enum::W_32,
+            2 => Width_enum::W_16,
+            _ => panic!("invalid Width_enum value: {}", n),
         }
     }
 }
-libcc2rs::impl_enum_inc_dec!(Width);
+libcc2rs::impl_enum_inc_dec!(Width_enum);
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union anon_0 {
@@ -40,22 +40,22 @@ impl Default for anon_0 {
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Sink {
-    pub width: Width,
+    pub width: Width_enum,
     pub out: anon_0,
 }
 pub unsafe fn write_count_1(mut s: *mut Sink, mut count: i64) {
     'switch: {
         let __match_cond = ((*s).width as u32);
         match __match_cond {
-            v if v == ((Width::W_64 as i32) as u32) => {
+            v if v == ((Width_enum::W_64 as i32) as u32) => {
                 (*((*s).out.handle as *mut i64)) = count;
                 break 'switch;
             }
-            v if v == ((Width::W_32 as i32) as u32) => {
+            v if v == ((Width_enum::W_32 as i32) as u32) => {
                 (*((*s).out.handle as *mut i32)) = (count as i32);
                 break 'switch;
             }
-            v if v == ((Width::W_16 as i32) as u32) => {
+            v if v == ((Width_enum::W_16 as i32) as u32) => {
                 (*((*s).out.handle as *mut i16)) = (count as i16);
                 break 'switch;
             }
@@ -73,7 +73,7 @@ unsafe fn main_0() -> i32 {
     let mut buf32: i32 = 0;
     let mut buf16: i16 = 0_i16;
     let mut s: Sink = <Sink>::default();
-    s.width = Width::W_64;
+    s.width = Width_enum::W_64;
     s.out.handle = ((&mut buf64 as *mut i64) as *mut i64 as *mut ::libc::c_void);
     (unsafe {
         let _s: *mut Sink = (&mut s as *mut Sink);
@@ -81,7 +81,7 @@ unsafe fn main_0() -> i32 {
         write_count_1(_s, _count)
     });
     assert!(((((buf64) == (1234605616436508552_i64)) as i32) != 0));
-    s.width = Width::W_32;
+    s.width = Width_enum::W_32;
     s.out.handle = ((&mut buf32 as *mut i32) as *mut i32 as *mut ::libc::c_void);
     (unsafe {
         let _s: *mut Sink = (&mut s as *mut Sink);
@@ -89,7 +89,7 @@ unsafe fn main_0() -> i32 {
         write_count_1(_s, _count)
     });
     assert!(((((buf32) == (305419896)) as i32) != 0));
-    s.width = Width::W_16;
+    s.width = Width_enum::W_16;
     s.out.handle = ((&mut buf16 as *mut i16) as *mut i16 as *mut ::libc::c_void);
     (unsafe {
         let _s: *mut Sink = (&mut s as *mut Sink);

--- a/tests/unit/tag_vs_identifier_collision.c
+++ b/tests/unit/tag_vs_identifier_collision.c
@@ -1,0 +1,77 @@
+// no-compile: refcount
+#include <assert.h>
+
+typedef enum { MODE_IDLE, MODE_ACTIVE, MODE_DONE } widget;
+
+struct widget {
+  int id;
+  widget mode;
+};
+
+typedef struct {
+  int x;
+  int y;
+} point;
+
+union point {
+  int whole;
+  short half;
+};
+
+typedef union {
+  int i;
+  unsigned u;
+} slot;
+
+enum slot { SLOT_A, SLOT_B };
+
+struct Outer {
+  struct Inner {
+    int tag_field;
+  } field;
+};
+
+typedef struct {
+  int typedef_field;
+} Inner;
+
+static int is_active(struct widget *w) { return w->mode == MODE_ACTIVE; }
+
+int main(void) {
+  struct widget w;
+  w.id = 7;
+  w.mode = MODE_ACTIVE;
+  assert(is_active(&w));
+  w.mode = MODE_DONE;
+  assert(w.mode == MODE_DONE);
+
+  point p;
+  p.x = 3;
+  p.y = 4;
+  assert(p.x + p.y == 7);
+
+  union point up;
+  up.whole = 5;
+  assert(up.whole == 5);
+
+  slot b;
+  b.i = 9;
+  assert(b.i == 9);
+
+  enum slot e = SLOT_B;
+  assert(e == SLOT_B);
+
+  struct Inner inner_tag;
+  inner_tag.tag_field = 11;
+  assert(inner_tag.tag_field == 11);
+
+  Inner inner_typedef;
+  inner_typedef.typedef_field = 22;
+  assert(inner_typedef.typedef_field == 22);
+
+  struct Outer o;
+  o.field.tag_field = 33;
+  assert(o.field.tag_field == 33);
+
+  return w.id;
+}


### PR DESCRIPTION
C allows name collision between the following 2 declarations:

```c
struct X {};
typedef enum {} X;
```

The 2 declarations live in different name spaces:


6.2.3 Name spaces of identifiers
[...] there are separate namespaces for various categories of identifiers, as follows:
1. the tags of structures, unions, and enumerations (disambiguated by following any) of the keywords struct, union, or enum);
2. all other identifiers, called ordinary identifiers (declared in ordinary declarators or as enumeration constants).

`struct X {}` lives in namespace 1 and `typedef enum {} X` lives in namespace 2. 


We cannot translate both to `X` in the Rust code. We need to disambiguate between the 2 names. I chose to translate them as:

```
struct X {} -> X
typedef enum {} X -> X_enum
```

C++ does not have the name space rule for identifiers. I added the `tag->getASTContext().getLangOpts().CPlusPlus` check in DisambiguateAnonymousTag to avoid polluting the C++ generated files.