### PR TITLE
Fix translations for unnamed function parameters

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -483,7 +483,7 @@ bool Converter::ConvertVarDeclSkipInit(clang::VarDecl *decl) {
   if ((hoisted_decls_.contains(decl) || !qual_type.isConstQualified()) &&
       !qual_type->isReferenceType() &&
       ((method_or_null == nullptr) || !method_or_null->isVirtual()) &&
-      !IsGlobalVar(decl)) {
+      !IsGlobalVar(decl) && name != "_") {
     StrCat(keyword_mut_);
   }
 

--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -481,7 +481,15 @@ std::string GetNamedDeclAsString(const clang::NamedDecl *decl) {
   }
 
   if (name.empty()) {
-    name = "self";
+    auto *pdecl = llvm::dyn_cast<clang::ParmVarDecl>(decl);
+    assert(pdecl && "Unexpected unnamed construct");
+
+    const auto *ctor =
+        llvm::dyn_cast<clang::CXXConstructorDecl>(pdecl->getDeclContext());
+    name = (pdecl->isExplicitObjectParameter() ||
+            (ctor && ctor->isCopyOrMoveConstructor()))
+               ? "self"
+               : "_";
   }
 
   return name;

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -594,6 +594,11 @@ void ConverterRefCount::EmitFunctionPreamble(clang::FunctionDecl *decl) {
   for (auto *param : params) {
     if (!param->getType()->isReferenceType()) {
       auto name = GetNamedDeclAsString(param);
+      // Skip emitting the preamble for unnamed parameters
+      if (name == "_") {
+        continue;
+      }
+
       auto type = ToString(param->getType());
       auto init = name;
 

--- a/tests/unit/empty_main.cpp
+++ b/tests/unit/empty_main.cpp
@@ -1,0 +1,1 @@
+int main(int, char **) { return 0; }

--- a/tests/unit/out/refcount/empty_main.rs
+++ b/tests/unit/out/refcount/empty_main.rs
@@ -1,0 +1,27 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+
+pub fn main() {
+    let argv: Vec<Value<Vec<u8>>> = ::std::env::args()
+        .map(|x| Rc::new(RefCell::new(x.as_bytes().to_vec())))
+        .collect();
+    let mut argv: Value<Vec<Ptr<u8>>> = Rc::new(RefCell::new(
+        argv.iter()
+            .map(|x| {
+                x.borrow_mut().push(0);
+                x.as_pointer()
+            })
+            .collect(),
+    ));
+    (*argv.borrow_mut()).push(Ptr::null());
+    ::std::process::exit(main_0(::std::env::args().len() as i32, argv.as_pointer()));
+}
+fn main_0(_: i32, _: Ptr<Ptr<u8>>) -> i32 {
+    return 0;
+}

--- a/tests/unit/out/unsafe/empty_main.rs
+++ b/tests/unit/out/unsafe/empty_main.rs
@@ -1,0 +1,21 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+
+pub fn main() {
+    let mut args: Vec<Vec<u8>> = std::env::args()
+        .map(|arg| arg.as_bytes().to_vec())
+        .collect();
+    args.iter_mut().for_each(|v| v.push(0));
+    let mut argv: Vec<*mut u8> = args.iter().map(|arg| arg.as_ptr() as *mut u8).collect();
+    argv.push(::std::ptr::null_mut());
+    unsafe { ::std::process::exit(main_0((argv.len() - 1) as i32, argv.as_mut_ptr()) as i32) }
+}
+unsafe fn main_0(_: i32, _: *mut *mut u8) -> i32 {
+    return 0;
+}


### PR DESCRIPTION
The current implementation of `GetNamedDeclAsString` defaults to returning `self` whenever the declaration corresponds to an unnamed function parameter. This leads to incorrect translations such as the following:
```cpp
int main(int, char**) { return 0; }
```
```rust
fn main_0(self: i32, self: Ptr<Ptr<u8>>) -> i32 {
    let self: Value<i32> = Rc::new(RefCell::new(self));
    let self: Value<Ptr<Ptr<u8>>> = Rc::new(RefCell::new(self));
    return 0;
}
```

This patch addresses this issue by changing `GetNamedDeclAsString` to return `self` only when it is actually required, and `_` otherwise.