### PR TITLE
Wrap variadic arg in paren before calling .into()

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -1487,8 +1487,8 @@ std::optional<std::string> Converter::TryPluginConvert(clang::CallExpr *call) {
 }
 
 void Converter::ConvertVariadicArg(clang::Expr *arg) {
+  PushParen p(*this);
   if (arg->getType()->isFunctionPointerType()) {
-    PushParen p(*this);
     Convert(arg);
     StrCat(".map_or(::std::ptr::null_mut(), |f| f as *mut ::libc::c_void)");
     return;

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -1487,7 +1487,6 @@ std::optional<std::string> Converter::TryPluginConvert(clang::CallExpr *call) {
 }
 
 void Converter::ConvertVariadicArg(clang::Expr *arg) {
-  PushParen p(*this);
   if (arg->getType()->isFunctionPointerType()) {
     Convert(arg);
     StrCat(".map_or(::std::ptr::null_mut(), |f| f as *mut ::libc::c_void)");
@@ -1706,7 +1705,10 @@ void Converter::ConvertGenericCallExpr(clang::CallExpr *expr) {
       StrCat("& [");
       for (unsigned i = num_named_params; i < num_args; ++i) {
         auto *arg = expr->getArg(i + arg_begin);
-        ConvertVariadicArg(arg);
+        {
+          PushParen p(*this);
+          ConvertVariadicArg(arg);
+        }
         StrCat(".into()", token::kComma);
       }
       StrCat(']');

--- a/rules/cstring/tgt_refcount.rs
+++ b/rules/cstring/tgt_refcount.rs
@@ -21,3 +21,7 @@ fn f4(a0: AnyPtr, a1: AnyPtr, a2: usize) -> AnyPtr {
     a0.memcpy(&a1, a2 as usize);
     a0.clone()
 }
+
+unsafe fn f7(a0: Ptr<u8>) -> u64 {
+    a0.to_string_iterator().count() as u64
+}

--- a/tests/unit/out/refcount/va_arg_chain.rs
+++ b/tests/unit/out/refcount/va_arg_chain.rs
@@ -45,21 +45,24 @@ fn main_0() -> i32 {
     assert!(
         (((({
             let _n: i32 = 2;
-            top_level_2(_n, &[100.into(), 200.into(), 300.into(), 400.into()])
+            top_level_2(
+                _n,
+                &[(100).into(), (200).into(), (300).into(), (400).into()],
+            )
         }) == 300) as i32)
             != 0)
     );
     assert!(
         (((({
             let _n: i32 = 0;
-            top_level_2(_n, &[42.into(), 99.into()])
+            top_level_2(_n, &[(42).into(), (99).into()])
         }) == 42) as i32)
             != 0)
     );
     assert!(
         (((({
             let _n: i32 = 3;
-            top_level_2(_n, &[1.into(), 2.into(), 3.into(), 4.into()])
+            top_level_2(_n, &[(1).into(), (2).into(), (3).into(), (4).into()])
         }) == 4) as i32)
             != 0)
     );

--- a/tests/unit/out/refcount/va_arg_concat.rs
+++ b/tests/unit/out/refcount/va_arg_concat.rs
@@ -29,21 +29,24 @@ fn main_0() -> i32 {
     assert!(
         (((({
             let _first: i32 = 1;
-            sum_ints_0(_first, &[2.into(), 3.into(), 4.into(), 0.into()])
+            sum_ints_0(_first, &[(2).into(), (3).into(), (4).into(), (0).into()])
         }) == 10) as i32)
             != 0)
     );
     assert!(
         (((({
             let _first: i32 = 100;
-            sum_ints_0(_first, &[0.into()])
+            sum_ints_0(_first, &[(0).into()])
         }) == 100) as i32)
             != 0)
     );
     assert!(
         (((({
             let _first: i32 = 5;
-            sum_ints_0(_first, &[5.into(), 5.into(), 5.into(), 5.into(), 0.into()])
+            sum_ints_0(
+                _first,
+                &[(5).into(), (5).into(), (5).into(), (5).into(), (0).into()],
+            )
         }) == 25) as i32)
             != 0)
     );

--- a/tests/unit/out/refcount/va_arg_conditional.rs
+++ b/tests/unit/out/refcount/va_arg_conditional.rs
@@ -24,7 +24,7 @@ fn main_0() -> i32 {
     assert!(
         (((({
             let _verbose: i32 = 1;
-            let _fmt: Ptr<u8> = Ptr::from_string_literal("%d");
+            let _fmt: Ptr<u8> = Ptr::from_string_literal(b"%d");
             conditional_log_0(_verbose, _fmt, &[(42).into()])
         }) == 42) as i32)
             != 0)
@@ -32,7 +32,7 @@ fn main_0() -> i32 {
     assert!(
         (((({
             let _verbose: i32 = 0;
-            let _fmt: Ptr<u8> = Ptr::from_string_literal("%d");
+            let _fmt: Ptr<u8> = Ptr::from_string_literal(b"%d");
             conditional_log_0(_verbose, _fmt, &[(99).into()])
         }) == -1_i32) as i32)
             != 0)

--- a/tests/unit/out/refcount/va_arg_conditional.rs
+++ b/tests/unit/out/refcount/va_arg_conditional.rs
@@ -24,16 +24,16 @@ fn main_0() -> i32 {
     assert!(
         (((({
             let _verbose: i32 = 1;
-            let _fmt: Ptr<u8> = Ptr::from_string_literal(b"%d");
-            conditional_log_0(_verbose, _fmt, &[42.into()])
+            let _fmt: Ptr<u8> = Ptr::from_string_literal("%d");
+            conditional_log_0(_verbose, _fmt, &[(42).into()])
         }) == 42) as i32)
             != 0)
     );
     assert!(
         (((({
             let _verbose: i32 = 0;
-            let _fmt: Ptr<u8> = Ptr::from_string_literal(b"%d");
-            conditional_log_0(_verbose, _fmt, &[99.into()])
+            let _fmt: Ptr<u8> = Ptr::from_string_literal("%d");
+            conditional_log_0(_verbose, _fmt, &[(99).into()])
         }) == -1_i32) as i32)
             != 0)
     );

--- a/tests/unit/out/refcount/va_arg_copy.rs
+++ b/tests/unit/out/refcount/va_arg_copy.rs
@@ -34,7 +34,7 @@ fn main_0() -> i32 {
     assert!(
         (((({
             let _count: i32 = 3;
-            sum_with_copy_0(_count, &[10.into(), 20.into(), 30.into()])
+            sum_with_copy_0(_count, &[(10).into(), (20).into(), (30).into()])
         }) == 120) as i32)
             != 0)
     );

--- a/tests/unit/out/refcount/va_arg_fn_ptr.rs
+++ b/tests/unit/out/refcount/va_arg_fn_ptr.rs
@@ -58,14 +58,14 @@ fn main_0() -> i32 {
     assert!(
         (((({
             let _x: i32 = 5;
-            apply_unary_3(_x, &[FnPtr::<fn(i32) -> i32>::new(square_0).into()])
+            apply_unary_3(_x, &[(FnPtr::<fn(i32) -> i32>::new(square_0)).into()])
         }) == 25) as i32)
             != 0)
     );
     assert!(
         (((({
             let _x: i32 = 7;
-            apply_unary_3(_x, &[FnPtr::<fn(i32) -> i32>::new(negate_1).into()])
+            apply_unary_3(_x, &[(FnPtr::<fn(i32) -> i32>::new(negate_1)).into()])
         }) == -7_i32) as i32)
             != 0)
     );
@@ -73,7 +73,7 @@ fn main_0() -> i32 {
         (((({
             let _a: i32 = 3;
             let _b: i32 = 4;
-            apply_binary_4(_a, _b, &[FnPtr::<fn(i32, i32) -> i32>::new(add_2).into()])
+            apply_binary_4(_a, _b, &[(FnPtr::<fn(i32, i32) -> i32>::new(add_2)).into()])
         }) == 7) as i32)
             != 0)
     );

--- a/tests/unit/out/refcount/va_arg_forward.rs
+++ b/tests/unit/out/refcount/va_arg_forward.rs
@@ -37,14 +37,14 @@ fn main_0() -> i32 {
     assert!(
         (((({
             let _count: i32 = 3;
-            outer_1(_count, &[10.into(), 20.into(), 30.into()])
+            outer_1(_count, &[(10).into(), (20).into(), (30).into()])
         }) == 60) as i32)
             != 0)
     );
     assert!(
         (((({
             let _count: i32 = 1;
-            outer_1(_count, &[42.into()])
+            outer_1(_count, &[(42).into()])
         }) == 42) as i32)
             != 0)
     );

--- a/tests/unit/out/refcount/va_arg_mixed_int_ptr.rs
+++ b/tests/unit/out/refcount/va_arg_mixed_int_ptr.rs
@@ -37,12 +37,12 @@ fn main_0() -> i32 {
             mixed_args_0(
                 _count,
                 &[
-                    0.into(),
-                    10.into(),
-                    1.into(),
+                    (0).into(),
+                    (10).into(),
+                    (1).into(),
                     (x.as_pointer()).into(),
-                    0.into(),
-                    20.into(),
+                    (0).into(),
+                    (20).into(),
                 ],
             )
         }) == 130) as i32)
@@ -52,14 +52,14 @@ fn main_0() -> i32 {
     assert!(
         (((({
             let _count: i32 = 1;
-            mixed_args_0(_count, &[1.into(), (y.as_pointer()).into()])
+            mixed_args_0(_count, &[(1).into(), (y.as_pointer()).into()])
         }) == 50) as i32)
             != 0)
     );
     assert!(
         (((({
             let _count: i32 = 2;
-            mixed_args_0(_count, &[0.into(), 5.into(), 0.into(), 3.into()])
+            mixed_args_0(_count, &[(0).into(), (5).into(), (0).into(), (3).into()])
         }) == 8) as i32)
             != 0)
     );

--- a/tests/unit/out/refcount/va_arg_mixed_types.rs
+++ b/tests/unit/out/refcount/va_arg_mixed_types.rs
@@ -36,12 +36,12 @@ fn main_0() -> i32 {
             sum_mixed_0(
                 _count,
                 &[
-                    0.into(),
-                    10.into(),
-                    1.into(),
-                    2.05E+1.into(),
-                    2.into(),
-                    30_i64.into(),
+                    (0).into(),
+                    (10).into(),
+                    (1).into(),
+                    (2.05E+1).into(),
+                    (2).into(),
+                    (30_i64).into(),
                 ],
             )
         }) == 60) as i32)
@@ -50,14 +50,17 @@ fn main_0() -> i32 {
     assert!(
         (((({
             let _count: i32 = 1;
-            sum_mixed_0(_count, &[0.into(), 42.into()])
+            sum_mixed_0(_count, &[(0).into(), (42).into()])
         }) == 42) as i32)
             != 0)
     );
     assert!(
         (((({
             let _count: i32 = 2;
-            sum_mixed_0(_count, &[1.into(), 3.7E+0.into(), 2.into(), 100_i64.into()])
+            sum_mixed_0(
+                _count,
+                &[(1).into(), (3.7E+0).into(), (2).into(), (100_i64).into()],
+            )
         }) == 103) as i32)
             != 0)
     );

--- a/tests/unit/out/refcount/va_arg_non_primitive_ptrs.rs
+++ b/tests/unit/out/refcount/va_arg_non_primitive_ptrs.rs
@@ -40,29 +40,29 @@ pub fn dispatch_0(option: i32, __args: &[VaArg]) -> i32 {
     'switch: {
         let __match_cond = (*option.borrow());
         match __match_cond {
-            v if v == (opt::OPT_STRING_OUT as i32) => {
+            __v if __v == (opt::OPT_STRING_OUT as i32) => {
                 let out: Value<Ptr<Ptr<u8>>> = Rc::new(RefCell::new(
                     ((*ap.borrow_mut()).arg::<Ptr<Ptr<u8>>>()).clone(),
                 ));
-                (*out.borrow()).write(Ptr::from_string_literal("hello"));
+                (*out.borrow()).write(Ptr::from_string_literal(b"hello"));
                 (*result.borrow_mut()) = 1;
                 break 'switch;
             }
-            v if v == (opt::OPT_FILE as i32) => {
+            __v if __v == (opt::OPT_FILE as i32) => {
                 let f: Value<Ptr<::std::fs::File>> = Rc::new(RefCell::new(
                     ((*ap.borrow_mut()).arg::<Ptr<::std::fs::File>>()).clone(),
                 ));
                 (*result.borrow_mut()) = ((!((*f.borrow()).is_null())) as i32).clone();
                 break 'switch;
             }
-            v if v == (opt::OPT_NODE as i32) => {
+            __v if __v == (opt::OPT_NODE as i32) => {
                 let n: Value<Ptr<node>> = Rc::new(RefCell::new(
                     ((*ap.borrow_mut()).arg::<Ptr<node>>()).clone(),
                 ));
                 (*result.borrow_mut()) = (*(*(*n.borrow()).upgrade().deref()).data.borrow());
                 break 'switch;
             }
-            v if v == (opt::OPT_NODE_OUT as i32) => {
+            __v if __v == (opt::OPT_NODE_OUT as i32) => {
                 let out: Value<Ptr<Ptr<node>>> = Rc::new(RefCell::new(
                     ((*ap.borrow_mut()).arg::<Ptr<Ptr<node>>>()).clone(),
                 ));

--- a/tests/unit/out/refcount/va_arg_non_primitive_ptrs.rs
+++ b/tests/unit/out/refcount/va_arg_non_primitive_ptrs.rs
@@ -40,29 +40,29 @@ pub fn dispatch_0(option: i32, __args: &[VaArg]) -> i32 {
     'switch: {
         let __match_cond = (*option.borrow());
         match __match_cond {
-            __v if __v == (opt::OPT_STRING_OUT as i32) => {
+            v if v == (opt::OPT_STRING_OUT as i32) => {
                 let out: Value<Ptr<Ptr<u8>>> = Rc::new(RefCell::new(
                     ((*ap.borrow_mut()).arg::<Ptr<Ptr<u8>>>()).clone(),
                 ));
-                (*out.borrow()).write(Ptr::from_string_literal(b"hello"));
+                (*out.borrow()).write(Ptr::from_string_literal("hello"));
                 (*result.borrow_mut()) = 1;
                 break 'switch;
             }
-            __v if __v == (opt::OPT_FILE as i32) => {
+            v if v == (opt::OPT_FILE as i32) => {
                 let f: Value<Ptr<::std::fs::File>> = Rc::new(RefCell::new(
                     ((*ap.borrow_mut()).arg::<Ptr<::std::fs::File>>()).clone(),
                 ));
                 (*result.borrow_mut()) = ((!((*f.borrow()).is_null())) as i32).clone();
                 break 'switch;
             }
-            __v if __v == (opt::OPT_NODE as i32) => {
+            v if v == (opt::OPT_NODE as i32) => {
                 let n: Value<Ptr<node>> = Rc::new(RefCell::new(
                     ((*ap.borrow_mut()).arg::<Ptr<node>>()).clone(),
                 ));
                 (*result.borrow_mut()) = (*(*(*n.borrow()).upgrade().deref()).data.borrow());
                 break 'switch;
             }
-            __v if __v == (opt::OPT_NODE_OUT as i32) => {
+            v if v == (opt::OPT_NODE_OUT as i32) => {
                 let out: Value<Ptr<Ptr<node>>> = Rc::new(RefCell::new(
                     ((*ap.borrow_mut()).arg::<Ptr<Ptr<node>>>()).clone(),
                 ));
@@ -91,7 +91,7 @@ fn main_0() -> i32 {
     assert!(
         (((({
             let _option: i32 = (opt::OPT_FILE as i32);
-            dispatch_0(_option, &[libcc2rs::cout().into()])
+            dispatch_0(_option, &[(libcc2rs::cout()).into()])
         }) == 1) as i32)
             != 0)
     );
@@ -100,10 +100,10 @@ fn main_0() -> i32 {
             let _option: i32 = (opt::OPT_FILE as i32);
             dispatch_0(
                 _option,
-                &[(AnyPtr::default())
+                &[((AnyPtr::default())
                     .cast::<::std::fs::File>()
-                    .expect("ub:wrong type")
-                    .into()],
+                    .expect("ub:wrong type"))
+                .into()],
             )
         }) == 0) as i32)
             != 0)

--- a/tests/unit/out/refcount/va_arg_printf.rs
+++ b/tests/unit/out/refcount/va_arg_printf.rs
@@ -32,17 +32,24 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
+    let dummy: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal("dummy")));
     assert!(
         (((({
-            let _fmt: Ptr<u8> = Ptr::from_string_literal(b"hello %d %d");
-            logf_1(_fmt, &[10.into(), 32.into()])
-        }) == 42) as i32)
+            let _fmt: Ptr<u8> = Ptr::from_string_literal("hello %d %d");
+            logf_1(
+                _fmt,
+                &[
+                    (10).into(),
+                    ((*dummy.borrow()).to_string_iterator().count() as u64).into(),
+                ],
+            )
+        }) == 15) as i32)
             != 0)
     );
     assert!(
         (((({
-            let _fmt: Ptr<u8> = Ptr::from_string_literal(b"x %d %d");
-            logf_1(_fmt, &[1.into(), 2.into()])
+            let _fmt: Ptr<u8> = Ptr::from_string_literal("x %d %d");
+            logf_1(_fmt, &[(1).into(), (2).into()])
         }) == 3) as i32)
             != 0)
     );

--- a/tests/unit/out/refcount/va_arg_printf.rs
+++ b/tests/unit/out/refcount/va_arg_printf.rs
@@ -32,10 +32,10 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    let dummy: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal("dummy")));
+    let dummy: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal(b"dummy")));
     assert!(
         (((({
-            let _fmt: Ptr<u8> = Ptr::from_string_literal("hello %d %d");
+            let _fmt: Ptr<u8> = Ptr::from_string_literal(b"hello %d %d");
             logf_1(
                 _fmt,
                 &[
@@ -48,7 +48,7 @@ fn main_0() -> i32 {
     );
     assert!(
         (((({
-            let _fmt: Ptr<u8> = Ptr::from_string_literal("x %d %d");
+            let _fmt: Ptr<u8> = Ptr::from_string_literal(b"x %d %d");
             logf_1(_fmt, &[(1).into(), (2).into()])
         }) == 3) as i32)
             != 0)

--- a/tests/unit/out/refcount/va_arg_snprintf.rs
+++ b/tests/unit/out/refcount/va_arg_snprintf.rs
@@ -28,8 +28,8 @@ fn main_0() -> i32 {
         (((({
             let _buf: Ptr<u8> = (buf.as_pointer() as Ptr<u8>);
             let _size: i32 = 1;
-            let _fmt: Ptr<u8> = Ptr::from_string_literal(b"%d");
-            extract_first_0(_buf, _size, _fmt, &[42.into()])
+            let _fmt: Ptr<u8> = Ptr::from_string_literal("%d");
+            extract_first_0(_buf, _size, _fmt, &[(42).into()])
         }) == 42) as i32)
             != 0)
     );
@@ -38,8 +38,8 @@ fn main_0() -> i32 {
         (((({
             let _buf: Ptr<u8> = (buf.as_pointer() as Ptr<u8>);
             let _size: i32 = 1;
-            let _fmt: Ptr<u8> = Ptr::from_string_literal(b"%d");
-            extract_first_0(_buf, _size, _fmt, &[65.into()])
+            let _fmt: Ptr<u8> = Ptr::from_string_literal("%d");
+            extract_first_0(_buf, _size, _fmt, &[(65).into()])
         }) == 65) as i32)
             != 0)
     );

--- a/tests/unit/out/refcount/va_arg_snprintf.rs
+++ b/tests/unit/out/refcount/va_arg_snprintf.rs
@@ -28,7 +28,7 @@ fn main_0() -> i32 {
         (((({
             let _buf: Ptr<u8> = (buf.as_pointer() as Ptr<u8>);
             let _size: i32 = 1;
-            let _fmt: Ptr<u8> = Ptr::from_string_literal("%d");
+            let _fmt: Ptr<u8> = Ptr::from_string_literal(b"%d");
             extract_first_0(_buf, _size, _fmt, &[(42).into()])
         }) == 42) as i32)
             != 0)
@@ -38,7 +38,7 @@ fn main_0() -> i32 {
         (((({
             let _buf: Ptr<u8> = (buf.as_pointer() as Ptr<u8>);
             let _size: i32 = 1;
-            let _fmt: Ptr<u8> = Ptr::from_string_literal("%d");
+            let _fmt: Ptr<u8> = Ptr::from_string_literal(b"%d");
             extract_first_0(_buf, _size, _fmt, &[(65).into()])
         }) == 65) as i32)
             != 0)

--- a/tests/unit/out/refcount/va_arg_struct_ctx.rs
+++ b/tests/unit/out/refcount/va_arg_struct_ctx.rs
@@ -42,14 +42,14 @@ fn main_0() -> i32 {
     (*(*ctx.borrow()).last_error.borrow_mut()) = 0;
     ({
         let _ctx: Ptr<context> = (ctx.as_pointer());
-        let _fmt: Ptr<u8> = Ptr::from_string_literal("error %d");
+        let _fmt: Ptr<u8> = Ptr::from_string_literal(b"error %d");
         set_error_0(_ctx, _fmt, &[(42).into()])
     });
     assert!(((((*(*ctx.borrow()).last_error.borrow()) == 42) as i32) != 0));
     (*(*ctx.borrow()).verbose.borrow_mut()) = 0;
     ({
         let _ctx: Ptr<context> = (ctx.as_pointer());
-        let _fmt: Ptr<u8> = Ptr::from_string_literal("error %d");
+        let _fmt: Ptr<u8> = Ptr::from_string_literal(b"error %d");
         set_error_0(_ctx, _fmt, &[(99).into()])
     });
     assert!(((((*(*ctx.borrow()).last_error.borrow()) == 42) as i32) != 0));

--- a/tests/unit/out/refcount/va_arg_struct_ctx.rs
+++ b/tests/unit/out/refcount/va_arg_struct_ctx.rs
@@ -42,15 +42,15 @@ fn main_0() -> i32 {
     (*(*ctx.borrow()).last_error.borrow_mut()) = 0;
     ({
         let _ctx: Ptr<context> = (ctx.as_pointer());
-        let _fmt: Ptr<u8> = Ptr::from_string_literal(b"error %d");
-        set_error_0(_ctx, _fmt, &[42.into()])
+        let _fmt: Ptr<u8> = Ptr::from_string_literal("error %d");
+        set_error_0(_ctx, _fmt, &[(42).into()])
     });
     assert!(((((*(*ctx.borrow()).last_error.borrow()) == 42) as i32) != 0));
     (*(*ctx.borrow()).verbose.borrow_mut()) = 0;
     ({
         let _ctx: Ptr<context> = (ctx.as_pointer());
-        let _fmt: Ptr<u8> = Ptr::from_string_literal(b"error %d");
-        set_error_0(_ctx, _fmt, &[99.into()])
+        let _fmt: Ptr<u8> = Ptr::from_string_literal("error %d");
+        set_error_0(_ctx, _fmt, &[(99).into()])
     });
     assert!(((((*(*ctx.borrow()).last_error.borrow()) == 42) as i32) != 0));
     return 0;

--- a/tests/unit/out/refcount/va_arg_two_passes.rs
+++ b/tests/unit/out/refcount/va_arg_two_passes.rs
@@ -39,7 +39,7 @@ fn main_0() -> i32 {
     assert!(
         (((({
             let _first: i32 = 2;
-            sum_then_product_0(_first, &[3.into(), 4.into(), 0.into()])
+            sum_then_product_0(_first, &[(3).into(), (4).into(), (0).into()])
         }) == 33) as i32)
             != 0)
     );

--- a/tests/unit/out/unsafe/va_arg_chain.rs
+++ b/tests/unit/out/unsafe/va_arg_chain.rs
@@ -40,21 +40,24 @@ unsafe fn main_0() -> i32 {
     assert!(
         ((((unsafe {
             let _n: i32 = 2;
-            top_level_2(_n, &[100.into(), 200.into(), 300.into(), 400.into()])
+            top_level_2(
+                _n,
+                &[(100).into(), (200).into(), (300).into(), (400).into()],
+            )
         }) == (300)) as i32)
             != 0)
     );
     assert!(
         ((((unsafe {
             let _n: i32 = 0;
-            top_level_2(_n, &[42.into(), 99.into()])
+            top_level_2(_n, &[(42).into(), (99).into()])
         }) == (42)) as i32)
             != 0)
     );
     assert!(
         ((((unsafe {
             let _n: i32 = 3;
-            top_level_2(_n, &[1.into(), 2.into(), 3.into(), 4.into()])
+            top_level_2(_n, &[(1).into(), (2).into(), (3).into(), (4).into()])
         }) == (4)) as i32)
             != 0)
     );

--- a/tests/unit/out/unsafe/va_arg_concat.rs
+++ b/tests/unit/out/unsafe/va_arg_concat.rs
@@ -30,21 +30,24 @@ unsafe fn main_0() -> i32 {
     assert!(
         ((((unsafe {
             let _first: i32 = 1;
-            sum_ints_0(_first, &[2.into(), 3.into(), 4.into(), 0.into()])
+            sum_ints_0(_first, &[(2).into(), (3).into(), (4).into(), (0).into()])
         }) == (10)) as i32)
             != 0)
     );
     assert!(
         ((((unsafe {
             let _first: i32 = 100;
-            sum_ints_0(_first, &[0.into()])
+            sum_ints_0(_first, &[(0).into()])
         }) == (100)) as i32)
             != 0)
     );
     assert!(
         ((((unsafe {
             let _first: i32 = 5;
-            sum_ints_0(_first, &[5.into(), 5.into(), 5.into(), 5.into(), 0.into()])
+            sum_ints_0(
+                _first,
+                &[(5).into(), (5).into(), (5).into(), (5).into(), (0).into()],
+            )
         }) == (25)) as i32)
             != 0)
     );

--- a/tests/unit/out/unsafe/va_arg_conditional.rs
+++ b/tests/unit/out/unsafe/va_arg_conditional.rs
@@ -25,7 +25,7 @@ unsafe fn main_0() -> i32 {
         ((((unsafe {
             let _verbose: i32 = 1;
             let _fmt: *const u8 = (b"%d\0".as_ptr().cast_mut()).cast_const();
-            conditional_log_0(_verbose, _fmt, &[42.into()])
+            conditional_log_0(_verbose, _fmt, &[(42).into()])
         }) == (42)) as i32)
             != 0)
     );
@@ -33,7 +33,7 @@ unsafe fn main_0() -> i32 {
         ((((unsafe {
             let _verbose: i32 = 0;
             let _fmt: *const u8 = (b"%d\0".as_ptr().cast_mut()).cast_const();
-            conditional_log_0(_verbose, _fmt, &[99.into()])
+            conditional_log_0(_verbose, _fmt, &[(99).into()])
         }) == (-1_i32)) as i32)
             != 0)
     );

--- a/tests/unit/out/unsafe/va_arg_copy.rs
+++ b/tests/unit/out/unsafe/va_arg_copy.rs
@@ -35,7 +35,7 @@ unsafe fn main_0() -> i32 {
     assert!(
         ((((unsafe {
             let _count: i32 = 3;
-            sum_with_copy_0(_count, &[10.into(), 20.into(), 30.into()])
+            sum_with_copy_0(_count, &[(10).into(), (20).into(), (30).into()])
         }) == (120)) as i32)
             != 0)
     );

--- a/tests/unit/out/unsafe/va_arg_forward.rs
+++ b/tests/unit/out/unsafe/va_arg_forward.rs
@@ -34,14 +34,14 @@ unsafe fn main_0() -> i32 {
     assert!(
         ((((unsafe {
             let _count: i32 = 3;
-            outer_1(_count, &[10.into(), 20.into(), 30.into()])
+            outer_1(_count, &[(10).into(), (20).into(), (30).into()])
         }) == (60)) as i32)
             != 0)
     );
     assert!(
         ((((unsafe {
             let _count: i32 = 1;
-            outer_1(_count, &[42.into()])
+            outer_1(_count, &[(42).into()])
         }) == (42)) as i32)
             != 0)
     );

--- a/tests/unit/out/unsafe/va_arg_mixed_int_ptr.rs
+++ b/tests/unit/out/unsafe/va_arg_mixed_int_ptr.rs
@@ -36,12 +36,12 @@ unsafe fn main_0() -> i32 {
             mixed_args_0(
                 _count,
                 &[
-                    0.into(),
-                    10.into(),
-                    1.into(),
+                    (0).into(),
+                    (10).into(),
+                    (1).into(),
                     (&mut x as *mut i32).into(),
-                    0.into(),
-                    20.into(),
+                    (0).into(),
+                    (20).into(),
                 ],
             )
         }) == (130)) as i32)
@@ -51,14 +51,14 @@ unsafe fn main_0() -> i32 {
     assert!(
         ((((unsafe {
             let _count: i32 = 1;
-            mixed_args_0(_count, &[1.into(), (&mut y as *mut i32).into()])
+            mixed_args_0(_count, &[(1).into(), (&mut y as *mut i32).into()])
         }) == (50)) as i32)
             != 0)
     );
     assert!(
         ((((unsafe {
             let _count: i32 = 2;
-            mixed_args_0(_count, &[0.into(), 5.into(), 0.into(), 3.into()])
+            mixed_args_0(_count, &[(0).into(), (5).into(), (0).into(), (3).into()])
         }) == (8)) as i32)
             != 0)
     );

--- a/tests/unit/out/unsafe/va_arg_mixed_types.rs
+++ b/tests/unit/out/unsafe/va_arg_mixed_types.rs
@@ -37,12 +37,12 @@ unsafe fn main_0() -> i32 {
             sum_mixed_0(
                 _count,
                 &[
-                    0.into(),
-                    10.into(),
-                    1.into(),
-                    2.05E+1.into(),
-                    2.into(),
-                    30_i64.into(),
+                    (0).into(),
+                    (10).into(),
+                    (1).into(),
+                    (2.05E+1).into(),
+                    (2).into(),
+                    (30_i64).into(),
                 ],
             )
         }) == (60)) as i32)
@@ -51,14 +51,17 @@ unsafe fn main_0() -> i32 {
     assert!(
         ((((unsafe {
             let _count: i32 = 1;
-            sum_mixed_0(_count, &[0.into(), 42.into()])
+            sum_mixed_0(_count, &[(0).into(), (42).into()])
         }) == (42)) as i32)
             != 0)
     );
     assert!(
         ((((unsafe {
             let _count: i32 = 2;
-            sum_mixed_0(_count, &[1.into(), 3.7E+0.into(), 2.into(), 100_i64.into()])
+            sum_mixed_0(
+                _count,
+                &[(1).into(), (3.7E+0).into(), (2).into(), (100_i64).into()],
+            )
         }) == (103)) as i32)
             != 0)
     );

--- a/tests/unit/out/unsafe/va_arg_non_primitive_ptrs.rs
+++ b/tests/unit/out/unsafe/va_arg_non_primitive_ptrs.rs
@@ -39,23 +39,23 @@ pub unsafe fn dispatch_0(mut option: i32, __args: &[VaArg]) -> i32 {
     'switch: {
         let __match_cond = option;
         match __match_cond {
-            v if v == (opt::OPT_STRING_OUT as i32) => {
+            __v if __v == (opt::OPT_STRING_OUT as i32) => {
                 let mut out: *mut *const u8 = ap.arg::<*mut *const u8>();
                 (*out) = (b"hello\0".as_ptr().cast_mut()).cast_const();
                 result = 1;
                 break 'switch;
             }
-            v if v == (opt::OPT_FILE as i32) => {
+            __v if __v == (opt::OPT_FILE as i32) => {
                 let mut f: *mut ::libc::FILE = ap.arg::<*mut ::libc::FILE>();
                 result = ((!((f).is_null())) as i32).clone();
                 break 'switch;
             }
-            v if v == (opt::OPT_NODE as i32) => {
+            __v if __v == (opt::OPT_NODE as i32) => {
                 let mut n: *mut node = ap.arg::<*mut node>();
                 result = (*n).data;
                 break 'switch;
             }
-            v if v == (opt::OPT_NODE_OUT as i32) => {
+            __v if __v == (opt::OPT_NODE_OUT as i32) => {
                 let mut out: *mut *mut node = ap.arg::<*mut *mut node>();
                 (*out) = std::ptr::null_mut();
                 result = 2;

--- a/tests/unit/out/unsafe/va_arg_non_primitive_ptrs.rs
+++ b/tests/unit/out/unsafe/va_arg_non_primitive_ptrs.rs
@@ -39,23 +39,23 @@ pub unsafe fn dispatch_0(mut option: i32, __args: &[VaArg]) -> i32 {
     'switch: {
         let __match_cond = option;
         match __match_cond {
-            __v if __v == (opt::OPT_STRING_OUT as i32) => {
+            v if v == (opt::OPT_STRING_OUT as i32) => {
                 let mut out: *mut *const u8 = ap.arg::<*mut *const u8>();
                 (*out) = (b"hello\0".as_ptr().cast_mut()).cast_const();
                 result = 1;
                 break 'switch;
             }
-            __v if __v == (opt::OPT_FILE as i32) => {
+            v if v == (opt::OPT_FILE as i32) => {
                 let mut f: *mut ::libc::FILE = ap.arg::<*mut ::libc::FILE>();
                 result = ((!((f).is_null())) as i32).clone();
                 break 'switch;
             }
-            __v if __v == (opt::OPT_NODE as i32) => {
+            v if v == (opt::OPT_NODE as i32) => {
                 let mut n: *mut node = ap.arg::<*mut node>();
                 result = (*n).data;
                 break 'switch;
             }
-            __v if __v == (opt::OPT_NODE_OUT as i32) => {
+            v if v == (opt::OPT_NODE_OUT as i32) => {
                 let mut out: *mut *mut node = ap.arg::<*mut *mut node>();
                 (*out) = std::ptr::null_mut();
                 result = 2;
@@ -84,7 +84,7 @@ unsafe fn main_0() -> i32 {
     assert!(
         ((((unsafe {
             let _option: i32 = (opt::OPT_FILE as i32);
-            dispatch_0(_option, &[libcc2rs::stdout_unsafe().into()])
+            dispatch_0(_option, &[(libcc2rs::stdout_unsafe()).into()])
         }) == (1)) as i32)
             != 0)
     );

--- a/tests/unit/out/unsafe/va_arg_printf.rs
+++ b/tests/unit/out/unsafe/va_arg_printf.rs
@@ -26,17 +26,24 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
+    let mut dummy: *const u8 = (b"dummy\0".as_ptr().cast_mut()).cast_const();
     assert!(
         ((((unsafe {
             let _fmt: *const u8 = (b"hello %d %d\0".as_ptr().cast_mut()).cast_const();
-            logf_1(_fmt, &[10.into(), 32.into()])
-        }) == (42)) as i32)
+            logf_1(
+                _fmt,
+                &[
+                    (10).into(),
+                    (libc::strlen(dummy as *const i8) as u64).into(),
+                ],
+            )
+        }) == (15)) as i32)
             != 0)
     );
     assert!(
         ((((unsafe {
             let _fmt: *const u8 = (b"x %d %d\0".as_ptr().cast_mut()).cast_const();
-            logf_1(_fmt, &[1.into(), 2.into()])
+            logf_1(_fmt, &[(1).into(), (2).into()])
         }) == (3)) as i32)
             != 0)
     );

--- a/tests/unit/out/unsafe/va_arg_snprintf.rs
+++ b/tests/unit/out/unsafe/va_arg_snprintf.rs
@@ -30,7 +30,7 @@ unsafe fn main_0() -> i32 {
             let _buf: *mut u8 = buf.as_mut_ptr();
             let _size: i32 = 1;
             let _fmt: *const u8 = (b"%d\0".as_ptr().cast_mut()).cast_const();
-            extract_first_0(_buf, _size, _fmt, &[42.into()])
+            extract_first_0(_buf, _size, _fmt, &[(42).into()])
         }) == (42)) as i32)
             != 0)
     );
@@ -40,7 +40,7 @@ unsafe fn main_0() -> i32 {
             let _buf: *mut u8 = buf.as_mut_ptr();
             let _size: i32 = 1;
             let _fmt: *const u8 = (b"%d\0".as_ptr().cast_mut()).cast_const();
-            extract_first_0(_buf, _size, _fmt, &[65.into()])
+            extract_first_0(_buf, _size, _fmt, &[(65).into()])
         }) == (65)) as i32)
             != 0)
     );

--- a/tests/unit/out/unsafe/va_arg_struct_ctx.rs
+++ b/tests/unit/out/unsafe/va_arg_struct_ctx.rs
@@ -31,14 +31,14 @@ unsafe fn main_0() -> i32 {
     (unsafe {
         let _ctx: *mut context = (&mut ctx as *mut context);
         let _fmt: *const u8 = (b"error %d\0".as_ptr().cast_mut()).cast_const();
-        set_error_0(_ctx, _fmt, &[42.into()])
+        set_error_0(_ctx, _fmt, &[(42).into()])
     });
     assert!(((((ctx.last_error) == (42)) as i32) != 0));
     ctx.verbose = 0;
     (unsafe {
         let _ctx: *mut context = (&mut ctx as *mut context);
         let _fmt: *const u8 = (b"error %d\0".as_ptr().cast_mut()).cast_const();
-        set_error_0(_ctx, _fmt, &[99.into()])
+        set_error_0(_ctx, _fmt, &[(99).into()])
     });
     assert!(((((ctx.last_error) == (42)) as i32) != 0));
     return 0;

--- a/tests/unit/out/unsafe/va_arg_two_passes.rs
+++ b/tests/unit/out/unsafe/va_arg_two_passes.rs
@@ -40,7 +40,7 @@ unsafe fn main_0() -> i32 {
     assert!(
         ((((unsafe {
             let _first: i32 = 2;
-            sum_then_product_0(_first, &[3.into(), 4.into(), 0.into()])
+            sum_then_product_0(_first, &[(3).into(), (4).into(), (0).into()])
         }) == (33)) as i32)
             != 0)
     );

--- a/tests/unit/va_arg_printf.c
+++ b/tests/unit/va_arg_printf.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <stdarg.h>
+#include <string.h>
 
 int logf_impl(const char *fmt, va_list ap) {
   (void)fmt;
@@ -15,7 +16,8 @@ int logf(const char *fmt, ...) {
 }
 
 int main() {
-  assert(logf("hello %d %d", 10, 32) == 42);
+  const char *dummy = "dummy";
+  assert(logf("hello %d %d", 10, strlen(dummy)) == 15);
   assert(logf("x %d %d", 1, 2) == 3);
   return 0;
 }


### PR DESCRIPTION
`libc::strlen(dummy as *const i8) as u64.into()` (without paren) errors because we can't write `as u64.into()`, we need to wrap the entire arg in a paren before calling .into(): `(libc::strlen(dummy as *const i8) as u64).into()`