### PR TITLE
Ensure `CheckTemplateArgumentList` is always called with a non-empty `CodeSynthesisContext`

### DIFF
--- a/cpp2rust/cpp_rule_preprocessor.cpp
+++ b/cpp2rust/cpp_rule_preprocessor.cpp
@@ -270,6 +270,7 @@ private:
 
         clang::DefaultArguments defaultArgs;
         clang::Sema::CheckTemplateArgumentInfo ctai;
+        clang::Sema::InstantiatingTemplate Inst(*sema_, loc_, decl);
         auto invalid = sema_->CheckTemplateArgumentList(
             decl, decl->getTemplateParameters(), loc_, targsInfo, defaultArgs,
             true, ctai);


### PR DESCRIPTION
Fixes an internal Clang assertion failure triggered when preprocessing the rules for `std::unique_ptr` with `--cxxflags='-stdlib=libc++'`.