### PR TITLE
Handle char array initialization through `{ string literal }`

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -2758,12 +2758,8 @@ bool Converter::VisitInitListExpr(clang::InitListExpr *expr) {
       StrCat(token::kComma);
     }
   } else {
-    if (expr->getNumInits() == 1 && qual_type->isArrayType() &&
-        qual_type->getArrayElementTypeNoTypeQual()->isCharType() &&
-        clang::isa<clang::StringLiteral>(
-            expr->getInit(0)->IgnoreParenImpCasts())) {
-      auto *init = expr->getInit(0);
-      ConvertVarInit(init->getType(), init);
+    if (IsInitExprOfStringLiteral(expr)) {
+      Convert(expr->getInit(0)->IgnoreParenImpCasts());
       return false;
     }
     PushBracket bracket(*this);

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -2758,6 +2758,14 @@ bool Converter::VisitInitListExpr(clang::InitListExpr *expr) {
       StrCat(token::kComma);
     }
   } else {
+    if (expr->getNumInits() == 1 && qual_type->isArrayType() &&
+        qual_type->getArrayElementTypeNoTypeQual()->isCharType() &&
+        clang::isa<clang::StringLiteral>(
+            expr->getInit(0)->IgnoreParenImpCasts())) {
+      auto *init = expr->getInit(0);
+      ConvertVarInit(init->getType(), init);
+      return false;
+    }
     PushBracket bracket(*this);
     for (auto *init : expr->inits()) {
       ConvertVarInit(init->getType(), init);

--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -255,6 +255,14 @@ bool IsAsciiStringLiteral(const clang::StringLiteral *str) {
   return true;
 }
 
+bool IsInitExprOfStringLiteral(const clang::InitListExpr *expr) {
+  auto type = expr->getType();
+  return expr->getNumInits() == 1 && type->isArrayType() &&
+         type->getArrayElementTypeNoTypeQual()->isCharType() &&
+         clang::isa<clang::StringLiteral>(
+             expr->getInit(0)->IgnoreParenImpCasts());
+}
+
 std::vector<clang::CXXConstructorDecl *>
 GetTemplateInstantiatedCtors(clang::CXXRecordDecl *decl) {
   std::vector<clang::CXXConstructorDecl *> out;

--- a/cpp2rust/converter/converter_lib.h
+++ b/cpp2rust/converter/converter_lib.h
@@ -67,6 +67,8 @@ bool IsCallToOstream(clang::CallExpr *expr);
 
 bool IsAsciiStringLiteral(const clang::StringLiteral *str);
 
+bool IsInitExprOfStringLiteral(const clang::InitListExpr *expr);
+
 std::vector<clang::CXXConstructorDecl *>
 GetTemplateInstantiatedCtors(clang::CXXRecordDecl *decl);
 

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -1397,6 +1397,12 @@ bool ConverterRefCount::VisitInitListExpr(clang::InitListExpr *expr) {
     return false;
   }
 
+  if (IsInitExprOfStringLiteral(expr)) {
+    Convert(expr->getInit(0)->IgnoreParenImpCasts());
+    computed_expr_type_ = ComputedExprType::FreshValue;
+    return false;
+  }
+
   auto conv = getConversionKind();
   // 2D arrays are FullRefCount'ed on the second level as well.
   PushConversionKind push(

--- a/tests/unit/out/refcount/string_literals.rs
+++ b/tests/unit/out/refcount/string_literals.rs
@@ -60,5 +60,12 @@ fn main_0() -> i32 {
         let _str: Ptr<u8> = (immutable_empty_arr.as_pointer() as Ptr<u8>);
         foo_const_1(_str)
     });
+    let inited_through_init_list: Value<Box<[u8]>> = Rc::new(RefCell::new(Box::<[u8]>::from(
+        b"papanasi cu smantana\0".as_slice(),
+    )));
+    ({
+        let _str: Ptr<u8> = (inited_through_init_list.as_pointer() as Ptr<u8>);
+        foo_const_1(_str)
+    });
     return 0;
 }

--- a/tests/unit/out/refcount/string_literals_c.rs
+++ b/tests/unit/out/refcount/string_literals_c.rs
@@ -91,5 +91,12 @@ fn main_0() -> i32 {
         let _str: Ptr<u8> = (immutable_empty_arr.as_pointer() as Ptr<u8>);
         foo_const_1(_str)
     });
+    let inited_through_init_list: Value<Box<[u8]>> = Rc::new(RefCell::new(Box::<[u8]>::from(
+        b"papanasi cu smantana\0".as_slice(),
+    )));
+    ({
+        let _str: Ptr<u8> = (inited_through_init_list.as_pointer() as Ptr<u8>);
+        foo_const_1(_str)
+    });
     return 0;
 }

--- a/tests/unit/out/unsafe/string_literals.rs
+++ b/tests/unit/out/unsafe/string_literals.rs
@@ -49,5 +49,10 @@ unsafe fn main_0() -> i32 {
         let _str: *const u8 = immutable_empty_arr.as_ptr();
         foo_const_1(_str)
     });
+    let inited_through_init_list: [u8; 21] = *b"papanasi cu smantana\0";
+    (unsafe {
+        let _str: *const u8 = inited_through_init_list.as_ptr();
+        foo_const_1(_str)
+    });
     return 0;
 }

--- a/tests/unit/out/unsafe/string_literals_c.rs
+++ b/tests/unit/out/unsafe/string_literals_c.rs
@@ -84,5 +84,10 @@ unsafe fn main_0() -> i32 {
         let _str: *const u8 = immutable_empty_arr.as_ptr();
         foo_const_1(_str)
     });
+    let inited_through_init_list: [u8; 21] = *b"papanasi cu smantana\0";
+    (unsafe {
+        let _str: *const u8 = inited_through_init_list.as_ptr();
+        foo_const_1(_str)
+    });
     return 0;
 }

--- a/tests/unit/string_literals.cpp
+++ b/tests/unit/string_literals.cpp
@@ -23,7 +23,7 @@ int main() {
   foo_const(immutable_empty);
   foo_const(immutable_empty_arr);
 
-  const char inited_through_init_list[] = { "papanasi cu smantana" };
+  const char inited_through_init_list[] = {"papanasi cu smantana"};
   foo_const(inited_through_init_list);
 
   return 0;

--- a/tests/unit/string_literals.cpp
+++ b/tests/unit/string_literals.cpp
@@ -22,5 +22,9 @@ int main() {
   foo_const("");
   foo_const(immutable_empty);
   foo_const(immutable_empty_arr);
+
+  const char inited_through_init_list[] = { "papanasi cu smantana" };
+  foo_const(inited_through_init_list);
+
   return 0;
 }

--- a/tests/unit/string_literals_c.c
+++ b/tests/unit/string_literals_c.c
@@ -32,7 +32,7 @@ int main() {
   foo_const(mutable_empty_arr);
   foo_const(immutable_empty_arr);
 
-  const char inited_through_init_list[] = { "papanasi cu smantana" };
+  const char inited_through_init_list[] = {"papanasi cu smantana"};
   foo_const(inited_through_init_list);
 
   return 0;

--- a/tests/unit/string_literals_c.c
+++ b/tests/unit/string_literals_c.c
@@ -31,5 +31,9 @@ int main() {
   foo_const(immutable_empty);
   foo_const(mutable_empty_arr);
   foo_const(immutable_empty_arr);
+
+  const char inited_through_init_list[] = { "papanasi cu smantana" };
+  foo_const(inited_through_init_list);
+
   return 0;
 }


### PR DESCRIPTION
`const char var[] = {"string literal"}` is a valid initialization. Add support for it in codegen.