### PR TITLE
Add llvm compile flags to cpp2rust_core

### DIFF
--- a/cpp2rust/CMakeLists.txt
+++ b/cpp2rust/CMakeLists.txt
@@ -5,6 +5,7 @@ list(REMOVE_ITEM CORE_SOURCES
 )
 
 add_library(cpp2rust_core STATIC ${CORE_SOURCES})
+llvm_update_compile_flags(cpp2rust_core)
 
 target_link_libraries(cpp2rust_core PUBLIC
     clangAST


### PR DESCRIPTION
Ensure `cpp2rust_core` is compiled with flags consistent with LLVM's. This fixes linking issues when using LLVM builds with RTTI disabled.