### PR TITLE
Fix class template translations

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -3476,7 +3476,7 @@ std::string Converter::GetRecordName(const clang::NamedDecl *decl) const {
   if (auto it = inner_structs_.find(ID); it != inner_structs_.end()) {
     return it->second;
   }
-  return ReplaceAll(Mapper::ToString(decl), "::", "_");
+  return Mapper::ToRustName(Mapper::ToString(Mapper::GetTypeForDecl(decl)));
 }
 
 std::vector<const char *>

--- a/cpp2rust/converter/mapper.cpp
+++ b/cpp2rust/converter/mapper.cpp
@@ -723,9 +723,30 @@ bool ParamIsPointer(const clang::Expr *expr, unsigned index) {
   return GetParamInfo(expr, index).is_pointer();
 }
 
+clang::QualType GetTypeForDecl(const clang::NamedDecl *decl) {
+  if (const auto *spec =
+          llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(decl)) {
+    llvm::ArrayRef<clang::TemplateArgument> args =
+        spec->getTemplateArgs().asArray();
+    llvm::SmallVector<clang::TemplateArgument, 4> canon(args.begin(),
+                                                        args.end());
+    ctx_->canonicalizeTemplateArguments(canon);
+
+    return ctx_->getTemplateSpecializationType(
+        clang::ElaboratedTypeKeyword::None,
+        clang::TemplateName(spec->getSpecializedTemplate()), args, canon);
+  }
+
+  const auto *rdecl = llvm::dyn_cast<clang::TagDecl>(decl);
+  assert(rdecl && "Unsupported decl type");
+
+  return ctx_->getTagType(clang::ElaboratedTypeKeyword::None,
+                          rdecl->getQualifier(), rdecl, /*OwnsTag*/ false);
+}
+
 void AddRuleForUserDefinedType(clang::NamedDecl *decl) {
-  auto cpp_name = ToString(decl);
-  auto rs_name = ReplaceAll(cpp_name, "::", "_");
+  auto cpp_name = ToString(GetTypeForDecl(decl));
+  auto rs_name = ToRustName(cpp_name);
 
   AddTypeRule(cpp_name, TranslationRule::TypeRule::Plain(rs_name));
 
@@ -765,6 +786,16 @@ void AddRuleForUserDefinedType(clang::NamedDecl *decl) {
       }
     }
   }
+}
+
+std::string ToRustName(std::string name) {
+  size_t pos = 0;
+  std::string chars = "<>, ";
+  while ((pos = name.find_first_of(chars, pos)) != std::string::npos) {
+    name.replace(pos, 1, 1, '_');
+    ++pos;
+  }
+  return ReplaceAll(name, "::", "_");
 }
 
 std::string ToString(clang::QualType qual_type, ScalarSugar sugar) {

--- a/cpp2rust/converter/mapper.cpp
+++ b/cpp2rust/converter/mapper.cpp
@@ -790,9 +790,8 @@ void AddRuleForUserDefinedType(clang::NamedDecl *decl) {
 
 std::string ToRustName(std::string name) {
   size_t pos = 0;
-  std::string chars = "<>, ";
-  while ((pos = name.find_first_of(chars, pos)) != std::string::npos) {
-    name.replace(pos, 1, 1, '_');
+  while ((pos = name.find_first_of("<>, ", pos)) != std::string::npos) {
+    name[pos] = '_';
     ++pos;
   }
   return ReplaceAll(name, "::", "_");

--- a/cpp2rust/converter/mapper.h
+++ b/cpp2rust/converter/mapper.h
@@ -43,10 +43,12 @@ enum class ScalarSugar {
   kPreserve,
 };
 
+clang::QualType GetTypeForDecl(const clang::NamedDecl *decl);
 std::string ToString(clang::QualType qual_type,
                      ScalarSugar sugar = ScalarSugar::kDesugar);
 std::string ToString(const clang::Expr *expr);
 std::string ToString(const clang::NamedDecl *decl);
+std::string ToRustName(std::string name);
 
 void LoadTranslationRules(Model model, clang::ASTContext &ctx,
                           const std::string &rules_dir);

--- a/tests/unit/class_templates.cpp
+++ b/tests/unit/class_templates.cpp
@@ -1,0 +1,43 @@
+#include <cassert>
+#include <vector>
+
+template <typename T> class MyContainer {
+  std::vector<T> vec;
+
+public:
+  using value_type = T;
+  using reference = T &;
+  using const_reference = const T &;
+  using size_type = std::size_t;
+
+  bool empty() const { return vec.empty(); }
+  size_type size() const { return vec.size(); }
+  const_reference back() const { return vec.back(); }
+  reference back() { return vec.back(); }
+  void pop_back() { return vec.pop_back(); }
+  void push_back(const_reference item) { vec.push_back(item); }
+};
+
+int main() {
+  MyContainer<int> imc;
+  assert(imc.empty());
+  imc.push_back(1);
+  assert(imc.size() == 1 && imc.back() == 1);
+  imc.pop_back();
+  assert(imc.empty());
+
+  MyContainer<char> cmc;
+  assert(cmc.empty());
+  cmc.push_back('a');
+  assert(cmc.size() == 1 && cmc.back() == 'a');
+  cmc.pop_back();
+  assert(cmc.empty());
+
+  MyContainer<float> fmc;
+  assert(fmc.empty());
+  fmc.push_back('a');
+  assert(fmc.size() == 1 && fmc.back() == 'a');
+  fmc.pop_back();
+  assert(fmc.empty());
+  return 0;
+}

--- a/tests/unit/class_templates.cpp
+++ b/tests/unit/class_templates.cpp
@@ -35,8 +35,8 @@ int main() {
 
   MyContainer<float> fmc;
   assert(fmc.empty());
-  fmc.push_back('a');
-  assert(fmc.size() == 1 && fmc.back() == 'a');
+  fmc.push_back(1.0);
+  assert(fmc.size() == 1 && fmc.back() == 1.0);
   fmc.pop_back();
   assert(fmc.empty());
   return 0;

--- a/tests/unit/out/refcount/class_templates.rs
+++ b/tests/unit/out/refcount/class_templates.rs
@@ -147,12 +147,12 @@ fn main_0() -> i32 {
     let fmc: Value<MyContainer_float_> = Rc::new(RefCell::new(<MyContainer_float_>::default()));
     assert!(({ (*fmc.borrow()).empty() }));
     ({
-        let _item: Value<f32> = Rc::new(RefCell::new((('a' as u8) as f32)));
+        let _item: Value<f32> = Rc::new(RefCell::new((1.0E+0 as f32)));
         (*fmc.borrow()).push_back(_item.as_pointer())
     });
     assert!(
         (({ (*fmc.borrow()).size() }) == 1_usize)
-            && ((({ (*fmc.borrow()).back() }).read()) == ((('a' as u8) as i32) as f32))
+            && (((({ (*fmc.borrow()).back() }).read()) as f64) == 1.0E+0)
     );
     ({ (*fmc.borrow()).pop_back() });
     assert!(({ (*fmc.borrow()).empty() }));

--- a/tests/unit/out/refcount/class_templates.rs
+++ b/tests/unit/out/refcount/class_templates.rs
@@ -1,0 +1,86 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+#[derive(Default)]
+pub struct MyContainer {
+    vec_: Value<Vec<i32>>,
+}
+impl MyContainer {
+    pub fn empty(&self) -> bool {
+        return (*self.vec_.borrow()).is_empty();
+    }
+    pub fn size(&self) -> usize {
+        return (*self.vec_.borrow()).len();
+    }
+    pub fn back_const(&self) -> Ptr<i32> {
+        return (self.vec_.as_pointer() as Ptr<i32>).to_last();
+    }
+    pub fn back(&self) -> Ptr<i32> {
+        return (self.vec_.as_pointer() as Ptr<i32>).to_last();
+    }
+    pub fn pop_back(&self) {
+        (*self.vec_.borrow_mut()).pop();
+        return;
+    }
+    pub fn push_back(&self, item: Ptr<i32>) {
+        {
+            let a0_clone = (item.read()).clone();
+            (*self.vec_.borrow_mut()).push(a0_clone)
+        };
+    }
+}
+impl Clone for MyContainer {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            vec_: Rc::new(RefCell::new((*self.vec_.borrow()).clone())),
+        };
+        this
+    }
+}
+impl ByteRepr for MyContainer {}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let imc: Value<MyContainer> = Rc::new(RefCell::new(<MyContainer>::default()));
+    assert!(({ (*imc.borrow()).empty() }));
+    ({
+        let _item: Value<i32> = Rc::new(RefCell::new(1));
+        (*imc.borrow()).push_back(_item.as_pointer())
+    });
+    assert!(
+        (({ (*imc.borrow()).size() }) == 1_usize) && ((({ (*imc.borrow()).back() }).read()) == 1)
+    );
+    ({ (*imc.borrow()).pop_back() });
+    assert!(({ (*imc.borrow()).empty() }));
+    let cmc: Value<MyContainer> = Rc::new(RefCell::new(<MyContainer>::default()));
+    assert!(({ (*cmc.borrow()).empty() }));
+    ({
+        let _item: Value<u8> = Rc::new(RefCell::new(('a' as u8)));
+        (*cmc.borrow()).push_back(_item.as_pointer())
+    });
+    assert!(
+        (({ (*cmc.borrow()).size() }) == 1_usize)
+            && (((({ (*cmc.borrow()).back() }).read()) as i32) == (('a' as u8) as i32))
+    );
+    ({ (*cmc.borrow()).pop_back() });
+    assert!(({ (*cmc.borrow()).empty() }));
+    let fmc: Value<MyContainer> = Rc::new(RefCell::new(<MyContainer>::default()));
+    assert!(({ (*fmc.borrow()).empty() }));
+    ({
+        let _item: Value<f32> = Rc::new(RefCell::new((('a' as u8) as f32)));
+        (*fmc.borrow()).push_back(_item.as_pointer())
+    });
+    assert!(
+        (({ (*fmc.borrow()).size() }) == 1_usize)
+            && ((({ (*fmc.borrow()).back() }).read()) == ((('a' as u8) as i32) as f32))
+    );
+    ({ (*fmc.borrow()).pop_back() });
+    assert!(({ (*fmc.borrow()).empty() }));
+    return 0;
+}

--- a/tests/unit/out/refcount/class_templates.rs
+++ b/tests/unit/out/refcount/class_templates.rs
@@ -7,10 +7,10 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 #[derive(Default)]
-pub struct MyContainer {
+pub struct MyContainer_int_ {
     vec_: Value<Vec<i32>>,
 }
-impl MyContainer {
+impl MyContainer_int_ {
     pub fn empty(&self) -> bool {
         return (*self.vec_.borrow()).is_empty();
     }
@@ -34,7 +34,7 @@ impl MyContainer {
         };
     }
 }
-impl Clone for MyContainer {
+impl Clone for MyContainer_int_ {
     fn clone(&self) -> Self {
         let mut this = Self {
             vec_: Rc::new(RefCell::new((*self.vec_.borrow()).clone())),
@@ -42,12 +42,86 @@ impl Clone for MyContainer {
         this
     }
 }
-impl ByteRepr for MyContainer {}
+impl ByteRepr for MyContainer_int_ {}
+#[derive(Default)]
+pub struct MyContainer_char_ {
+    vec_: Value<Vec<u8>>,
+}
+impl MyContainer_char_ {
+    pub fn empty(&self) -> bool {
+        return (*self.vec_.borrow()).is_empty();
+    }
+    pub fn size(&self) -> usize {
+        return (*self.vec_.borrow()).len();
+    }
+    pub fn back_const(&self) -> Ptr<u8> {
+        return (self.vec_.as_pointer() as Ptr<u8>).to_last();
+    }
+    pub fn back(&self) -> Ptr<u8> {
+        return (self.vec_.as_pointer() as Ptr<u8>).to_last();
+    }
+    pub fn pop_back(&self) {
+        (*self.vec_.borrow_mut()).pop();
+        return;
+    }
+    pub fn push_back(&self, item: Ptr<u8>) {
+        {
+            let a0_clone = (item.read()).clone();
+            (*self.vec_.borrow_mut()).push(a0_clone)
+        };
+    }
+}
+impl Clone for MyContainer_char_ {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            vec_: Rc::new(RefCell::new((*self.vec_.borrow()).clone())),
+        };
+        this
+    }
+}
+impl ByteRepr for MyContainer_char_ {}
+#[derive(Default)]
+pub struct MyContainer_float_ {
+    vec_: Value<Vec<f32>>,
+}
+impl MyContainer_float_ {
+    pub fn empty(&self) -> bool {
+        return (*self.vec_.borrow()).is_empty();
+    }
+    pub fn size(&self) -> usize {
+        return (*self.vec_.borrow()).len();
+    }
+    pub fn back_const(&self) -> Ptr<f32> {
+        return (self.vec_.as_pointer() as Ptr<f32>).to_last();
+    }
+    pub fn back(&self) -> Ptr<f32> {
+        return (self.vec_.as_pointer() as Ptr<f32>).to_last();
+    }
+    pub fn pop_back(&self) {
+        (*self.vec_.borrow_mut()).pop();
+        return;
+    }
+    pub fn push_back(&self, item: Ptr<f32>) {
+        {
+            let a0_clone = (item.read()).clone();
+            (*self.vec_.borrow_mut()).push(a0_clone)
+        };
+    }
+}
+impl Clone for MyContainer_float_ {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            vec_: Rc::new(RefCell::new((*self.vec_.borrow()).clone())),
+        };
+        this
+    }
+}
+impl ByteRepr for MyContainer_float_ {}
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    let imc: Value<MyContainer> = Rc::new(RefCell::new(<MyContainer>::default()));
+    let imc: Value<MyContainer_int_> = Rc::new(RefCell::new(<MyContainer_int_>::default()));
     assert!(({ (*imc.borrow()).empty() }));
     ({
         let _item: Value<i32> = Rc::new(RefCell::new(1));
@@ -58,7 +132,7 @@ fn main_0() -> i32 {
     );
     ({ (*imc.borrow()).pop_back() });
     assert!(({ (*imc.borrow()).empty() }));
-    let cmc: Value<MyContainer> = Rc::new(RefCell::new(<MyContainer>::default()));
+    let cmc: Value<MyContainer_char_> = Rc::new(RefCell::new(<MyContainer_char_>::default()));
     assert!(({ (*cmc.borrow()).empty() }));
     ({
         let _item: Value<u8> = Rc::new(RefCell::new(('a' as u8)));
@@ -70,7 +144,7 @@ fn main_0() -> i32 {
     );
     ({ (*cmc.borrow()).pop_back() });
     assert!(({ (*cmc.borrow()).empty() }));
-    let fmc: Value<MyContainer> = Rc::new(RefCell::new(<MyContainer>::default()));
+    let fmc: Value<MyContainer_float_> = Rc::new(RefCell::new(<MyContainer_float_>::default()));
     assert!(({ (*fmc.borrow()).empty() }));
     ({
         let _item: Value<f32> = Rc::new(RefCell::new((('a' as u8) as f32)));

--- a/tests/unit/out/unsafe/class_templates.rs
+++ b/tests/unit/out/unsafe/class_templates.rs
@@ -1,0 +1,78 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+#[repr(C)]
+#[derive(Clone, Default)]
+pub struct MyContainer {
+    vec_: Vec<i32>,
+}
+impl MyContainer {
+    pub unsafe fn empty(&self) -> bool {
+        return self.vec_.is_empty();
+    }
+    pub unsafe fn size(&self) -> usize {
+        return self.vec_.len();
+    }
+    pub unsafe fn back_const(&self) -> *const i32 {
+        return ((self.vec_).last().unwrap());
+    }
+    pub unsafe fn back(&mut self) -> *mut i32 {
+        return ((self.vec_).last_mut().unwrap());
+    }
+    pub unsafe fn pop_back(&mut self) {
+        self.vec_.pop();
+        return;
+    }
+    pub unsafe fn push_back(&mut self, item: *const i32) {
+        {
+            let a0_clone = (*item).clone();
+            self.vec_.push(a0_clone)
+        };
+    }
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut imc: MyContainer = <MyContainer>::default();
+    assert!((unsafe { imc.empty() }));
+    (unsafe {
+        let mut _item = 1;
+        imc.push_back(&mut _item)
+    });
+    assert!(((unsafe { imc.size() }) == (1_usize)) && ((*(unsafe { imc.back() })) == (1)));
+    (unsafe { imc.pop_back() });
+    assert!((unsafe { imc.empty() }));
+    let mut cmc: MyContainer = <MyContainer>::default();
+    assert!((unsafe { cmc.empty() }));
+    (unsafe {
+        let mut _item = ('a' as u8);
+        cmc.push_back(&mut _item)
+    });
+    assert!(
+        ((unsafe { cmc.size() }) == (1_usize))
+            && (((*(unsafe { cmc.back() })) as i32) == (('a' as u8) as i32))
+    );
+    (unsafe { cmc.pop_back() });
+    assert!((unsafe { cmc.empty() }));
+    let mut fmc: MyContainer = <MyContainer>::default();
+    assert!((unsafe { fmc.empty() }));
+    (unsafe {
+        let mut _item = (('a' as u8) as f32);
+        fmc.push_back(&mut _item)
+    });
+    assert!(
+        ((unsafe { fmc.size() }) == (1_usize))
+            && ((*(unsafe { fmc.back() })) == ((('a' as u8) as i32) as f32))
+    );
+    (unsafe { fmc.pop_back() });
+    assert!((unsafe { fmc.empty() }));
+    return 0;
+}

--- a/tests/unit/out/unsafe/class_templates.rs
+++ b/tests/unit/out/unsafe/class_templates.rs
@@ -123,12 +123,11 @@ unsafe fn main_0() -> i32 {
     let mut fmc: MyContainer_float_ = <MyContainer_float_>::default();
     assert!((unsafe { fmc.empty() }));
     (unsafe {
-        let mut _item = (('a' as u8) as f32);
+        let mut _item = (1.0E+0 as f32);
         fmc.push_back(&mut _item)
     });
     assert!(
-        ((unsafe { fmc.size() }) == (1_usize))
-            && ((*(unsafe { fmc.back() })) == ((('a' as u8) as i32) as f32))
+        ((unsafe { fmc.size() }) == (1_usize)) && (((*(unsafe { fmc.back() })) as f64) == (1.0E+0))
     );
     (unsafe { fmc.pop_back() });
     assert!((unsafe { fmc.empty() }));

--- a/tests/unit/out/unsafe/class_templates.rs
+++ b/tests/unit/out/unsafe/class_templates.rs
@@ -8,10 +8,10 @@ use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 #[repr(C)]
 #[derive(Clone, Default)]
-pub struct MyContainer {
+pub struct MyContainer_int_ {
     vec_: Vec<i32>,
 }
-impl MyContainer {
+impl MyContainer_int_ {
     pub unsafe fn empty(&self) -> bool {
         return self.vec_.is_empty();
     }
@@ -35,13 +35,71 @@ impl MyContainer {
         };
     }
 }
+#[repr(C)]
+#[derive(Clone, Default)]
+pub struct MyContainer_char_ {
+    vec_: Vec<u8>,
+}
+impl MyContainer_char_ {
+    pub unsafe fn empty(&self) -> bool {
+        return self.vec_.is_empty();
+    }
+    pub unsafe fn size(&self) -> usize {
+        return self.vec_.len();
+    }
+    pub unsafe fn back_const(&self) -> *const u8 {
+        return ((self.vec_).last().unwrap());
+    }
+    pub unsafe fn back(&mut self) -> *mut u8 {
+        return ((self.vec_).last_mut().unwrap());
+    }
+    pub unsafe fn pop_back(&mut self) {
+        self.vec_.pop();
+        return;
+    }
+    pub unsafe fn push_back(&mut self, item: *const u8) {
+        {
+            let a0_clone = (*item).clone();
+            self.vec_.push(a0_clone)
+        };
+    }
+}
+#[repr(C)]
+#[derive(Clone, Default)]
+pub struct MyContainer_float_ {
+    vec_: Vec<f32>,
+}
+impl MyContainer_float_ {
+    pub unsafe fn empty(&self) -> bool {
+        return self.vec_.is_empty();
+    }
+    pub unsafe fn size(&self) -> usize {
+        return self.vec_.len();
+    }
+    pub unsafe fn back_const(&self) -> *const f32 {
+        return ((self.vec_).last().unwrap());
+    }
+    pub unsafe fn back(&mut self) -> *mut f32 {
+        return ((self.vec_).last_mut().unwrap());
+    }
+    pub unsafe fn pop_back(&mut self) {
+        self.vec_.pop();
+        return;
+    }
+    pub unsafe fn push_back(&mut self, item: *const f32) {
+        {
+            let a0_clone = (*item).clone();
+            self.vec_.push(a0_clone)
+        };
+    }
+}
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut imc: MyContainer = <MyContainer>::default();
+    let mut imc: MyContainer_int_ = <MyContainer_int_>::default();
     assert!((unsafe { imc.empty() }));
     (unsafe {
         let mut _item = 1;
@@ -50,7 +108,7 @@ unsafe fn main_0() -> i32 {
     assert!(((unsafe { imc.size() }) == (1_usize)) && ((*(unsafe { imc.back() })) == (1)));
     (unsafe { imc.pop_back() });
     assert!((unsafe { imc.empty() }));
-    let mut cmc: MyContainer = <MyContainer>::default();
+    let mut cmc: MyContainer_char_ = <MyContainer_char_>::default();
     assert!((unsafe { cmc.empty() }));
     (unsafe {
         let mut _item = ('a' as u8);
@@ -62,7 +120,7 @@ unsafe fn main_0() -> i32 {
     );
     (unsafe { cmc.pop_back() });
     assert!((unsafe { cmc.empty() }));
-    let mut fmc: MyContainer = <MyContainer>::default();
+    let mut fmc: MyContainer_float_ = <MyContainer_float_>::default();
     assert!((unsafe { fmc.empty() }));
     (unsafe {
         let mut _item = (('a' as u8) as f32);


### PR DESCRIPTION
Fixes how class templates are translated.

Class templates are currently monomorphized:
https://github.com/Cpp2Rust/cpp2rust/blob/8f79a34db82d97f1b41ac2576b8a202458d029ea/cpp2rust/converter/converter.cpp#L3316-L3321

However, the name of each translated Rust struct was the plain C++ name, leading to collisions.

Additionally, the C++ name used in the translation rule inserted into Mapper was also the plain C++ name.
This name does not match how the type itself is printed, which led to internal cpp2rust assertion failures due to missing translation rules.