### PR TITLE
Avoid from_fn for initializing integer arrays

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -3151,6 +3151,10 @@ bool Converter::VisitImplicitValueInitExpr(clang::ImplicitValueInitExpr *expr) {
   if (auto arr_ty = clang::dyn_cast<clang::ArrayType>(
           expr->getType()->getCanonicalTypeInternal().getTypePtr())) {
     if (auto const_arr_ty = clang::dyn_cast<clang::ConstantArrayType>(arr_ty)) {
+      if (const_arr_ty->getElementType()->isCharType()) {
+        StrCat(std::format("[0; {}]", const_arr_ty->getSize().getZExtValue()));
+        return false;
+      }
       StrCat(
           std::format("std::array::from_fn::<_, {}, _>(|_| Default::default())",
                       const_arr_ty->getSize().getZExtValue()));

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -3151,7 +3151,8 @@ bool Converter::VisitImplicitValueInitExpr(clang::ImplicitValueInitExpr *expr) {
   if (auto arr_ty = clang::dyn_cast<clang::ArrayType>(
           expr->getType()->getCanonicalTypeInternal().getTypePtr())) {
     if (auto const_arr_ty = clang::dyn_cast<clang::ConstantArrayType>(arr_ty)) {
-      if (const_arr_ty->getElementType()->isCharType()) {
+      auto elem_ty = const_arr_ty->getElementType();
+      if (elem_ty->isIntegerType() && !elem_ty->isEnumeralType()) {
         StrCat(std::format("[0; {}]", const_arr_ty->getSize().getZExtValue()));
         return false;
       }

--- a/tests/unit/array_const_init.c
+++ b/tests/unit/array_const_init.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+
+struct S {
+  int head;
+  int tail[3];
+  char buf[4];
+};
+
+struct S s = {5};
+
+int main() {
+  assert(s.head == 5);
+  for (int i = 0; i < 3; i++) {
+    assert(s.tail[i] == 0);
+  }
+  for (int i = 0; i < 4; i++) {
+    assert(s.buf[i] == 0);
+  }
+  return 0;
+}

--- a/tests/unit/out/refcount/array_const_init.rs
+++ b/tests/unit/out/refcount/array_const_init.rs
@@ -1,0 +1,60 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+#[derive()]
+pub struct S {
+    pub head: Value<i32>,
+    pub tail: Value<Box<[i32]>>,
+    pub buf: Value<Box<[u8]>>,
+}
+impl Default for S {
+    fn default() -> Self {
+        S {
+            head: <Value<i32>>::default(),
+            tail: Rc::new(RefCell::new(
+                (0..3).map(|_| <i32>::default()).collect::<Box<[i32]>>(),
+            )),
+            buf: Rc::new(RefCell::new(
+                (0..4).map(|_| <u8>::default()).collect::<Box<[u8]>>(),
+            )),
+        }
+    }
+}
+impl ByteRepr for S {}
+thread_local!(
+    pub static s_0: Value<S> = Rc::new(RefCell::new(S {
+        head: Rc::new(RefCell::new(5)),
+        tail: Rc::new(RefCell::new(Box::new([0; 3]))),
+        buf: Rc::new(RefCell::new(Box::new([0; 4]))),
+    }));
+);
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(((((*(*s_0.with(Value::clone).borrow()).head.borrow()) == 5) as i32) != 0));
+    let i: Value<i32> = Rc::new(RefCell::new(0));
+    'loop_: while ((((*i.borrow()) < 3) as i32) != 0) {
+        assert!(
+            ((((*(*s_0.with(Value::clone).borrow()).tail.borrow())[(*i.borrow()) as usize] == 0)
+                as i32)
+                != 0)
+        );
+        (*i.borrow_mut()).postfix_inc();
+    }
+    let i: Value<i32> = Rc::new(RefCell::new(0));
+    'loop_: while ((((*i.borrow()) < 4) as i32) != 0) {
+        assert!(
+            (((((*(*s_0.with(Value::clone).borrow()).buf.borrow())[(*i.borrow()) as usize] as i32)
+                == 0) as i32)
+                != 0)
+        );
+        (*i.borrow_mut()).postfix_inc();
+    }
+    return 0;
+}

--- a/tests/unit/out/unsafe/array_const_init.rs
+++ b/tests/unit/out/unsafe/array_const_init.rs
@@ -1,0 +1,50 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct S {
+    pub head: i32,
+    pub tail: [i32; 3],
+    pub buf: [u8; 4],
+}
+impl Default for S {
+    fn default() -> Self {
+        S {
+            head: 0_i32,
+            tail: [0_i32; 3],
+            buf: [0_u8; 4],
+        }
+    }
+}
+pub static mut s_0: S = unsafe {
+    S {
+        head: 5,
+        tail: [0; 3],
+        buf: [0; 4],
+    }
+};
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(((((s_0.head) == (5)) as i32) != 0));
+    let mut i: i32 = 0;
+    'loop_: while ((((i) < (3)) as i32) != 0) {
+        assert!(((((s_0.tail[(i) as usize]) == (0)) as i32) != 0));
+        i.postfix_inc();
+    }
+    let mut i: i32 = 0;
+    'loop_: while ((((i) < (4)) as i32) != 0) {
+        assert!(((((s_0.buf[(i) as usize] as i32) == (0)) as i32) != 0));
+        i.postfix_inc();
+    }
+    return 0;
+}


### PR DESCRIPTION
from_fn cannot be used in const initializers in Rust.