### PR TITLE
Avoid hoisting for function call arguments that don't alias

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -1681,6 +1681,24 @@ Converter::CallInfo Converter::CollectCallInfo(clang::CallExpr *expr) {
     }
   }
 
+  // Inline arguments that don't alias
+  clang::Expr *receiver = GetCallObject(expr);
+  for (auto &ca : info.args) {
+    if (ca.kind != Kind::Hoisted) {
+      continue;
+    }
+    bool aliases = receiver && ArgsMayAlias(ca.expr, receiver);
+    for (const auto &other : info.args) {
+      if (&other != &ca && ArgsMayAlias(ca.expr, other.expr)) {
+        aliases = true;
+        break;
+      }
+    }
+    if (!aliases) {
+      ca.kind = Kind::Inline;
+    }
+  }
+
   return info;
 }
 

--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -644,25 +644,28 @@ clang::Expr *GetCallObject(clang::CallExpr *expr) {
   return nullptr;
 }
 
-std::unordered_set<const clang::ValueDecl *>
-GetAllVars(const clang::Stmt *stmt) {
-  std::unordered_set<const clang::ValueDecl *> vars;
+static void GetAllVarsImpl(const clang::Stmt *stmt,
+                           std::unordered_set<const clang::ValueDecl *> &vars) {
   if (!stmt) {
-    return vars;
+    return;
   }
 
   if (auto *decl_ref = clang::dyn_cast<clang::DeclRefExpr>(stmt)) {
     vars.insert(decl_ref->getDecl());
   } else if (auto *member = clang::dyn_cast<clang::MemberExpr>(stmt)) {
     vars.insert(member->getMemberDecl());
-    auto child_vars = GetAllVars(member->getBase());
-    vars.insert(child_vars.begin(), child_vars.end());
+    GetAllVarsImpl(member->getBase(), vars);
   }
 
   for (auto *child : stmt->children()) {
-    auto child_vars = GetAllVars(child);
-    vars.insert(child_vars.begin(), child_vars.end());
+    GetAllVarsImpl(child, vars);
   }
+}
+
+std::unordered_set<const clang::ValueDecl *>
+GetAllVars(const clang::Stmt *stmt) {
+  std::unordered_set<const clang::ValueDecl *> vars;
+  GetAllVarsImpl(stmt, vars);
   return vars;
 }
 

--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -13,6 +13,7 @@
 #include <cctype>
 #include <filesystem>
 #include <format>
+#include <ranges>
 #include <unordered_set>
 
 #include "converter/lex.h"
@@ -641,6 +642,75 @@ clang::Expr *GetCallObject(clang::CallExpr *expr) {
       return opcall->getArg(0)->IgnoreParenImpCasts();
   }
   return nullptr;
+}
+
+std::unordered_set<const clang::ValueDecl *>
+GetAllVars(const clang::Stmt *stmt) {
+  std::unordered_set<const clang::ValueDecl *> vars;
+  if (!stmt) {
+    return vars;
+  }
+
+  if (auto *decl_ref = clang::dyn_cast<clang::DeclRefExpr>(stmt)) {
+    vars.insert(decl_ref->getDecl());
+  } else if (auto *member = clang::dyn_cast<clang::MemberExpr>(stmt)) {
+    vars.insert(member->getMemberDecl());
+    auto child_vars = GetAllVars(member->getBase());
+    vars.insert(child_vars.begin(), child_vars.end());
+  }
+
+  for (auto *child : stmt->children()) {
+    auto child_vars = GetAllVars(child);
+    vars.insert(child_vars.begin(), child_vars.end());
+  }
+  return vars;
+}
+
+bool ReferencesThis(const clang::Stmt *stmt) {
+  if (!stmt) {
+    return false;
+  }
+  if (clang::isa<clang::CXXThisExpr>(stmt)) {
+    return true;
+  }
+  for (auto *child : stmt->children()) {
+    if (ReferencesThis(child)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool MayCauseBorrowMutError(const clang::Expr *lhs, const clang::Expr *rhs) {
+  auto lhs_vars = GetAllVars(lhs);
+  auto rhs_vars = GetAllVars(rhs);
+
+  auto predicate = [lhs](auto *var) {
+    auto qual_type = var->getType();
+    return (qual_type->isPointerType() || qual_type->isReferenceType()) &&
+           qual_type->getPointeeType()
+                   .getCanonicalType()
+                   .getUnqualifiedType() ==
+               lhs->getType().getCanonicalType().getUnqualifiedType();
+  };
+
+  if (std::ranges::any_of(rhs_vars, predicate) ||
+      (std::ranges::any_of(lhs_vars, predicate) && !rhs_vars.empty())) {
+    return true;
+  }
+
+  for (auto *lhs_var : lhs_vars) {
+    if (rhs_vars.count(lhs_var))
+      return true;
+  }
+  return false;
+}
+
+bool ArgsMayAlias(const clang::Expr *a, const clang::Expr *b) {
+  if (ReferencesThis(a) && ReferencesThis(b)) {
+    return true;
+  }
+  return MayCauseBorrowMutError(a, b) || MayCauseBorrowMutError(b, a);
 }
 
 std::vector<clang::Expr *>

--- a/cpp2rust/converter/converter_lib.h
+++ b/cpp2rust/converter/converter_lib.h
@@ -12,6 +12,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_set>
 #include <vector>
 
 #include "logging.h"
@@ -138,6 +139,15 @@ void ForEachTemplateArgument(
 }
 
 clang::Expr *GetCallObject(clang::CallExpr *expr);
+
+std::unordered_set<const clang::ValueDecl *>
+GetAllVars(const clang::Stmt *stmt);
+
+bool ReferencesThis(const clang::Stmt *stmt);
+
+bool MayCauseBorrowMutError(const clang::Expr *lhs, const clang::Expr *rhs);
+
+bool ArgsMayAlias(const clang::Expr *a, const clang::Expr *b);
 
 clang::Expr *GetCalleeOrExpr(clang::Expr *expr);
 

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -1826,51 +1826,6 @@ void ConverterRefCount::ConvertVarInit(clang::QualType qual_type,
   }
 }
 
-static std::unordered_set<const clang::ValueDecl *>
-GetAllVars(const clang::Stmt *stmt) {
-  std::unordered_set<const clang::ValueDecl *> vars;
-
-  if (auto *decl_ref = clang::dyn_cast<clang::DeclRefExpr>(stmt)) {
-    vars.insert(decl_ref->getDecl());
-  } else if (auto *member = clang::dyn_cast<clang::MemberExpr>(stmt)) {
-    vars.insert(member->getMemberDecl());
-    auto child_vars = GetAllVars(member->getBase());
-    vars.insert(child_vars.begin(), child_vars.end());
-  }
-
-  for (auto *child : stmt->children()) {
-    auto child_vars = GetAllVars(child);
-    vars.insert(child_vars.begin(), child_vars.end());
-  }
-  return vars;
-}
-
-bool ConverterRefCount::MayCauseBorrowMutError(const clang::Expr *lhs,
-                                               const clang::Expr *rhs) {
-  auto lhs_vars = GetAllVars(lhs);
-  auto rhs_vars = GetAllVars(rhs);
-
-  auto predicate = [lhs](auto *var) {
-    auto qual_type = var->getType();
-    return (qual_type->isPointerType() || qual_type->isReferenceType()) &&
-           qual_type->getPointeeType()
-                   .getCanonicalType()
-                   .getUnqualifiedType() ==
-               lhs->getType().getCanonicalType().getUnqualifiedType();
-  };
-
-  if (std::ranges::any_of(rhs_vars, predicate) ||
-      (std::ranges::any_of(lhs_vars, predicate) && !rhs_vars.empty())) {
-    return true;
-  }
-
-  for (auto *lhs_var : lhs_vars) {
-    if (rhs_vars.count(lhs_var))
-      return true;
-  }
-  return false;
-}
-
 void ConverterRefCount::EmitSetOrAssign(clang::Expr *lhs,
                                         std::string_view rhs) {
   auto lhs_str = ConvertLValue(lhs);

--- a/cpp2rust/converter/models/converter_refcount.h
+++ b/cpp2rust/converter/models/converter_refcount.h
@@ -142,8 +142,6 @@ public:
   std::vector<const char *>
   GetStructAttributes(const clang::RecordDecl *decl) override;
 
-  bool MayCauseBorrowMutError(const clang::Expr *lhs, const clang::Expr *rhs);
-
   bool Convert(clang::QualType qual_type) override;
   bool
   Convert(clang::Expr *expr,

--- a/tests/multi-file/opaque_forward_decl/out/refcount/opaque_forward_decl.rs
+++ b/tests/multi-file/opaque_forward_decl/out/refcount/opaque_forward_decl.rs
@@ -20,10 +20,7 @@ fn main_0() -> i32 {
         p: Rc::new(RefCell::new(Ptr::<opaque>::null())),
         x: Rc::new(RefCell::new(42)),
     }));
-    ({
-        let _c: Ptr<container> = (c.as_pointer());
-        touch_0(_c)
-    });
+    ({ touch_0((c.as_pointer())) });
     assert!(((((*(*c.borrow()).x.borrow()) == 42) as i32) != 0));
     assert!(((((*(*c.borrow()).p.borrow()).is_null()) as i32) != 0));
     return 0;

--- a/tests/multi-file/opaque_forward_decl/out/unsafe/opaque_forward_decl.rs
+++ b/tests/multi-file/opaque_forward_decl/out/unsafe/opaque_forward_decl.rs
@@ -22,10 +22,7 @@ unsafe fn main_0() -> i32 {
         p: std::ptr::null_mut(),
         x: 42,
     };
-    (unsafe {
-        let _c: *mut container = (&mut c as *mut container);
-        touch_0(_c)
-    });
+    (unsafe { touch_0((&mut c as *mut container)) });
     assert!(((((c.x) == (42)) as i32) != 0));
     assert!(((((c.p).is_null()) as i32) != 0));
     return 0;

--- a/tests/ub/out/refcount/dangling-prvalue-as-lvalue.rs
+++ b/tests/ub/out/refcount/dangling-prvalue-as-lvalue.rs
@@ -14,10 +14,7 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let v: Value<Vec<i32>> = Rc::new(RefCell::new(vec![1, 2]));
-    let b: Ptr<i32> = ({
-        let _a: Ptr<i32> = (v.as_pointer() as Ptr<i32>);
-        foo_0(_a)
-    });
+    let b: Ptr<i32> = ({ foo_0((v.as_pointer() as Ptr<i32>)) });
     (*v.borrow_mut()).clear();
     return (b.read());
 }

--- a/tests/ub/out/refcount/ub12.rs
+++ b/tests/ub/out/refcount/ub12.rs
@@ -15,10 +15,7 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let alloc: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::alloc(1)));
-    ({
-        let _ptr: Ptr<i32> = (*alloc.borrow()).clone();
-        escape_0(_ptr)
-    });
+    ({ escape_0((*alloc.borrow()).clone()) });
     (*alloc.borrow()).delete();
     return 0;
 }

--- a/tests/ub/out/refcount/ub13.rs
+++ b/tests/ub/out/refcount/ub13.rs
@@ -15,9 +15,6 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let p1: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::alloc(1)));
-    ({
-        let _p: Ptr<i32> = (*p1.borrow()).clone();
-        escape_0(_p)
-    });
+    ({ escape_0((*p1.borrow()).clone()) });
     return ((*p1.borrow()).read());
 }

--- a/tests/ub/out/refcount/ub16.rs
+++ b/tests/ub/out/refcount/ub16.rs
@@ -20,12 +20,9 @@ fn main_0() -> i32 {
             .collect::<Box<[i32]>>(),
     )));
     let out: Value<i32> = Rc::new(RefCell::new(
-        (({
-            let _a: Ptr<i32> = ((*p1.borrow()).offset((1) as isize));
-            foo_0(_a)
-        })
-        .offset((4) as isize)
-        .read()),
+        (({ foo_0(((*p1.borrow()).offset((1) as isize))) })
+            .offset((4) as isize)
+            .read()),
     ));
     (*p1.borrow()).delete_array();
     return 0;

--- a/tests/ub/out/refcount/ub19.rs
+++ b/tests/ub/out/refcount/ub19.rs
@@ -15,9 +15,6 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let x: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::alloc(1)));
-    ({
-        let _array: Ptr<i32> = (*x.borrow()).clone();
-        foo_0(_array)
-    });
+    ({ foo_0((*x.borrow()).clone()) });
     return 0;
 }

--- a/tests/ub/out/refcount/ub20.rs
+++ b/tests/ub/out/refcount/ub20.rs
@@ -19,9 +19,6 @@ fn main_0() -> i32 {
             .map(|_| <i32>::default())
             .collect::<Box<[i32]>>(),
     )));
-    ({
-        let _single: Ptr<i32> = (*x.borrow()).clone();
-        foo_0(_single)
-    });
+    ({ foo_0((*x.borrow()).clone()) });
     return 0;
 }

--- a/tests/ub/out/refcount/ub21.rs
+++ b/tests/ub/out/refcount/ub21.rs
@@ -23,8 +23,5 @@ fn main_0() -> i32 {
         ('t' as u8),
         ('r' as u8),
     ])));
-    return (({
-        let _s: Ptr<u8> = (s.as_pointer() as Ptr<u8>);
-        strlen_0(_s)
-    }) as i32);
+    return (({ strlen_0((s.as_pointer() as Ptr<u8>)) }) as i32);
 }

--- a/tests/ub/out/refcount/ub4.rs
+++ b/tests/ub/out/refcount/ub4.rs
@@ -24,11 +24,7 @@ fn main_0() -> i32 {
     let x1: Value<i32> = Rc::new(RefCell::new(1));
     if ((*x1.borrow()) != 0) {
         let x2: Value<i32> = Rc::new(RefCell::new(-1_i32));
-        (*out.borrow_mut()) = ({
-            let _x1: Ptr<i32> = x1.as_pointer();
-            let _x2: Ptr<i32> = x2.as_pointer();
-            smaller_0(_x1, _x2)
-        });
+        (*out.borrow_mut()) = ({ smaller_0(x1.as_pointer(), x2.as_pointer()) });
     }
     return ((*out.borrow()).read());
 }

--- a/tests/ub/out/refcount/ub5.rs
+++ b/tests/ub/out/refcount/ub5.rs
@@ -16,10 +16,7 @@ pub fn main() {
 fn main_0() -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(1));
     let p: Value<Ptr<i32>> = Rc::new(RefCell::new((x.as_pointer())));
-    ({
-        let _p: Ptr<Ptr<i32>> = (p.as_pointer());
-        null_0(_p)
-    });
+    ({ null_0((p.as_pointer())) });
     let r: Ptr<i32> = (*p.borrow()).clone();
     return (r.read());
 }

--- a/tests/ub/out/refcount/ub6.rs
+++ b/tests/ub/out/refcount/ub6.rs
@@ -69,14 +69,6 @@ fn main_0() -> i32 {
                 .map(|_| <Ptr<i32>>::default())
                 .collect::<Box<[_]>>(),
         )))));
-    ({
-        let _arr: Ptr<Option<Value<Box<[Ptr<i32>]>>>> = arr.as_pointer();
-        let _n1: Ptr<i32> = n.as_pointer();
-        fill_1(_arr, _n1)
-    });
-    return (({
-        let _arr: Ptr<Option<Value<Box<[Ptr<i32>]>>>> = arr.as_pointer();
-        let _n1: Ptr<i32> = n.as_pointer();
-        any_2(_arr, _n1)
-    }) as i32);
+    ({ fill_1(arr.as_pointer(), n.as_pointer()) });
+    return (({ any_2(arr.as_pointer(), n.as_pointer()) }) as i32);
 }

--- a/tests/ub/out/refcount/ub7.rs
+++ b/tests/ub/out/refcount/ub7.rs
@@ -26,8 +26,5 @@ fn main_0() -> i32 {
         ('n' as u8),
         ('g' as u8),
     ])));
-    return (({
-        let _s: Ptr<u8> = ((s.as_pointer() as Ptr<u8>).offset(0 as isize));
-        strlen_0(_s)
-    }) as i32);
+    return (({ strlen_0(((s.as_pointer() as Ptr<u8>).offset(0 as isize))) }) as i32);
 }

--- a/tests/ub/out/unsafe/dangling-prvalue-as-lvalue.rs
+++ b/tests/ub/out/unsafe/dangling-prvalue-as-lvalue.rs
@@ -16,10 +16,7 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut v: Vec<i32> = vec![1, 2];
-    let b: *const i32 = (unsafe {
-        let _a: *const i32 = &(*v.as_mut_ptr()) as *const i32;
-        foo_0(_a)
-    });
+    let b: *const i32 = (unsafe { foo_0(&(*v.as_mut_ptr()) as *const i32) });
     v.clear();
     return (*b);
 }

--- a/tests/ub/out/unsafe/ub12.rs
+++ b/tests/ub/out/unsafe/ub12.rs
@@ -16,10 +16,7 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut alloc: *mut i32 = (Box::leak(Box::new(1)) as *mut i32);
-    (unsafe {
-        let _ptr: *mut i32 = alloc;
-        escape_0(_ptr)
-    });
+    (unsafe { escape_0(alloc) });
     ::std::mem::drop(Box::from_raw(alloc));
     return 0;
 }

--- a/tests/ub/out/unsafe/ub13.rs
+++ b/tests/ub/out/unsafe/ub13.rs
@@ -16,9 +16,6 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut p1: *mut i32 = (Box::leak(Box::new(1)) as *mut i32);
-    (unsafe {
-        let _p: *mut i32 = p1;
-        escape_0(_p)
-    });
+    (unsafe { escape_0(p1) });
     return (*p1);
 }

--- a/tests/ub/out/unsafe/ub16.rs
+++ b/tests/ub/out/unsafe/ub16.rs
@@ -17,11 +17,8 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut p1: *mut i32 =
         Box::leak((0..10_usize).map(|_| 0_i32).collect::<Box<[i32]>>()).as_mut_ptr();
-    let mut out: i32 = (*(unsafe {
-        let _a: *mut i32 = (&mut (*p1.offset((1) as isize)) as *mut i32);
-        foo_0(_a)
-    })
-    .offset((4) as isize));
+    let mut out: i32 =
+        (*(unsafe { foo_0((&mut (*p1.offset((1) as isize)) as *mut i32)) }).offset((4) as isize));
 
     ::std::mem::drop(Box::from_raw(::std::slice::from_raw_parts_mut(
         p1,

--- a/tests/ub/out/unsafe/ub19.rs
+++ b/tests/ub/out/unsafe/ub19.rs
@@ -19,9 +19,6 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut x: *mut i32 = (Box::leak(Box::new(1)) as *mut i32);
-    (unsafe {
-        let _array: *mut i32 = x;
-        foo_0(_array)
-    });
+    (unsafe { foo_0(x) });
     return 0;
 }

--- a/tests/ub/out/unsafe/ub20.rs
+++ b/tests/ub/out/unsafe/ub20.rs
@@ -17,9 +17,6 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut x: *mut i32 =
         Box::leak((0..10_usize).map(|_| 0_i32).collect::<Box<[i32]>>()).as_mut_ptr();
-    (unsafe {
-        let _single: *mut i32 = x;
-        foo_0(_single)
-    });
+    (unsafe { foo_0(x) });
     return 0;
 }

--- a/tests/ub/out/unsafe/ub21.rs
+++ b/tests/ub/out/unsafe/ub21.rs
@@ -20,8 +20,5 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let s: [u8; 3] = [('s' as u8), ('t' as u8), ('r' as u8)];
-    return ((unsafe {
-        let _s: *const u8 = s.as_ptr();
-        strlen_0(_s)
-    }) as i32);
+    return ((unsafe { strlen_0(s.as_ptr()) }) as i32);
 }

--- a/tests/ub/out/unsafe/ub4.rs
+++ b/tests/ub/out/unsafe/ub4.rs
@@ -19,11 +19,7 @@ unsafe fn main_0() -> i32 {
     let mut x1: i32 = 1;
     if (x1 != 0) {
         let mut x2: i32 = -1_i32;
-        out = (unsafe {
-            let _x1: *mut i32 = &mut x1 as *mut i32;
-            let _x2: *mut i32 = &mut x2 as *mut i32;
-            smaller_0(_x1, _x2)
-        });
+        out = (unsafe { smaller_0(&mut x1 as *mut i32, &mut x2 as *mut i32) });
     }
     return (*out);
 }

--- a/tests/ub/out/unsafe/ub5.rs
+++ b/tests/ub/out/unsafe/ub5.rs
@@ -17,10 +17,7 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut x: i32 = 1;
     let mut p: *mut i32 = (&mut x as *mut i32);
-    (unsafe {
-        let _p: *mut *mut i32 = (&mut p as *mut *mut i32);
-        null_0(_p)
-    });
+    (unsafe { null_0((&mut p as *mut *mut i32)) });
     let r: *mut i32 = &mut (*p) as *mut i32;
     return (*r);
 }

--- a/tests/ub/out/unsafe/ub6.rs
+++ b/tests/ub/out/unsafe/ub6.rs
@@ -46,14 +46,7 @@ unsafe fn main_0() -> i32 {
             .map(|_| <*mut i32>::default())
             .collect::<Box<[_]>>(),
     );
-    (unsafe {
-        let _arr: *mut Option<Box<[*mut i32]>> = &mut arr as *mut Option<Box<[*mut i32]>>;
-        let _n1: *mut i32 = &mut n as *mut i32;
-        fill_1(_arr, _n1)
-    });
-    return ((unsafe {
-        let _arr: *mut Option<Box<[*mut i32]>> = &mut arr as *mut Option<Box<[*mut i32]>>;
-        let _n1: *mut i32 = &mut n as *mut i32;
-        any_2(_arr, _n1)
-    }) as i32);
+    (unsafe { fill_1(&mut arr as *mut Option<Box<[*mut i32]>>, &mut n as *mut i32) });
+    return ((unsafe { any_2(&mut arr as *mut Option<Box<[*mut i32]>>, &mut n as *mut i32) })
+        as i32);
 }

--- a/tests/ub/out/unsafe/ub7.rs
+++ b/tests/ub/out/unsafe/ub7.rs
@@ -27,8 +27,5 @@ unsafe fn main_0() -> i32 {
         ('n' as u8),
         ('g' as u8),
     ];
-    return ((unsafe {
-        let _s: *const u8 = (&s[(0) as usize] as *const u8);
-        strlen_0(_s)
-    }) as i32);
+    return ((unsafe { strlen_0((&s[(0) as usize] as *const u8)) }) as i32);
 }

--- a/tests/unit/out/refcount/07_unique.rs
+++ b/tests/unit/out/refcount/07_unique.rs
@@ -22,10 +22,7 @@ fn main_0() -> i32 {
     let f_ptr2: Value<Ptr<i32>> = Rc::new(RefCell::new(((*f.borrow()).as_pointer())));
     (*f_ptr2.borrow()).write(11);
     (*f.borrow_mut()) = Some(Rc::new(RefCell::new(9)));
-    let __rhs = ({
-        let _u: Option<Value<i32>> = (*f.borrow_mut()).take();
-        fn_0(_u)
-    });
+    let __rhs = ({ fn_0((*f.borrow_mut()).take()) });
     (*f.borrow_mut()) = __rhs;
     return (*(*f.borrow()).as_ref().unwrap().borrow());
 }

--- a/tests/unit/out/refcount/11_move.rs
+++ b/tests/unit/out/refcount/11_move.rs
@@ -16,9 +16,6 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let n: Value<Option<Value<i32>>> = Rc::new(RefCell::new(Some(Rc::new(RefCell::new(10)))));
-    ({
-        let _n: Ptr<Option<Value<i32>>> = n.as_pointer();
-        change_0(_n)
-    });
+    ({ change_0(n.as_pointer()) });
     return (*(*n.borrow()).as_ref().unwrap().borrow());
 }

--- a/tests/unit/out/refcount/alloc_array.rs
+++ b/tests/unit/out/refcount/alloc_array.rs
@@ -44,14 +44,6 @@ fn main_0() -> i32 {
             .map(|_| <i32>::default())
             .collect::<Box<[_]>>(),
     )))));
-    ({
-        let _arr: Ptr<Option<Value<Box<[i32]>>>> = arr.as_pointer();
-        let _N: i32 = (*N.borrow());
-        All_0(_arr, _N, 1)
-    });
-    return ({
-        let _arr: Option<Value<Box<[i32]>>> = (*arr.borrow_mut()).take();
-        let _N: i32 = (*N.borrow());
-        Consume_1(_arr, _N)
-    });
+    ({ All_0(arr.as_pointer(), (*N.borrow()), 1) });
+    return ({ Consume_1((*arr.borrow_mut()).take(), (*N.borrow())) });
 }

--- a/tests/unit/out/refcount/bst.rs
+++ b/tests/unit/out/refcount/bst.rs
@@ -32,9 +32,10 @@ pub fn find_0(node: Ptr<node_t>, value: i32) -> Ptr<node_t> {
     }) && (!((*(*(*node.borrow()).upgrade().deref()).left.borrow()).is_null()))
     {
         return ({
-            let _node: Ptr<node_t> = (*(*(*node.borrow()).upgrade().deref()).left.borrow()).clone();
-            let _value: i32 = (*value.borrow());
-            find_0(_node, _value)
+            find_0(
+                (*(*(*node.borrow()).upgrade().deref()).left.borrow()).clone(),
+                (*value.borrow()),
+            )
         });
     } else if ({
         let _lhs = (*value.borrow());
@@ -42,10 +43,10 @@ pub fn find_0(node: Ptr<node_t>, value: i32) -> Ptr<node_t> {
     }) && (!((*(*(*node.borrow()).upgrade().deref()).right.borrow()).is_null()))
     {
         return ({
-            let _node: Ptr<node_t> =
-                (*(*(*node.borrow()).upgrade().deref()).right.borrow()).clone();
-            let _value: i32 = (*value.borrow());
-            find_0(_node, _value)
+            find_0(
+                (*(*(*node.borrow()).upgrade().deref()).right.borrow()).clone(),
+                (*value.borrow()),
+            )
         });
     } else if {
         let _lhs = (*value.borrow());
@@ -66,9 +67,10 @@ pub fn insert_1(node: Ptr<node_t>, new_node: Ptr<node_t>) -> Ptr<node_t> {
         _lhs < (*(*(*node.borrow()).upgrade().deref()).value.borrow())
     } {
         let __rhs = ({
-            let _node: Ptr<node_t> = (*(*(*node.borrow()).upgrade().deref()).left.borrow()).clone();
-            let _new_node: Ptr<node_t> = (*new_node.borrow()).clone();
-            insert_1(_node, _new_node)
+            insert_1(
+                (*(*(*node.borrow()).upgrade().deref()).left.borrow()).clone(),
+                (*new_node.borrow()).clone(),
+            )
         });
         (*(*(*node.borrow()).upgrade().deref()).left.borrow_mut()) = __rhs;
     } else if {
@@ -76,10 +78,10 @@ pub fn insert_1(node: Ptr<node_t>, new_node: Ptr<node_t>) -> Ptr<node_t> {
         _lhs > (*(*(*node.borrow()).upgrade().deref()).value.borrow())
     } {
         let __rhs = ({
-            let _node: Ptr<node_t> =
-                (*(*(*node.borrow()).upgrade().deref()).right.borrow()).clone();
-            let _new_node: Ptr<node_t> = (*new_node.borrow()).clone();
-            insert_1(_node, _new_node)
+            insert_1(
+                (*(*(*node.borrow()).upgrade().deref()).right.borrow()).clone(),
+                (*new_node.borrow()).clone(),
+            )
         });
         (*(*(*node.borrow()).upgrade().deref()).right.borrow_mut()) = __rhs;
     }
@@ -120,78 +122,33 @@ fn main_0() -> i32 {
             value: Rc::new(RefCell::new(4)),
         })))));
     let ptr1: Value<Ptr<node_t>> = Rc::new(RefCell::new(((*tree.borrow()).as_pointer())));
-    let __rhs = ({
-        let _node: Ptr<node_t> = (*ptr1.borrow()).clone();
-        let _new_node: Ptr<node_t> = ((*n1.borrow()).as_pointer());
-        insert_1(_node, _new_node)
-    });
+    let __rhs = ({ insert_1((*ptr1.borrow()).clone(), ((*n1.borrow()).as_pointer())) });
     (*ptr1.borrow_mut()) = __rhs;
-    let __rhs = ({
-        let _node: Ptr<node_t> = (*ptr1.borrow()).clone();
-        let _new_node: Ptr<node_t> = ((*n2.borrow()).as_pointer());
-        insert_1(_node, _new_node)
-    });
+    let __rhs = ({ insert_1((*ptr1.borrow()).clone(), ((*n2.borrow()).as_pointer())) });
     (*ptr1.borrow_mut()) = __rhs;
-    let __rhs = ({
-        let _node: Ptr<node_t> = (*ptr1.borrow()).clone();
-        let _new_node: Ptr<node_t> = ((*n3.borrow()).as_pointer());
-        insert_1(_node, _new_node)
-    });
+    let __rhs = ({ insert_1((*ptr1.borrow()).clone(), ((*n3.borrow()).as_pointer())) });
     (*ptr1.borrow_mut()) = __rhs;
-    let __rhs = ({
-        let _node: Ptr<node_t> = (*ptr1.borrow()).clone();
-        let _new_node: Ptr<node_t> = ((*n4.borrow()).as_pointer());
-        insert_1(_node, _new_node)
-    });
+    let __rhs = ({ insert_1((*ptr1.borrow()).clone(), ((*n4.borrow()).as_pointer())) });
     (*ptr1.borrow_mut()) = __rhs;
-    return ((((((((*(*({
-        let _node: Ptr<node_t> = (*ptr1.borrow()).clone();
-        find_0(_node, 0)
-    })
-    .upgrade()
-    .deref())
-    .value
-    .borrow())
+    return ((((((((*(*({ find_0((*ptr1.borrow()).clone(), 0) }).upgrade().deref())
+        .value
+        .borrow())
         == 0)
-        && ((*(*({
-            let _node: Ptr<node_t> = (*ptr1.borrow()).clone();
-            find_0(_node, 1)
-        })
-        .upgrade()
-        .deref())
-        .value
-        .borrow())
+        && ((*(*({ find_0((*ptr1.borrow()).clone(), 1) }).upgrade().deref())
+            .value
+            .borrow())
             == 1))
-        && ((*(*({
-            let _node: Ptr<node_t> = (*ptr1.borrow()).clone();
-            find_0(_node, 2)
-        })
-        .upgrade()
-        .deref())
-        .value
-        .borrow())
+        && ((*(*({ find_0((*ptr1.borrow()).clone(), 2) }).upgrade().deref())
+            .value
+            .borrow())
             == 2))
-        && ((*(*({
-            let _node: Ptr<node_t> = (*ptr1.borrow()).clone();
-            find_0(_node, 3)
-        })
-        .upgrade()
-        .deref())
-        .value
-        .borrow())
+        && ((*(*({ find_0((*ptr1.borrow()).clone(), 3) }).upgrade().deref())
+            .value
+            .borrow())
             == 3))
-        && ((*(*({
-            let _node: Ptr<node_t> = (*ptr1.borrow()).clone();
-            find_0(_node, 4)
-        })
-        .upgrade()
-        .deref())
-        .value
-        .borrow())
+        && ((*(*({ find_0((*ptr1.borrow()).clone(), 4) }).upgrade().deref())
+            .value
+            .borrow())
             == 4))
-        && (({
-            let _node: Ptr<node_t> = (*ptr1.borrow()).clone();
-            find_0(_node, 5)
-        })
-        .is_null())) as i32);
+        && (({ find_0((*ptr1.borrow()).clone(), 5) }).is_null())) as i32);
 }

--- a/tests/unit/out/refcount/cast_array_to_pointer_decay.rs
+++ b/tests/unit/out/refcount/cast_array_to_pointer_decay.rs
@@ -29,11 +29,6 @@ fn main_0() -> i32 {
         ('c' as u8),
         ('\0' as u8),
     ])));
-    return (({
-        let _p: Ptr<i32> = (a.as_pointer() as Ptr<i32>);
-        deref_0(_p)
-    }) + ({
-        let _s: Ptr<u8> = (s.as_pointer() as Ptr<u8>);
-        strlen_1(_s)
-    }));
+    return (({ deref_0((a.as_pointer() as Ptr<i32>)) })
+        + ({ strlen_1((s.as_pointer() as Ptr<u8>)) }));
 }

--- a/tests/unit/out/refcount/class.rs
+++ b/tests/unit/out/refcount/class.rs
@@ -32,8 +32,7 @@ impl Pair {
         return (({ self.GetFirst() })
             + ({
                 let _field: Ptr<i32> = self.first.as_pointer();
-                let _new_val: i32 = (*new_first.borrow());
-                self.Set(_field, _new_val)
+                self.Set(_field, (*new_first.borrow()))
             }));
     }
     pub fn SetSecond(&self, new_second: i32) -> i32 {
@@ -41,8 +40,7 @@ impl Pair {
         return (({ self.GetSecond() })
             + ({
                 let _field: Ptr<i32> = self.second.as_pointer();
-                let _new_val: i32 = (*new_second.borrow());
-                self.Set(_field, _new_val)
+                self.Set(_field, (*new_second.borrow()))
             }));
     }
 }
@@ -98,10 +96,8 @@ pub fn RandomRoute_0(route: Ptr<Route>) -> i32 {
         });
     } else {
         return ({
-            let _new_second: i32 = ({
-                let _new_first: i32 = -10_i32;
-                (*(*route.upgrade().deref()).path.borrow()).SetFirst(_new_first)
-            });
+            let _new_second: i32 =
+                ({ (*(*route.upgrade().deref()).path.borrow()).SetFirst(-10_i32) });
             (*(*route.upgrade().deref()).path.borrow()).SetSecond(_new_second)
         });
     }
@@ -126,17 +122,9 @@ fn main_0() -> i32 {
         cost: Rc::new(RefCell::new(10_f64)),
     }));
     let old_cost: Value<f64> = Rc::new(RefCell::new(
-        ({
-            let _new_cost: f64 = ({ (*route2.borrow()).SetCost(15_f64) });
-            (*route1.borrow()).SetCost(_new_cost)
-        }),
+        ({ (*route1.borrow()).SetCost(({ (*route2.borrow()).SetCost(15_f64) })) }),
     ));
-    return ((((({
-        let _route: Ptr<Route> = route1.as_pointer();
-        RandomRoute_0(_route)
-    }) + ({
-        let _route: Ptr<Route> = route2.as_pointer();
-        RandomRoute_0(_route)
-    })) as f64)
+    return ((((({ RandomRoute_0(route1.as_pointer()) }) + ({ RandomRoute_0(route2.as_pointer()) }))
+        as f64)
         + (*old_cost.borrow())) as i32);
 }

--- a/tests/unit/out/refcount/complex_function.rs
+++ b/tests/unit/out/refcount/complex_function.rs
@@ -98,55 +98,21 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let x1: Value<i32> = Rc::new(RefCell::new(0));
-    let x2: Value<i32> = Rc::new(RefCell::new(
-        ({
-            let _x: i32 = (*x1.borrow());
-            foo_0(_x)
-        }),
-    ));
+    let x2: Value<i32> = Rc::new(RefCell::new(({ foo_0((*x1.borrow())) })));
     let x3: Value<i32> = Rc::new(RefCell::new(
-        ((({
-            let _x: i32 = (*x2.borrow());
-            foo_0(_x)
-        }) + ({
-            let _x: i32 = (*x1.borrow());
-            foo_0(_x)
-        })) + 1),
+        ((({ foo_0((*x2.borrow())) }) + ({ foo_0((*x1.borrow())) })) + 1),
     ));
     (*x2.borrow_mut()) += 1;
-    (*x2.borrow_mut()) += ({
-        let _x: i32 = (*x1.borrow());
-        foo_0(_x)
-    });
-    let __rhs = ((({
-        let _x: i32 = (*x2.borrow());
-        foo_0(_x)
-    }) + ({
-        let _x: i32 = (*x3.borrow());
-        foo_0(_x)
-    })) + 1);
+    (*x2.borrow_mut()) += ({ foo_0((*x1.borrow())) });
+    let __rhs = ((({ foo_0((*x2.borrow())) }) + ({ foo_0((*x3.borrow())) })) + 1);
     (*x3.borrow_mut()) += __rhs;
     let p1: Value<Ptr<i32>> = Rc::new(RefCell::new((x1.as_pointer())));
-    let p2: Value<Ptr<i32>> = Rc::new(RefCell::new(
-        ({
-            let _x: Ptr<i32> = (*p1.borrow()).clone();
-            ptr_1(_x)
-        }),
-    ));
+    let p2: Value<Ptr<i32>> = Rc::new(RefCell::new(({ ptr_1((*p1.borrow()).clone()) })));
     (*p1.borrow_mut()) = (*p2.borrow()).clone();
-    (*p2.borrow_mut()) = ({
-        let _x: Ptr<i32> = (*p1.borrow()).clone();
-        ptr_1(_x)
-    });
+    (*p2.borrow_mut()) = ({ ptr_1((*p1.borrow()).clone()) });
     let r1: Ptr<i32> = x1.as_pointer();
-    let r2: Ptr<i32> = ({
-        let _x: Ptr<i32> = x1.as_pointer();
-        bar_2(_x)
-    });
-    let r3: Ptr<i32> = ({
-        let _x: Ptr<i32> = (r1).clone();
-        bar_2(_x)
-    });
+    let r2: Ptr<i32> = ({ bar_2(x1.as_pointer()) });
+    let r3: Ptr<i32> = ({ bar_2((r1).clone()) });
     let __rhs = (*x1.borrow());
     {
         let _ptr = r2.clone();
@@ -158,19 +124,8 @@ fn main_0() -> i32 {
         _ptr.write(_ptr.read() + __rhs)
     };
     let x4: Value<i32> = Rc::new(RefCell::new(
-        ((({
-            let _x: i32 = (*x3.borrow());
-            foo_0(_x)
-        }) + (({
-            let _x: Ptr<i32> = (x3.as_pointer());
-            ptr_1(_x)
-        })
-        .read()))
-            + (({
-                let _x: Ptr<i32> = x2.as_pointer();
-                bar_2(_x)
-            })
-            .read())),
+        ((({ foo_0((*x3.borrow())) }) + (({ ptr_1((x3.as_pointer())) }).read()))
+            + (({ bar_2(x2.as_pointer()) }).read())),
     ));
     let a: Value<X1> = Rc::new(RefCell::new(X1 {
         v: Rc::new(RefCell::new(0)),
@@ -238,210 +193,174 @@ fn main_0() -> i32 {
         .borrow()),
     ));
     {
-        let _ptr = ({
-            let _x: Ptr<i32> = x1.as_pointer();
-            bar_2(_x)
-        })
-        .clone();
+        let _ptr = ({ bar_2(x1.as_pointer()) }).clone();
         _ptr.write(_ptr.read() + 10)
     };
-    ({
-        let _x: Ptr<i32> = x1.as_pointer();
-        bar_2(_x)
-    })
-    .with_mut(|__v| __v.postfix_inc());
+    ({ bar_2(x1.as_pointer()) }).with_mut(|__v| __v.postfix_inc());
     let bar_out: Value<i32> = Rc::new(RefCell::new(
         (({
-            let _x: Ptr<i32> = (*({
-                (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
-                    .upgrade()
-                    .deref())
-                .get()
-            })
-            .upgrade()
-            .deref())
-            .v
-            .as_pointer();
-            bar_2(_x)
+            bar_2(
+                (*({
+                    (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
+                        .upgrade()
+                        .deref())
+                    .get()
+                })
+                .upgrade()
+                .deref())
+                .v
+                .as_pointer(),
+            )
         })
         .read()),
     ));
     let bar_inc: Value<i32> = Rc::new(RefCell::new(
-        ({
-            let _x: Ptr<i32> = x1.as_pointer();
-            bar_2(_x)
-        })
-        .with_mut(|__v| __v.prefix_inc()),
+        ({ bar_2(x1.as_pointer()) }).with_mut(|__v| __v.prefix_inc()),
     ));
-    (*bar_inc.borrow_mut()) = ({
-        let _x: Ptr<i32> = x1.as_pointer();
-        bar_2(_x)
-    })
-    .with_mut(|__v| __v.postfix_inc());
-    (*bar_inc.borrow_mut()) = (((({
-        let _x: Ptr<i32> = x1.as_pointer();
-        bar_2(_x)
-    })
-    .read())
-        + ({
-            let _x: i32 = (*x4.borrow());
-            foo_0(_x)
-        }))
-        + 1);
+    (*bar_inc.borrow_mut()) = ({ bar_2(x1.as_pointer()) }).with_mut(|__v| __v.postfix_inc());
+    (*bar_inc.borrow_mut()) =
+        (((({ bar_2(x1.as_pointer()) }).read()) + ({ foo_0((*x4.borrow())) })) + 1);
     {
         let _ptr = ({
-            let _x: Ptr<i32> = (*({
-                (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
-                    .upgrade()
-                    .deref())
-                .get()
-            })
-            .upgrade()
-            .deref())
-            .v
-            .as_pointer();
-            bar_2(_x)
+            bar_2(
+                (*({
+                    (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
+                        .upgrade()
+                        .deref())
+                    .get()
+                })
+                .upgrade()
+                .deref())
+                .v
+                .as_pointer(),
+            )
         })
         .clone();
         _ptr.write(_ptr.read() + 10)
     };
     ({
-        let _x: Ptr<i32> = (*({
-            (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
-                .upgrade()
-                .deref())
-            .get()
-        })
-        .upgrade()
-        .deref())
-        .v
-        .as_pointer();
-        bar_2(_x)
+        bar_2(
+            (*({
+                (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
+                    .upgrade()
+                    .deref())
+                .get()
+            })
+            .upgrade()
+            .deref())
+            .v
+            .as_pointer(),
+        )
     })
     .with_mut(|__v| __v.postfix_inc());
     let bar_inc2: Value<i32> = Rc::new(RefCell::new(
         ({
-            let _x: Ptr<i32> = (*({
-                (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
-                    .upgrade()
-                    .deref())
-                .get()
-            })
-            .upgrade()
-            .deref())
-            .v
-            .as_pointer();
-            bar_2(_x)
+            bar_2(
+                (*({
+                    (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
+                        .upgrade()
+                        .deref())
+                    .get()
+                })
+                .upgrade()
+                .deref())
+                .v
+                .as_pointer(),
+            )
         })
         .with_mut(|__v| __v.prefix_inc()),
     ));
     (*bar_inc2.borrow_mut()) = ({
-        let _x: Ptr<i32> = (*({
-            (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
-                .upgrade()
-                .deref())
-            .get()
-        })
-        .upgrade()
-        .deref())
-        .v
-        .as_pointer();
-        bar_2(_x)
+        bar_2(
+            (*({
+                (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
+                    .upgrade()
+                    .deref())
+                .get()
+            })
+            .upgrade()
+            .deref())
+            .v
+            .as_pointer(),
+        )
     })
     .with_mut(|__v| __v.postfix_inc());
+    ({ ptr_1((x1.as_pointer())) }).with_mut(|__v| __v.prefix_inc());
+    {
+        let _ptr = ({ ptr_1((x1.as_pointer())) }).clone();
+        _ptr.write(_ptr.read() + 1)
+    };
     ({
-        let _x: Ptr<i32> = (x1.as_pointer());
-        ptr_1(_x)
+        ptr_1(
+            ((*({
+                (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
+                    .upgrade()
+                    .deref())
+                .get()
+            })
+            .upgrade()
+            .deref())
+            .v
+            .as_pointer()),
+        )
     })
     .with_mut(|__v| __v.prefix_inc());
     {
         let _ptr = ({
-            let _x: Ptr<i32> = (x1.as_pointer());
-            ptr_1(_x)
-        })
-        .clone();
-        _ptr.write(_ptr.read() + 1)
-    };
-    ({
-        let _x: Ptr<i32> = ((*({
-            (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
+            ptr_1(
+                ((*({
+                    (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
+                        .upgrade()
+                        .deref())
+                    .get()
+                })
                 .upgrade()
                 .deref())
-            .get()
-        })
-        .upgrade()
-        .deref())
-        .v
-        .as_pointer());
-        ptr_1(_x)
-    })
-    .with_mut(|__v| __v.prefix_inc());
-    {
-        let _ptr = ({
-            let _x: Ptr<i32> = ((*({
-                (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
-                    .upgrade()
-                    .deref())
-                .get()
-            })
-            .upgrade()
-            .deref())
-            .v
-            .as_pointer());
-            ptr_1(_x)
+                .v
+                .as_pointer()),
+            )
         })
         .clone();
         _ptr.write(_ptr.read() + 1)
     };
     {
         let _ptr = ({
-            let _x: Ptr<i32> = ((*({
-                (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
-                    .upgrade()
-                    .deref())
-                .get()
-            })
-            .upgrade()
-            .deref())
-            .v
-            .as_pointer());
-            ptr_1(_x)
+            ptr_1(
+                ((*({
+                    (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
+                        .upgrade()
+                        .deref())
+                    .get()
+                })
+                .upgrade()
+                .deref())
+                .v
+                .as_pointer()),
+            )
         })
         .clone();
         _ptr.write(_ptr.read() + 1)
     };
     let ptr1: Value<i32> = Rc::new(RefCell::new(
         ({
-            let _x: Ptr<i32> = ((*({
-                (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
-                    .upgrade()
-                    .deref())
-                .get()
-            })
-            .upgrade()
-            .deref())
-            .v
-            .as_pointer());
-            ptr_1(_x)
+            ptr_1(
+                ((*({
+                    (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
+                        .upgrade()
+                        .deref())
+                    .get()
+                })
+                .upgrade()
+                .deref())
+                .v
+                .as_pointer()),
+            )
         })
         .with_mut(|__v| __v.postfix_inc()),
     ));
     let ptr2: Ptr<i32> = ({
-        let _x: Ptr<i32> = ((*({
-            (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
-                .upgrade()
-                .deref())
-            .get()
-        })
-        .upgrade()
-        .deref())
-        .v
-        .as_pointer());
-        ptr_1(_x)
-    });
-    let ptr3: Value<Ptr<i32>> = Rc::new(RefCell::new(
-        ({
-            let _x: Ptr<i32> = ((*({
+        ptr_1(
+            ((*({
                 (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
                     .upgrade()
                     .deref())
@@ -450,94 +369,115 @@ fn main_0() -> i32 {
             .upgrade()
             .deref())
             .v
-            .as_pointer());
-            ptr_1(_x)
+            .as_pointer()),
+        )
+    });
+    let ptr3: Value<Ptr<i32>> = Rc::new(RefCell::new(
+        ({
+            ptr_1(
+                ((*({
+                    (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
+                        .upgrade()
+                        .deref())
+                    .get()
+                })
+                .upgrade()
+                .deref())
+                .v
+                .as_pointer()),
+            )
         }),
     ));
     let vptr: Value<i32> = Rc::new(RefCell::new(
         (({
-            let _x: Ptr<i32> = ((*({
-                (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
-                    .upgrade()
-                    .deref())
-                .get()
-            })
-            .upgrade()
-            .deref())
-            .v
-            .as_pointer());
-            ptr_1(_x)
+            ptr_1(
+                ((*({
+                    (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
+                        .upgrade()
+                        .deref())
+                    .get()
+                })
+                .upgrade()
+                .deref())
+                .v
+                .as_pointer()),
+            )
         })
         .read()),
     ));
     let pref: Value<Ptr<i32>> = Rc::new(RefCell::new(
         ({
-            let _x: Ptr<i32> = (*({
-                (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
-                    .upgrade()
-                    .deref())
-                .get()
-            })
-            .upgrade()
-            .deref())
-            .v
-            .as_pointer();
-            bar_2(_x)
+            bar_2(
+                (*({
+                    (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
+                        .upgrade()
+                        .deref())
+                    .get()
+                })
+                .upgrade()
+                .deref())
+                .v
+                .as_pointer(),
+            )
         }),
     ));
     ({
-        let _x: Ptr<i32> = (*({
-            (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
-                .upgrade()
-                .deref())
-            .get()
-        })
-        .upgrade()
-        .deref())
-        .v
-        .as_pointer();
-        bar_2(_x)
+        bar_2(
+            (*({
+                (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
+                    .upgrade()
+                    .deref())
+                .get()
+            })
+            .upgrade()
+            .deref())
+            .v
+            .as_pointer(),
+        )
     })
     .with_mut(|__v| __v.postfix_inc());
     return (((({
-        let _x: Ptr<i32> = ((*({
-            (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
-                .upgrade()
-                .deref())
-            .get()
-        })
-        .upgrade()
-        .deref())
-        .v
-        .as_pointer());
-        ptr_1(_x)
+        ptr_1(
+            ((*({
+                (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
+                    .upgrade()
+                    .deref())
+                .get()
+            })
+            .upgrade()
+            .deref())
+            .v
+            .as_pointer()),
+        )
     })
     .read())
         + (({
-            let _x: Ptr<i32> = (*({
-                (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
-                    .upgrade()
-                    .deref())
-                .get()
-            })
-            .upgrade()
-            .deref())
-            .v
-            .as_pointer();
-            bar_2(_x)
+            bar_2(
+                (*({
+                    (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
+                        .upgrade()
+                        .deref())
+                    .get()
+                })
+                .upgrade()
+                .deref())
+                .v
+                .as_pointer(),
+            )
         })
         .read()))
         + ({
-            let _x: i32 = (*(*({
-                (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
-                    .upgrade()
-                    .deref())
-                .get()
-            })
-            .upgrade()
-            .deref())
-            .v
-            .borrow());
-            foo_0(_x)
+            foo_0(
+                (*(*({
+                    (*({ (*({ (*d.borrow()).get() }).upgrade().deref()).get() })
+                        .upgrade()
+                        .deref())
+                    .get()
+                })
+                .upgrade()
+                .deref())
+                .v
+                .borrow()),
+            )
         }));
 }

--- a/tests/unit/out/refcount/doubly_linked_list.rs
+++ b/tests/unit/out/refcount/doubly_linked_list.rs
@@ -63,10 +63,7 @@ pub fn Append_2(head: Ptr<Node>, new_node: Ptr<Node>) {
         let __rhs = (*(*(*curr.borrow()).upgrade().deref()).next.borrow()).clone();
         (*curr.borrow_mut()) = __rhs;
     }
-    ({
-        let _n: Ptr<Node> = (new_node).clone();
-        (*(*curr.borrow()).upgrade().deref()).SetNext(_n)
-    });
+    ({ (*(*curr.borrow()).upgrade().deref()).SetNext((new_node).clone()) });
     ({
         let _p: Ptr<Node> = (*curr.borrow()).clone();
         (*new_node.upgrade().deref()).SetPrev(_p)
@@ -195,161 +192,94 @@ fn main_0() -> i32 {
         let _new_node: Ptr<Node> = n7.as_pointer();
         Append_2(_head, _new_node)
     });
-    let __rhs = ({
-        let _head: Ptr<Node> = (*head.borrow()).clone();
-        Delete_3(_head, 5)
-    });
+    let __rhs = ({ Delete_3((*head.borrow()).clone(), 5) });
     (*head.borrow_mut()) = __rhs;
-    let __rhs = ({
-        let _head: Ptr<Node> = (*head.borrow()).clone();
-        Delete_3(_head, 0)
-    });
+    let __rhs = ({ Delete_3((*head.borrow()).clone(), 0) });
     (*head.borrow_mut()) = __rhs;
-    let __rhs = ({
-        let _head: Ptr<Node> = (*head.borrow()).clone();
-        let _val: i32 = -2_i32;
-        Delete_3(_head, _val)
-    });
+    let __rhs = ({ Delete_3((*head.borrow()).clone(), -2_i32) });
     (*head.borrow_mut()) = __rhs;
-    let tail: Value<Ptr<Node>> = Rc::new(RefCell::new(
-        ({
-            let _head: Ptr<Node> = (*head.borrow()).clone();
-            Tail_4(_head)
-        }),
-    ));
+    let tail: Value<Ptr<Node>> = Rc::new(RefCell::new(({ Tail_4((*head.borrow()).clone()) })));
     assert!(
-        ((*(*({
-            let _head: Ptr<Node> = (*head.borrow()).clone();
-            Find_0(_head, 0)
-        })
-        .upgrade()
-        .deref())
-        .val
-        .borrow())
+        ((*(*({ Find_0((*head.borrow()).clone(), 0,) }).upgrade().deref())
+            .val
+            .borrow())
             == 4)
     );
     assert!(
-        ((*(*({
-            let _head: Ptr<Node> = (*head.borrow()).clone();
-            Find_0(_head, 1)
-        })
-        .upgrade()
-        .deref())
-        .val
-        .borrow())
+        ((*(*({ Find_0((*head.borrow()).clone(), 1,) }).upgrade().deref())
+            .val
+            .borrow())
             == 3)
     );
     assert!(
-        ((*(*({
-            let _head: Ptr<Node> = (*head.borrow()).clone();
-            Find_0(_head, 2)
-        })
-        .upgrade()
-        .deref())
-        .val
-        .borrow())
+        ((*(*({ Find_0((*head.borrow()).clone(), 2,) }).upgrade().deref())
+            .val
+            .borrow())
             == 2)
     );
     assert!(
-        ((*(*({
-            let _head: Ptr<Node> = (*head.borrow()).clone();
-            Find_0(_head, 3)
-        })
-        .upgrade()
-        .deref())
-        .val
-        .borrow())
+        ((*(*({ Find_0((*head.borrow()).clone(), 3,) }).upgrade().deref())
+            .val
+            .borrow())
             == 1)
     );
     assert!(
-        ((*(*({
-            let _head: Ptr<Node> = (*head.borrow()).clone();
-            Find_0(_head, 4)
-        })
-        .upgrade()
-        .deref())
-        .val
-        .borrow())
+        ((*(*({ Find_0((*head.borrow()).clone(), 4,) }).upgrade().deref())
+            .val
+            .borrow())
             == -1_i32)
     );
-    assert!(({
-        let _head: Ptr<Node> = (*head.borrow()).clone();
-        Find_0(_head, 5)
-    })
-    .is_null());
+    assert!(({ Find_0((*head.borrow()).clone(), 5,) }).is_null());
     assert!(
-        ((*(*({
-            let _tail: Ptr<Node> = (*tail.borrow()).clone();
-            FindBack_1(_tail, 0)
-        })
-        .upgrade()
-        .deref())
+        ((*(*({ FindBack_1((*tail.borrow()).clone(), 0,) })
+            .upgrade()
+            .deref())
         .val
         .borrow())
             == -1_i32)
     );
     assert!(
-        ((*(*({
-            let _tail: Ptr<Node> = (*tail.borrow()).clone();
-            FindBack_1(_tail, 1)
-        })
-        .upgrade()
-        .deref())
+        ((*(*({ FindBack_1((*tail.borrow()).clone(), 1,) })
+            .upgrade()
+            .deref())
         .val
         .borrow())
             == 1)
     );
     assert!(
-        ((*(*({
-            let _tail: Ptr<Node> = (*tail.borrow()).clone();
-            FindBack_1(_tail, 2)
-        })
-        .upgrade()
-        .deref())
+        ((*(*({ FindBack_1((*tail.borrow()).clone(), 2,) })
+            .upgrade()
+            .deref())
         .val
         .borrow())
             == 2)
     );
     assert!(
-        ((*(*({
-            let _tail: Ptr<Node> = (*tail.borrow()).clone();
-            FindBack_1(_tail, 3)
-        })
-        .upgrade()
-        .deref())
+        ((*(*({ FindBack_1((*tail.borrow()).clone(), 3,) })
+            .upgrade()
+            .deref())
         .val
         .borrow())
             == 3)
     );
     assert!(
-        ((*(*({
-            let _tail: Ptr<Node> = (*tail.borrow()).clone();
-            FindBack_1(_tail, 4)
-        })
-        .upgrade()
-        .deref())
+        ((*(*({ FindBack_1((*tail.borrow()).clone(), 4,) })
+            .upgrade()
+            .deref())
         .val
         .borrow())
             == 4)
     );
-    assert!((*(*({
-        let _tail: Ptr<Node> = (*tail.borrow()).clone();
-        FindBack_1(_tail, 4)
-    })
-    .upgrade()
-    .deref())
+    assert!((*(*({ FindBack_1((*tail.borrow()).clone(), 4,) })
+        .upgrade()
+        .deref())
     .prev
     .borrow())
     .is_null());
     assert!(
-        ((*(*(*(*({
-            let _head: Ptr<Node> = (*head.borrow()).clone();
-            Find_0(_head, 0)
-        })
-        .upgrade()
-        .deref())
-        .next
-        .borrow())
+        ((*(*(*(*({ Find_0((*head.borrow()).clone(), 0,) }).upgrade().deref())
+            .next
+            .borrow())
         .upgrade()
         .deref())
         .val
@@ -357,14 +287,9 @@ fn main_0() -> i32 {
             == 3)
     );
     assert!(
-        ((*(*(*(*(*(*({
-            let _head: Ptr<Node> = (*head.borrow()).clone();
-            Find_0(_head, 1)
-        })
-        .upgrade()
-        .deref())
-        .next
-        .borrow())
+        ((*(*(*(*(*(*({ Find_0((*head.borrow()).clone(), 1,) }).upgrade().deref())
+            .next
+            .borrow())
         .upgrade()
         .deref())
         .next
@@ -376,36 +301,25 @@ fn main_0() -> i32 {
             == 1)
     );
     assert!(
-        ((*(*(*(*({
-            let _head: Ptr<Node> = (*head.borrow()).clone();
-            Find_0(_head, 2)
-        })
-        .upgrade()
-        .deref())
-        .prev
-        .borrow())
+        ((*(*(*(*({ Find_0((*head.borrow()).clone(), 2,) }).upgrade().deref())
+            .prev
+            .borrow())
         .upgrade()
         .deref())
         .val
         .borrow())
             == 3)
     );
-    assert!((*(*({
-        let _head: Ptr<Node> = (*head.borrow()).clone();
-        Find_0(_head, 4)
-    })
-    .upgrade()
-    .deref())
-    .next
-    .borrow())
-    .is_null());
     assert!(
-        ((*(*(*(*(*(*({
-            let _tail: Ptr<Node> = (*tail.borrow()).clone();
-            FindBack_1(_tail, 1)
-        })
-        .upgrade()
-        .deref())
+        (*(*({ Find_0((*head.borrow()).clone(), 4,) }).upgrade().deref())
+            .next
+            .borrow())
+        .is_null()
+    );
+    assert!(
+        ((*(*(*(*(*(*({ FindBack_1((*tail.borrow()).clone(), 1,) })
+            .upgrade()
+            .deref())
         .prev
         .borrow())
         .upgrade()
@@ -418,169 +332,90 @@ fn main_0() -> i32 {
         .borrow())
             == 3)
     );
-    (*(*(*(*({
-        let _head: Ptr<Node> = (*head.borrow()).clone();
-        Find_0(_head, 0)
-    })
-    .upgrade()
-    .deref())
-    .next
-    .borrow())
+    (*(*(*(*({ Find_0((*head.borrow()).clone(), 0) }).upgrade().deref())
+        .next
+        .borrow())
     .upgrade()
     .deref())
     .val
     .borrow_mut()) = 30;
     assert!(
-        ((*(*({
-            let _head: Ptr<Node> = (*head.borrow()).clone();
-            Find_0(_head, 1)
-        })
-        .upgrade()
-        .deref())
-        .val
-        .borrow())
+        ((*(*({ Find_0((*head.borrow()).clone(), 1,) }).upgrade().deref())
+            .val
+            .borrow())
             == 30)
     );
-    let __rhs = ((*(*({
-        let _head: Ptr<Node> = (*head.borrow()).clone();
-        Find_0(_head, 0)
-    })
-    .upgrade()
-    .deref())
-    .val
-    .borrow())
-        + (*(*({
-            let _head: Ptr<Node> = (*head.borrow()).clone();
-            Find_0(_head, 3)
-        })
-        .upgrade()
-        .deref())
+    let __rhs = ((*(*({ Find_0((*head.borrow()).clone(), 0) }).upgrade().deref())
         .val
-        .borrow()));
-    (*(*(*(*({
-        let _head: Ptr<Node> = (*head.borrow()).clone();
-        Find_0(_head, 1)
-    })
-    .upgrade()
-    .deref())
-    .next
-    .borrow())
+        .borrow())
+        + (*(*({ Find_0((*head.borrow()).clone(), 3) }).upgrade().deref())
+            .val
+            .borrow()));
+    (*(*(*(*({ Find_0((*head.borrow()).clone(), 1) }).upgrade().deref())
+        .next
+        .borrow())
     .upgrade()
     .deref())
     .val
     .borrow_mut()) = __rhs;
     assert!(
-        ((*(*({
-            let _head: Ptr<Node> = (*head.borrow()).clone();
-            Find_0(_head, 2)
-        })
-        .upgrade()
-        .deref())
-        .val
-        .borrow())
+        ((*(*({ Find_0((*head.borrow()).clone(), 2,) }).upgrade().deref())
+            .val
+            .borrow())
             == (4 + 1))
     );
     let sum: Value<i32> = Rc::new(RefCell::new(
-        (((((*(*({
-            let _head: Ptr<Node> = (*head.borrow()).clone();
-            Find_0(_head, 0)
-        })
-        .upgrade()
-        .deref())
-        .val
-        .borrow())
-            + (*(*({
-                let _head: Ptr<Node> = (*head.borrow()).clone();
-                Find_0(_head, 1)
-            })
-            .upgrade()
-            .deref())
+        (((((*(*({ Find_0((*head.borrow()).clone(), 0) }).upgrade().deref())
             .val
-            .borrow()))
-            + (*(*({
-                let _head: Ptr<Node> = (*head.borrow()).clone();
-                Find_0(_head, 2)
-            })
-            .upgrade()
-            .deref())
-            .val
-            .borrow()))
-            + (*(*({
-                let _head: Ptr<Node> = (*head.borrow()).clone();
-                Find_0(_head, 3)
-            })
-            .upgrade()
-            .deref())
-            .val
-            .borrow()))
-            + (*(*({
-                let _head: Ptr<Node> = (*head.borrow()).clone();
-                Find_0(_head, 4)
-            })
-            .upgrade()
-            .deref())
-            .val
-            .borrow())),
+            .borrow())
+            + (*(*({ Find_0((*head.borrow()).clone(), 1) }).upgrade().deref())
+                .val
+                .borrow()))
+            + (*(*({ Find_0((*head.borrow()).clone(), 2) }).upgrade().deref())
+                .val
+                .borrow()))
+            + (*(*({ Find_0((*head.borrow()).clone(), 3) }).upgrade().deref())
+                .val
+                .borrow()))
+            + (*(*({ Find_0((*head.borrow()).clone(), 4) }).upgrade().deref())
+                .val
+                .borrow())),
     ));
     assert!(((*sum.borrow()) == ((((4 + 30) + 5) + 1) + -1_i32)));
     assert!(
         ({
-            let _lhs = (*(*({
-                let _head: Ptr<Node> = (*head.borrow()).clone();
-                Find_0(_head, 0)
-            })
-            .upgrade()
-            .deref())
-            .val
-            .borrow());
-            _lhs + (*(*({
-                let _tail: Ptr<Node> = (*tail.borrow()).clone();
-                FindBack_1(_tail, 0)
-            })
-            .upgrade()
-            .deref())
+            let _lhs = (*(*({ Find_0((*head.borrow()).clone(), 0) }).upgrade().deref())
+                .val
+                .borrow());
+            _lhs + (*(*({ FindBack_1((*tail.borrow()).clone(), 0) })
+                .upgrade()
+                .deref())
             .val
             .borrow())
         } == (4 + -1_i32))
     );
     assert!({
-        let _lhs = (*(*(*(*({
-            let _head: Ptr<Node> = (*head.borrow()).clone();
-            Find_0(_head, 2)
-        })
-        .upgrade()
-        .deref())
-        .next
-        .borrow())
+        let _lhs = (*(*(*(*({ Find_0((*head.borrow()).clone(), 2) }).upgrade().deref())
+            .next
+            .borrow())
         .upgrade()
         .deref())
         .val
         .borrow());
-        _lhs == (*(*({
-            let _tail: Ptr<Node> = (*tail.borrow()).clone();
-            FindBack_1(_tail, 1)
-        })
-        .upgrade()
-        .deref())
+        _lhs == (*(*({ FindBack_1((*tail.borrow()).clone(), 1) })
+            .upgrade()
+            .deref())
         .val
         .borrow())
     });
     assert!({
-        let _lhs = (*(*({
-            let _head: Ptr<Node> = (*head.borrow()).clone();
-            Find_0(_head, 0)
-        })
-        .upgrade()
-        .deref())
-        .prev
-        .borrow())
+        let _lhs = (*(*({ Find_0((*head.borrow()).clone(), 0) }).upgrade().deref())
+            .prev
+            .borrow())
         .clone();
-        _lhs == (*(*({
-            let _tail: Ptr<Node> = (*tail.borrow()).clone();
-            FindBack_1(_tail, 4)
-        })
-        .upgrade()
-        .deref())
+        _lhs == (*(*({ FindBack_1((*tail.borrow()).clone(), 4) })
+            .upgrade()
+            .deref())
         .prev
         .borrow())
         .clone()

--- a/tests/unit/out/refcount/enum_int_interop.rs
+++ b/tests/unit/out/refcount/enum_int_interop.rs
@@ -186,18 +186,12 @@ fn main_0() -> i32 {
     (*o.borrow_mut()) = Option::from(20);
     assert!((((*o.borrow()) as i32) == (Option::OPT_B as i32)));
     let rc: Value<i32> = Rc::new(RefCell::new(
-        ({
-            let _option: i32 = ((*o.borrow()) as i32).clone();
-            classify_option_5(_option)
-        }),
+        ({ classify_option_5(((*o.borrow()) as i32).clone()) }),
     ));
     assert!(((*rc.borrow()) == 2));
     (*rc.borrow_mut()) = ({ classify_option_5(20) });
     assert!(((*rc.borrow()) == 2));
-    (*rc.borrow_mut()) = ({
-        let _option: i32 = (Option::OPT_C as i32);
-        classify_option_5(_option)
-    });
+    (*rc.borrow_mut()) = ({ classify_option_5((Option::OPT_C as i32)) });
     assert!(((*rc.borrow()) == 3));
     let t: Value<Tag> = Rc::new(RefCell::new(Tag::TAG_ONE));
     assert!((((*t.borrow()) as i32) == 1));

--- a/tests/unit/out/refcount/enum_int_interop_c.rs
+++ b/tests/unit/out/refcount/enum_int_interop_c.rs
@@ -180,18 +180,12 @@ fn main_0() -> i32 {
     (*o.borrow_mut()) = Option::from(20);
     assert!((((((*o.borrow()) as u32) == ((Option::OPT_B as i32) as u32)) as i32) != 0));
     let rc: Value<i32> = Rc::new(RefCell::new(
-        ({
-            let _option: i32 = ((*o.borrow()) as i32).clone();
-            classify_option_5(_option)
-        }),
+        ({ classify_option_5(((*o.borrow()) as i32).clone()) }),
     ));
     assert!(((((*rc.borrow()) == 2) as i32) != 0));
     (*rc.borrow_mut()) = ({ classify_option_5(20) });
     assert!(((((*rc.borrow()) == 2) as i32) != 0));
-    (*rc.borrow_mut()) = ({
-        let _option: i32 = (Option::OPT_C as i32);
-        classify_option_5(_option)
-    });
+    (*rc.borrow_mut()) = ({ classify_option_5((Option::OPT_C as i32)) });
     assert!(((((*rc.borrow()) == 3) as i32) != 0));
     let t: Value<Tag_enum> = Rc::new(RefCell::new(Tag_enum::TAG_ONE));
     assert!((((((*t.borrow()) as u32) == 1_u32) as i32) != 0));

--- a/tests/unit/out/refcount/expr_as_bool_c.rs
+++ b/tests/unit/out/refcount/expr_as_bool_c.rs
@@ -81,45 +81,13 @@ fn main_0() -> i32 {
     ));
     assert!(((((*either.borrow()) == 1) as i32) != 0));
     assert!(((((*both.borrow()) == 0) as i32) != 0));
-    assert!(
-        (((({
-            let _rc: i32 = -1_i32;
-            cmp_eq_0(_rc)
-        }) == 1) as i32)
-            != 0)
-    );
+    assert!((((({ cmp_eq_0(-1_i32,) }) == 1) as i32) != 0));
     assert!((((({ cmp_eq_0(0,) }) == 0) as i32) != 0));
     assert!(
-        (((({
-            let _p: Ptr<u8> = (*p1.borrow()).clone();
-            let _q: Ptr<u8> = (*p2.borrow()).clone();
-            cmp_or_ptr_1(_p, _q)
-        }) == 1) as i32)
-            != 0)
+        (((({ cmp_or_ptr_1((*p1.borrow()).clone(), (*p2.borrow()).clone(),) }) == 1) as i32) != 0)
     );
-    assert!(
-        (((({
-            let _p: Ptr<u8> = Ptr::<u8>::null();
-            let _q: Ptr<u8> = Ptr::<u8>::null();
-            cmp_or_ptr_1(_p, _q)
-        }) == 0) as i32)
-            != 0)
-    );
-    assert!(
-        (((({
-            let _s1: Ptr<u8> = Ptr::<u8>::null();
-            let _s2: Ptr<u8> = Ptr::<u8>::null();
-            both_null_2(_s1, _s2)
-        }) == 1) as i32)
-            != 0)
-    );
-    assert!(
-        (((({
-            let _s1: Ptr<u8> = (*p1.borrow()).clone();
-            let _s2: Ptr<u8> = Ptr::<u8>::null();
-            both_null_2(_s1, _s2)
-        }) == 0) as i32)
-            != 0)
-    );
+    assert!((((({ cmp_or_ptr_1(Ptr::<u8>::null(), Ptr::<u8>::null(),) }) == 0) as i32) != 0));
+    assert!((((({ both_null_2(Ptr::<u8>::null(), Ptr::<u8>::null(),) }) == 1) as i32) != 0));
+    assert!((((({ both_null_2((*p1.borrow()).clone(), Ptr::<u8>::null(),) }) == 0) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/refcount/expr_as_bool_cpp.rs
+++ b/tests/unit/out/refcount/expr_as_bool_cpp.rs
@@ -76,40 +76,11 @@ fn main_0() -> i32 {
     ));
     assert!(((*either.borrow()) == 1));
     assert!(((*both.borrow()) == 0));
-    assert!(
-        (({
-            let _rc: i32 = -1_i32;
-            cmp_eq_0(_rc)
-        }) == 1)
-    );
+    assert!((({ cmp_eq_0(-1_i32,) }) == 1));
     assert!((({ cmp_eq_0(0,) }) == 0));
-    assert!(
-        (({
-            let _p: Ptr<u8> = (*p1.borrow()).clone();
-            let _q: Ptr<u8> = (*p2.borrow()).clone();
-            cmp_or_ptr_1(_p, _q)
-        }) == 1)
-    );
-    assert!(
-        (({
-            let _p: Ptr<u8> = Ptr::<u8>::null();
-            let _q: Ptr<u8> = Ptr::<u8>::null();
-            cmp_or_ptr_1(_p, _q)
-        }) == 0)
-    );
-    assert!(
-        (({
-            let _s1: Ptr<u8> = Ptr::<u8>::null();
-            let _s2: Ptr<u8> = Ptr::<u8>::null();
-            both_null_2(_s1, _s2)
-        }) == 1)
-    );
-    assert!(
-        (({
-            let _s1: Ptr<u8> = (*p1.borrow()).clone();
-            let _s2: Ptr<u8> = Ptr::<u8>::null();
-            both_null_2(_s1, _s2)
-        }) == 0)
-    );
+    assert!((({ cmp_or_ptr_1((*p1.borrow()).clone(), (*p2.borrow()).clone(),) }) == 1));
+    assert!((({ cmp_or_ptr_1(Ptr::<u8>::null(), Ptr::<u8>::null(),) }) == 0));
+    assert!((({ both_null_2(Ptr::<u8>::null(), Ptr::<u8>::null(),) }) == 1));
+    assert!((({ both_null_2((*p1.borrow()).clone(), Ptr::<u8>::null(),) }) == 0));
     return 0;
 }

--- a/tests/unit/out/refcount/fatorial.rs
+++ b/tests/unit/out/refcount/fatorial.rs
@@ -11,11 +11,7 @@ pub fn fatorial_0(n: i32) -> i32 {
     if ((*n.borrow()) == 0) {
         return 1;
     }
-    return ((*n.borrow())
-        * ({
-            let _n: i32 = ((*n.borrow()) - 1);
-            fatorial_0(_n)
-        }));
+    return ((*n.borrow()) * ({ fatorial_0(((*n.borrow()) - 1)) }));
 }
 pub fn fatorial_by_ref_1(n: Ptr<i32>) {
     if ((n.read()) == 1) {
@@ -26,10 +22,7 @@ pub fn fatorial_by_ref_1(n: Ptr<i32>) {
         return;
     }
     let n_1: Value<i32> = Rc::new(RefCell::new(((n.read()) - 1)));
-    ({
-        let _n: Ptr<i32> = n_1.as_pointer();
-        fatorial_by_ref_1(_n)
-    });
+    ({ fatorial_by_ref_1(n_1.as_pointer()) });
     let __rhs = (*n_1.borrow());
     {
         let _ptr = n.clone();
@@ -46,10 +39,7 @@ pub fn fatorial_by_ptr_2(n: Ptr<i32>) {
         return;
     }
     let n_1: Value<i32> = Rc::new(RefCell::new((((*n.borrow()).read()) - 1)));
-    ({
-        let _n: Ptr<i32> = (n_1.as_pointer());
-        fatorial_by_ptr_2(_n)
-    });
+    ({ fatorial_by_ptr_2((n_1.as_pointer())) });
     let __rhs = (*n_1.borrow());
     {
         let _ptr = (*n.borrow()).clone();
@@ -61,17 +51,8 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let n1: Value<i32> = Rc::new(RefCell::new(2));
-    ({
-        let _n: Ptr<i32> = (n1.as_pointer());
-        fatorial_by_ptr_2(_n)
-    });
+    ({ fatorial_by_ptr_2((n1.as_pointer())) });
     let n: Value<i32> = Rc::new(RefCell::new(((*n1.borrow()) + 1)));
-    ({
-        let _n: Ptr<i32> = n.as_pointer();
-        fatorial_by_ref_1(_n)
-    });
-    return ({
-        let _n: i32 = (*n.borrow());
-        fatorial_0(_n)
-    });
+    ({ fatorial_by_ref_1(n.as_pointer()) });
+    return ({ fatorial_0((*n.borrow())) });
 }

--- a/tests/unit/out/refcount/fcall.rs
+++ b/tests/unit/out/refcount/fcall.rs
@@ -15,60 +15,32 @@ pub fn f3_1(x: f64, y: f64, z: f64) -> f64 {
     let x: Value<f64> = Rc::new(RefCell::new(x));
     let y: Value<f64> = Rc::new(RefCell::new(y));
     let z: Value<f64> = Rc::new(RefCell::new(z));
-    return (({
-        let _x: f64 = (*x.borrow());
-        let _y: f64 = (*y.borrow());
-        f2_0(_x, _y)
-    }) + (*z.borrow()));
+    return (({ f2_0((*x.borrow()), (*y.borrow())) }) + (*z.borrow()));
 }
 pub fn f1_2(x: f64, y: f64) -> f64 {
     let x: Value<f64> = Rc::new(RefCell::new(x));
     let y: Value<f64> = Rc::new(RefCell::new(y));
-    let z1: Value<f64> = Rc::new(RefCell::new(
-        ({
-            let _x: f64 = (*x.borrow());
-            let _y: f64 = (*y.borrow());
-            f2_0(_x, _y)
-        }),
-    ));
-    if (({
-        let _x: f64 = (*z1.borrow());
-        let _y: f64 = (*y.borrow());
-        f2_0(_x, _y)
-    }) < 0_f64)
-    {
+    let z1: Value<f64> = Rc::new(RefCell::new(({ f2_0((*x.borrow()), (*y.borrow())) })));
+    if (({ f2_0((*z1.borrow()), (*y.borrow())) }) < 0_f64) {
         let z2: Value<f64> = Rc::new(RefCell::new(
             -({
-                let _x: f64 = (*z1.borrow());
-                let _y: f64 = ({
-                    let _x: f64 = (*x.borrow());
-                    let _y: f64 = (*y.borrow());
-                    f2_0(_x, _y)
-                });
+                let _y: f64 = ({ f2_0((*x.borrow()), (*y.borrow())) });
                 let _z: f64 = (*y.borrow());
-                f3_1(_x, _y, _z)
+                f3_1((*z1.borrow()), _y, _z)
             }),
         ));
         return ({
-            let _x: f64 = ({
-                let _x: f64 = (*z2.borrow());
-                let _y: f64 = ({
-                    let _x: f64 = (*z1.borrow());
-                    let _y: f64 = (*z2.borrow());
-                    let _z: f64 = (*x.borrow());
-                    f3_1(_x, _y, _z)
-                });
-                f2_0(_x, _y)
-            });
-            let _y: f64 = (*y.borrow());
-            f2_0(_x, _y)
+            f2_0(
+                ({
+                    let _x: f64 = (*z2.borrow());
+                    let _y: f64 = ({ f3_1((*z1.borrow()), (*z2.borrow()), (*x.borrow())) });
+                    f2_0(_x, _y)
+                }),
+                (*y.borrow()),
+            )
         });
     }
-    return ({
-        let _x: f64 = (*z1.borrow());
-        let _y: f64 = (*x.borrow());
-        f2_0(_x, _y)
-    });
+    return ({ f2_0((*z1.borrow()), (*x.borrow())) });
 }
 pub fn main() {
     std::process::exit(main_0());

--- a/tests/unit/out/refcount/fft.rs
+++ b/tests/unit/out/refcount/fft.rs
@@ -162,18 +162,10 @@ pub fn fft_3(a: Ptr<Option<Value<Box<[Complex]>>>>, N: i32) -> Option<Value<Box<
         (*i.borrow_mut()).postfix_inc();
     }
     let y0: Value<Option<Value<Box<[Complex]>>>> = Rc::new(RefCell::new(
-        ({
-            let _a: Ptr<Option<Value<Box<[Complex]>>>> = A0.as_pointer();
-            let _N: i32 = ((*N.borrow()) / 2);
-            fft_3(_a, _N)
-        }),
+        ({ fft_3(A0.as_pointer(), ((*N.borrow()) / 2)) }),
     ));
     let y1: Value<Option<Value<Box<[Complex]>>>> = Rc::new(RefCell::new(
-        ({
-            let _a: Ptr<Option<Value<Box<[Complex]>>>> = A1.as_pointer();
-            let _N: i32 = ((*N.borrow()) / 2);
-            fft_3(_a, _N)
-        }),
+        ({ fft_3(A1.as_pointer(), ((*N.borrow()) / 2)) }),
     ));
     let k: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while ((*k.borrow()) < ((*N.borrow()) / 2)) {
@@ -204,16 +196,17 @@ pub fn fft_3(a: Ptr<Option<Value<Box<[Complex]>>>>, N: i32) -> Option<Value<Box<
                     [((*k.borrow()) as usize) as usize])
                     .clone();
                 let _z2: Complex = ({
-                    let _z1: Complex = ({
-                        let _z1: Complex = ((*w.borrow()).as_ref().unwrap().borrow()
-                            [((*k.borrow()) as usize) as usize])
-                            .clone();
-                        let _z2: Complex = ((*y1.borrow()).as_ref().unwrap().borrow()
-                            [((*k.borrow()) as usize) as usize])
-                            .clone();
-                        Product_0(_z1, _z2)
-                    });
-                    Neg_2(_z1)
+                    Neg_2(
+                        ({
+                            let _z1: Complex = ((*w.borrow()).as_ref().unwrap().borrow()
+                                [((*k.borrow()) as usize) as usize])
+                                .clone();
+                            let _z2: Complex = ((*y1.borrow()).as_ref().unwrap().borrow()
+                                [((*k.borrow()) as usize) as usize])
+                                .clone();
+                            Product_0(_z1, _z2)
+                        }),
+                    )
                 });
                 Sum_1(_z1, _z2)
             }),
@@ -247,13 +240,8 @@ fn main_0() -> i32 {
         (*a.borrow()).as_ref().unwrap().borrow_mut()[((*i.borrow()) as usize) as usize] = __rhs;
         (*i.borrow_mut()).postfix_inc();
     }
-    let b: Value<Option<Value<Box<[Complex]>>>> = Rc::new(RefCell::new(
-        ({
-            let _a: Ptr<Option<Value<Box<[Complex]>>>> = a.as_pointer();
-            let _N: i32 = (*N.borrow());
-            fft_3(_a, _N)
-        }),
-    ));
+    let b: Value<Option<Value<Box<[Complex]>>>> =
+        Rc::new(RefCell::new(({ fft_3(a.as_pointer(), (*N.borrow())) })));
     let reals: Value<Option<Value<Box<[i32]>>>> =
         Rc::new(RefCell::new(Some(Rc::new(RefCell::new(
             (0..((*N.borrow()) as usize))

--- a/tests/unit/out/refcount/fn_ptr.rs
+++ b/tests/unit/out/refcount/fn_ptr.rs
@@ -13,10 +13,7 @@ pub fn my_foo_0(p: AnyPtr) -> i32 {
 pub fn foo_1(fn_: FnPtr<fn(AnyPtr) -> i32>, pi: Ptr<i32>) -> i32 {
     let fn_: Value<FnPtr<fn(AnyPtr) -> i32>> = Rc::new(RefCell::new(fn_));
     let pi: Value<Ptr<i32>> = Rc::new(RefCell::new(pi));
-    return ({
-        let _arg0: AnyPtr = ((*pi.borrow()).clone() as Ptr<i32>).to_any();
-        (*(*fn_.borrow()))(_arg0)
-    });
+    return ({ (*(*fn_.borrow()))(((*pi.borrow()).clone() as Ptr<i32>).to_any()) });
 }
 pub fn main() {
     std::process::exit(main_0());
@@ -36,11 +33,7 @@ fn main_0() -> i32 {
     });
     let a: Value<i32> = Rc::new(RefCell::new(10));
     assert!({
-        let _lhs = ({
-            let _fn: FnPtr<fn(AnyPtr) -> i32> = (*fn_.borrow()).clone();
-            let _pi: Ptr<i32> = (a.as_pointer());
-            foo_1(_fn, _pi)
-        });
+        let _lhs = ({ foo_1((*fn_.borrow()).clone(), (a.as_pointer())) });
         _lhs == (*a.borrow())
     });
     return 0;

--- a/tests/unit/out/refcount/fn_ptr_as_condition.rs
+++ b/tests/unit/out/refcount/fn_ptr_as_condition.rs
@@ -17,10 +17,7 @@ pub fn maybe_call_1(cb: FnPtr<fn(Ptr<i32>)>, x: Ptr<i32>) {
     let cb: Value<FnPtr<fn(Ptr<i32>)>> = Rc::new(RefCell::new(cb));
     let x: Value<Ptr<i32>> = Rc::new(RefCell::new(x));
     if !(*cb.borrow()).is_null() {
-        ({
-            let _arg0: Ptr<i32> = (*x.borrow()).clone();
-            (*(*cb.borrow()))(_arg0)
-        });
+        ({ (*(*cb.borrow()))((*x.borrow()).clone()) });
     }
 }
 pub fn main() {
@@ -28,18 +25,10 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let a: Value<i32> = Rc::new(RefCell::new(5));
-    ({
-        let _cb: FnPtr<fn(Ptr<i32>)> = FnPtr::<fn(Ptr<i32>)>::new(double_it_0);
-        let _x: Ptr<i32> = (a.as_pointer());
-        maybe_call_1(_cb, _x)
-    });
+    ({ maybe_call_1(FnPtr::<fn(Ptr<i32>)>::new(double_it_0), (a.as_pointer())) });
     assert!(((*a.borrow()) == 10));
     let b: Value<i32> = Rc::new(RefCell::new(5));
-    ({
-        let _cb: FnPtr<fn(Ptr<i32>)> = FnPtr::null();
-        let _x: Ptr<i32> = (b.as_pointer());
-        maybe_call_1(_cb, _x)
-    });
+    ({ maybe_call_1(FnPtr::null(), (b.as_pointer())) });
     assert!(((*b.borrow()) == 5));
     let fn_: Value<FnPtr<fn(Ptr<i32>)>> = Rc::new(RefCell::new(FnPtr::null()));
     if !!(*fn_.borrow()).is_null() {
@@ -47,10 +36,7 @@ fn main_0() -> i32 {
     }
     let c: Value<i32> = Rc::new(RefCell::new(3));
     if !(*fn_.borrow()).is_null() {
-        ({
-            let _arg0: Ptr<i32> = (c.as_pointer());
-            (*(*fn_.borrow()))(_arg0)
-        });
+        ({ (*(*fn_.borrow()))((c.as_pointer())) });
     }
     assert!(((*c.borrow()) == 6));
     return 0;

--- a/tests/unit/out/refcount/fn_ptr_cast.rs
+++ b/tests/unit/out/refcount/fn_ptr_cast.rs
@@ -82,10 +82,7 @@ pub fn test_call_through_cast_5() {
     ));
     let val: Value<i32> = Rc::new(RefCell::new(100));
     let result: Value<i32> = Rc::new(RefCell::new(
-        ({
-            let _arg0: AnyPtr = ((val.as_pointer()) as Ptr<i32>).to_any();
-            (*(*gfn.borrow()))(_arg0, 42)
-        }),
+        ({ (*(*gfn.borrow()))(((val.as_pointer()) as Ptr<i32>).to_any(), 42) }),
     ));
     assert!(((*result.borrow()) == 142));
 }

--- a/tests/unit/out/refcount/fn_ptr_conditional.rs
+++ b/tests/unit/out/refcount/fn_ptr_conditional.rs
@@ -39,36 +39,16 @@ pub fn apply_4(fn_: FnPtr<fn(i32) -> i32>, x: i32) -> i32 {
         } else {
             FnPtr::<fn(i32) -> i32>::new(identity_2)
         }));
-    return ({
-        let _arg0: i32 = (*x.borrow());
-        (*(*actual.borrow()))(_arg0)
-    });
+    return ({ (*(*actual.borrow()))((*x.borrow())) });
 }
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
     assert!((({ (*({ pick_3(1,) }))(10,) }) == 11));
-    assert!(
-        (({
-            (*({
-                let _mode: i32 = -1_i32;
-                pick_3(_mode)
-            }))(10)
-        }) == 9)
-    );
+    assert!((({ (*({ pick_3(-1_i32,) }))(10,) }) == 9));
     assert!((({ (*({ pick_3(0,) }))(10,) }) == 10));
-    assert!(
-        (({
-            let _fn: FnPtr<fn(i32) -> i32> = FnPtr::<fn(i32) -> i32>::new(inc_0);
-            apply_4(_fn, 5)
-        }) == 6)
-    );
-    assert!(
-        (({
-            let _fn: FnPtr<fn(i32) -> i32> = FnPtr::null();
-            apply_4(_fn, 5)
-        }) == 5)
-    );
+    assert!((({ apply_4(FnPtr::<fn(i32) -> i32>::new(inc_0), 5,) }) == 6));
+    assert!((({ apply_4(FnPtr::null(), 5,) }) == 5));
     return 0;
 }

--- a/tests/unit/out/refcount/fn_ptr_default_arg.rs
+++ b/tests/unit/out/refcount/fn_ptr_default_arg.rs
@@ -14,10 +14,7 @@ pub fn apply_1(x: i32, fn_: Option<FnPtr<fn(i32) -> i32>>) -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(x));
     let fn_: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(fn_.unwrap_or(FnPtr::null())));
     if !(*fn_.borrow()).is_null() {
-        return ({
-            let _arg0: i32 = (*x.borrow());
-            (*(*fn_.borrow()))(_arg0)
-        });
+        return ({ (*(*fn_.borrow()))((*x.borrow())) });
     }
     return (*x.borrow());
 }
@@ -25,35 +22,15 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    assert!(
-        (({
-            let _fn: FnPtr<fn(i32) -> i32> = Default::default();
-            apply_1(5, Some(_fn))
-        }) == 5)
-    );
-    assert!(
-        (({
-            let _fn: FnPtr<fn(i32) -> i32> = FnPtr::null();
-            apply_1(5, Some(_fn))
-        }) == 5)
-    );
-    assert!(
-        (({
-            let _fn: FnPtr<fn(i32) -> i32> = FnPtr::<fn(i32) -> i32>::new(identity_0);
-            apply_1(5, Some(_fn))
-        }) == 5)
-    );
+    assert!((({ apply_1(5, Some(Default::default()),) }) == 5));
+    assert!((({ apply_1(5, Some(FnPtr::null()),) }) == 5));
+    assert!((({ apply_1(5, Some(FnPtr::<fn(i32) -> i32>::new(identity_0)),) }) == 5));
     let negate: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::new(
         (|x: i32| {
             let x: Value<i32> = Rc::new(RefCell::new(x));
             return -(*x.borrow());
         }),
     )));
-    assert!(
-        (({
-            let _fn: FnPtr<fn(i32) -> i32> = (*negate.borrow()).clone();
-            apply_1(5, Some(_fn))
-        }) == -5_i32)
-    );
+    assert!((({ apply_1(5, Some((*negate.borrow()).clone()),) }) == -5_i32));
     return 0;
 }

--- a/tests/unit/out/refcount/fn_ptr_global.rs
+++ b/tests/unit/out/refcount/fn_ptr_global.rs
@@ -24,10 +24,7 @@ pub fn set_op_3(fn_: FnPtr<fn(i32) -> i32>) {
 pub fn call_op_4(x: i32) -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(x));
     if !(*g_op_2.with(Value::clone).borrow()).is_null() {
-        return ({
-            let _arg0: i32 = (*x.borrow());
-            (*(*g_op_2.with(Value::clone).borrow()))(_arg0)
-        });
+        return ({ (*(*g_op_2.with(Value::clone).borrow()))((*x.borrow())) });
     }
     return (*x.borrow());
 }
@@ -36,29 +33,20 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     assert!((({ call_op_4(5,) }) == 5));
-    ({
-        let _fn: FnPtr<fn(i32) -> i32> = FnPtr::<fn(i32) -> i32>::new(double_it_0);
-        set_op_3(_fn)
-    });
+    ({ set_op_3(FnPtr::<fn(i32) -> i32>::new(double_it_0)) });
     assert!(!((*g_op_2.with(Value::clone).borrow()).is_null()));
     assert!({
         let _lhs = (*g_op_2.with(Value::clone).borrow()).clone();
         _lhs == FnPtr::<fn(i32) -> i32>::new(double_it_0)
     });
     assert!((({ call_op_4(5,) }) == 10));
-    ({
-        let _fn: FnPtr<fn(i32) -> i32> = FnPtr::<fn(i32) -> i32>::new(triple_it_1);
-        set_op_3(_fn)
-    });
+    ({ set_op_3(FnPtr::<fn(i32) -> i32>::new(triple_it_1)) });
     assert!({
         let _lhs = (*g_op_2.with(Value::clone).borrow()).clone();
         _lhs == FnPtr::<fn(i32) -> i32>::new(triple_it_1)
     });
     assert!((({ call_op_4(5,) }) == 15));
-    ({
-        let _fn: FnPtr<fn(i32) -> i32> = FnPtr::null();
-        set_op_3(_fn)
-    });
+    ({ set_op_3(FnPtr::null()) });
     assert!((*g_op_2.with(Value::clone).borrow()).is_null());
     assert!((({ call_op_4(5,) }) == 5));
     return 0;

--- a/tests/unit/out/refcount/fn_ptr_stdlib_compare.rs
+++ b/tests/unit/out/refcount/fn_ptr_stdlib_compare.rs
@@ -61,11 +61,7 @@ fn main_0() -> i32 {
             )),
         ));
     assert!(
-        (({
-            let _arg0: AnyPtr = AnyPtr::default();
-            let _arg3: Ptr<::std::fs::File> = Ptr::null();
-            (*(*f3.borrow()))(_arg0, 0_usize, 0_usize, _arg3)
-        }) == 22_usize)
+        (({ (*(*f3.borrow()))(AnyPtr::default(), 0_usize, 0_usize, Ptr::null(),) }) == 22_usize)
     );
     let mut __do_while = true;
     'loop_: while __do_while || (0 != 0) {
@@ -154,9 +150,12 @@ fn main_0() -> i32 {
         };
         let n: Value<usize> = Rc::new(RefCell::new(
             ({
-                let _arg0: AnyPtr = ((buf.as_pointer() as Ptr<u8>) as Ptr<u8>).to_any();
-                let _arg3: Ptr<::std::fs::File> = (*stream.borrow()).clone();
-                (*(*fn1.borrow()))(_arg0, 1_usize, 10_usize, _arg3)
+                (*(*fn1.borrow()))(
+                    ((buf.as_pointer() as Ptr<u8>) as Ptr<u8>).to_any(),
+                    1_usize,
+                    10_usize,
+                    (*stream.borrow()).clone(),
+                )
             }),
         ));
         assert!(((*n.borrow()) == 10_usize));
@@ -217,11 +216,7 @@ fn main_0() -> i32 {
             )),
         ));
     assert!(
-        (({
-            let _arg0: AnyPtr = AnyPtr::default();
-            let _arg3: Ptr<::std::fs::File> = Ptr::null();
-            (*(*g3.borrow()))(_arg0, 0_usize, 0_usize, _arg3)
-        }) == 33_usize)
+        (({ (*(*g3.borrow()))(AnyPtr::default(), 0_usize, 0_usize, Ptr::null(),) }) == 33_usize)
     );
     let mut __do_while = true;
     'loop_: while __do_while || (0 != 0) {
@@ -300,9 +295,12 @@ fn main_0() -> i32 {
         };
         let n: Value<usize> = Rc::new(RefCell::new(
             ({
-                let _arg0: AnyPtr = ((buf.as_pointer() as Ptr<u8>) as Ptr<u8>).to_any();
-                let _arg3: Ptr<::std::fs::File> = (*stream.borrow()).clone();
-                (*(*gn1.borrow()))(_arg0, 1_usize, 10_usize, _arg3)
+                (*(*gn1.borrow()))(
+                    ((buf.as_pointer() as Ptr<u8>) as Ptr<u8>).to_any(),
+                    1_usize,
+                    10_usize,
+                    (*stream.borrow()).clone(),
+                )
             }),
         ));
         assert!(((*n.borrow()) == 10_usize));

--- a/tests/unit/out/refcount/fn_ptr_void_return.rs
+++ b/tests/unit/out/refcount/fn_ptr_void_return.rs
@@ -18,36 +18,22 @@ pub fn zero_out_1(x: Ptr<i32>) {
 pub fn run_2(fn_: FnPtr<fn(Ptr<i32>)>, x: Ptr<i32>) {
     let fn_: Value<FnPtr<fn(Ptr<i32>)>> = Rc::new(RefCell::new(fn_));
     let x: Value<Ptr<i32>> = Rc::new(RefCell::new(x));
-    ({
-        let _arg0: Ptr<i32> = (*x.borrow()).clone();
-        (*(*fn_.borrow()))(_arg0)
-    });
+    ({ (*(*fn_.borrow()))((*x.borrow()).clone()) });
 }
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
     let a: Value<i32> = Rc::new(RefCell::new(42));
-    ({
-        let _fn: FnPtr<fn(Ptr<i32>)> = FnPtr::<fn(Ptr<i32>)>::new(negate_0);
-        let _x: Ptr<i32> = (a.as_pointer());
-        run_2(_fn, _x)
-    });
+    ({ run_2(FnPtr::<fn(Ptr<i32>)>::new(negate_0), (a.as_pointer())) });
     assert!(((*a.borrow()) == -42_i32));
-    ({
-        let _fn: FnPtr<fn(Ptr<i32>)> = FnPtr::<fn(Ptr<i32>)>::new(zero_out_1);
-        let _x: Ptr<i32> = (a.as_pointer());
-        run_2(_fn, _x)
-    });
+    ({ run_2(FnPtr::<fn(Ptr<i32>)>::new(zero_out_1), (a.as_pointer())) });
     assert!(((*a.borrow()) == 0));
     let fn_: Value<FnPtr<fn(Ptr<i32>)>> =
         Rc::new(RefCell::new(FnPtr::<fn(Ptr<i32>)>::new(negate_0)));
     assert!(!((*fn_.borrow()).is_null()));
     let b: Value<i32> = Rc::new(RefCell::new(10));
-    ({
-        let _arg0: Ptr<i32> = (b.as_pointer());
-        (*(*fn_.borrow()))(_arg0)
-    });
+    ({ (*(*fn_.borrow()))((b.as_pointer())) });
     assert!(((*b.borrow()) == -10_i32));
     return 0;
 }

--- a/tests/unit/out/refcount/fn_ptr_vtable.rs
+++ b/tests/unit/out/refcount/fn_ptr_vtable.rs
@@ -63,16 +63,8 @@ fn main_0() -> i32 {
     assert!(!((*(*vt.borrow()).get.borrow()).is_null()));
     assert!(!((*(*vt.borrow()).destroy.borrow()).is_null()));
     let obj: Value<AnyPtr> = Rc::new(RefCell::new(({ (*(*(*vt.borrow()).create.borrow()))(42) })));
-    assert!(
-        (({
-            let _arg0: AnyPtr = (*obj.borrow()).clone();
-            (*(*(*vt.borrow()).get.borrow()))(_arg0)
-        }) == 42)
-    );
-    ({
-        let _arg0: AnyPtr = (*obj.borrow()).clone();
-        (*(*(*vt.borrow()).destroy.borrow()))(_arg0)
-    });
+    assert!((({ (*(*(*vt.borrow()).get.borrow()))((*obj.borrow()).clone(),) }) == 42));
+    ({ (*(*(*vt.borrow()).destroy.borrow()))((*obj.borrow()).clone()) });
     assert!(((*storage_0.with(Value::clone).borrow()) == 0));
     (*(*vt.borrow()).get.borrow_mut()) = FnPtr::null();
     assert!((*(*vt.borrow()).get.borrow()).is_null());

--- a/tests/unit/out/refcount/function_overloading.rs
+++ b/tests/unit/out/refcount/function_overloading.rs
@@ -83,14 +83,8 @@ fn main_0() -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(1));
     let out: Value<i32> = Rc::new(RefCell::new(0));
     (*out.borrow_mut()) += ({ foo_0(0) });
-    (*out.borrow_mut()) += ({
-        let _x: Ptr<i32> = (x.as_pointer());
-        foo_1(_x)
-    });
-    (*out.borrow_mut()) += ({
-        let _x: Ptr<i32> = x.as_pointer();
-        bar_4(_x)
-    });
+    (*out.borrow_mut()) += ({ foo_1((x.as_pointer())) });
+    (*out.borrow_mut()) += ({ bar_4(x.as_pointer()) });
     (*out.borrow_mut()) += ({
         let _x: Ptr<i32> = (x.as_pointer());
         let _y: Ptr<i32> = (x.as_pointer());
@@ -103,11 +97,7 @@ fn main_0() -> i32 {
         foo_2(_x, _y)
     });
     let bar: Value<i32> = Rc::new(RefCell::new(5));
-    (*out.borrow_mut()) += (((*bar.borrow()) + ({ foo_0(0) }))
-        + ({
-            let _x: Ptr<i32> = (x.as_pointer());
-            foo_1(_x)
-        }));
+    (*out.borrow_mut()) += (((*bar.borrow()) + ({ foo_0(0) })) + ({ foo_1((x.as_pointer())) }));
     let foo1: Value<Foo> = Rc::new(RefCell::new(Foo {}));
     let foo2: Value<Foo> = Rc::new(RefCell::new(Foo {}));
     ({ (*foo1.borrow()).foo() });

--- a/tests/unit/out/refcount/goto_aggregate_default.rs
+++ b/tests/unit/out/refcount/goto_aggregate_default.rs
@@ -60,13 +60,7 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    assert!(
-        (((({
-            let _n: i32 = -1_i32;
-            agg_0(_n)
-        }) == 0) as i32)
-            != 0)
-    );
+    assert!((((({ agg_0(-1_i32,) }) == 0) as i32) != 0));
     assert!((((({ agg_0(1,) }) == 1) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/refcount/goto_cleanup.rs
+++ b/tests/unit/out/refcount/goto_cleanup.rs
@@ -81,13 +81,7 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    assert!(
-        (((({
-            let _n: i32 = -1_i32;
-            early_0(_n)
-        }) == -1_i32) as i32)
-            != 0)
-    );
+    assert!((((({ early_0(-1_i32,) }) == -1_i32) as i32) != 0));
     assert!((((({ early_0(5,) }) == 100) as i32) != 0));
     assert!((((({ from_loop_1(2,) }) == 999) as i32) != 0));
     assert!((((({ from_loop_1(10,) }) == 7) as i32) != 0));

--- a/tests/unit/out/refcount/goto_multi_label.rs
+++ b/tests/unit/out/refcount/goto_multi_label.rs
@@ -36,12 +36,6 @@ pub fn main() {
 fn main_0() -> i32 {
     assert!((((({ classify_0(5,) }) == 5) as i32) != 0));
     assert!((((({ classify_0(0,) }) == 0) as i32) != 0));
-    assert!(
-        (((({
-            let _n: i32 = -2_i32;
-            classify_0(_n)
-        }) == -1_i32) as i32)
-            != 0)
-    );
+    assert!((((({ classify_0(-2_i32,) }) == -1_i32) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/refcount/huffman.rs
+++ b/tests/unit/out/refcount/huffman.rs
@@ -133,10 +133,7 @@ impl MinHeap {
                     .clone();
                 Swap_0(_a, _b)
             });
-            ({
-                let _idx: i32 = (*smallest.borrow());
-                self.Heapify(_idx)
-            });
+            ({ self.Heapify((*smallest.borrow())) });
         }
     }
     pub fn ExtractMin(&self) -> Ptr<MinHeapNode> {
@@ -198,10 +195,7 @@ impl MinHeap {
         }
         let i: Value<i32> = Rc::new(RefCell::new((((*self.size.borrow()) - 2) / 2)));
         'loop_: while ((*i.borrow()) >= 0) {
-            ({
-                let _idx: i32 = (*i.borrow());
-                self.Heapify(_idx)
-            });
+            ({ self.Heapify((*i.borrow())) });
             (*i.borrow_mut()).prefix_dec();
         }
     }
@@ -233,12 +227,8 @@ pub fn Huffman_2(
     size: i32,
 ) -> Option<Value<MinHeap>> {
     let size: Value<i32> = Rc::new(RefCell::new(size));
-    let minHeap: Value<Option<Value<MinHeap>>> = Rc::new(RefCell::new(
-        ({
-            let _capacity: i32 = (*size.borrow());
-            AllocMinHeap_1(_capacity)
-        }),
-    ));
+    let minHeap: Value<Option<Value<MinHeap>>> =
+        Rc::new(RefCell::new(({ AllocMinHeap_1((*size.borrow())) })));
     ({
         let _data: Ptr<Option<Value<Box<[u8]>>>> = (data).clone();
         let _freq: Ptr<Option<Value<Box<[i32]>>>> = (freq).clone();
@@ -258,19 +248,15 @@ pub fn Huffman_2(
         ));
         let top: Value<Ptr<MinHeapNode>> = Rc::new(RefCell::new(
             ({
-                let _freq: i32 = {
+                (*(*minHeap.borrow()).as_ref().unwrap().borrow()).Alloc(('$' as u8), {
                     let _lhs = (*(*(*left.borrow()).upgrade().deref()).freq.borrow());
                     _lhs + (*(*(*right.borrow()).upgrade().deref()).freq.borrow())
-                };
-                (*(*minHeap.borrow()).as_ref().unwrap().borrow()).Alloc(('$' as u8), _freq)
+                })
             }),
         ));
         (*(*(*top.borrow()).upgrade().deref()).left.borrow_mut()) = (*left.borrow()).clone();
         (*(*(*top.borrow()).upgrade().deref()).right.borrow_mut()) = (*right.borrow()).clone();
-        ({
-            let _node: Ptr<MinHeapNode> = (*top.borrow()).clone();
-            (*(*minHeap.borrow()).as_ref().unwrap().borrow()).Insert(_node)
-        });
+        ({ (*(*minHeap.borrow()).as_ref().unwrap().borrow()).Insert((*top.borrow()).clone()) });
     }
     return (*minHeap.borrow_mut()).take();
 }
@@ -376,12 +362,13 @@ pub fn HuffmanCodes_5(
     let top: Value<i32> = Rc::new(RefCell::new(0));
     let next: Value<i32> = Rc::new(RefCell::new(0));
     ({
-        let _root: Ptr<MinHeapNode> = (*root.borrow()).clone();
-        let _arr: Ptr<Option<Value<Box<[i32]>>>> = arr.as_pointer();
-        let _top: i32 = (*top.borrow());
-        let _out: Ptr<Option<Value<Box<[i32]>>>> = out.as_pointer();
-        let _next: Ptr<i32> = next.as_pointer();
-        CollectCodes_4(_root, _arr, _top, _out, _next)
+        CollectCodes_4(
+            (*root.borrow()).clone(),
+            arr.as_pointer(),
+            (*top.borrow()),
+            out.as_pointer(),
+            next.as_pointer(),
+        )
     });
     return (*out.borrow_mut()).take();
 }
@@ -419,12 +406,7 @@ fn main_0() -> i32 {
         (*i.borrow_mut()).prefix_inc();
     }
     let out: Value<Option<Value<Box<[i32]>>>> = Rc::new(RefCell::new(
-        ({
-            let _data: Ptr<Option<Value<Box<[u8]>>>> = data.as_pointer();
-            let _freq: Ptr<Option<Value<Box<[i32]>>>> = freq.as_pointer();
-            let _size: i32 = (*size.borrow());
-            HuffmanCodes_5(_data, _freq, _size)
-        }),
+        ({ HuffmanCodes_5(data.as_pointer(), freq.as_pointer(), (*size.borrow())) }),
     ));
     return ((((((((*out.borrow()).as_ref().unwrap().borrow()[(0_usize) as usize] == 0)
         && ((*out.borrow()).as_ref().unwrap().borrow()[(1_usize) as usize] == 100))

--- a/tests/unit/out/refcount/implicit_autoref.rs
+++ b/tests/unit/out/refcount/implicit_autoref.rs
@@ -66,9 +66,9 @@ fn main_0() -> i32 {
             == 60)
     );
     ({
-        let _p: Ptr<i32> =
-            (((*p.borrow()).to_strong().as_pointer() as Ptr<i32>).offset(0_usize as isize));
-        write_through_0(_p)
+        write_through_0(
+            (((*p.borrow()).to_strong().as_pointer() as Ptr<i32>).offset(0_usize as isize)),
+        )
     });
     assert!(
         (((((*p.borrow()).to_strong().as_pointer()) as Ptr<i32>)

--- a/tests/unit/out/refcount/init_list.rs
+++ b/tests/unit/out/refcount/init_list.rs
@@ -23,9 +23,6 @@ fn main_0() -> i32 {
     ])));
     let arr: Value<Vec<i32>> = Rc::new(RefCell::new(vec![1, 2, 3]));
     let vec_: Value<Vec<i32>> = Rc::new(RefCell::new(vec![1, 2, 3]));
-    ({
-        let _list: Vec<i32> = vec![1, 2, 3, 4];
-        f_0(_list)
-    });
+    ({ f_0(vec![1, 2, 3, 4]) });
     return 0;
 }

--- a/tests/unit/out/refcount/initializer_list.rs
+++ b/tests/unit/out/refcount/initializer_list.rs
@@ -17,11 +17,6 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    assert!(
-        (({
-            let _bytes: Vec<i32> = vec![1, 2, 3];
-            f_0(_bytes)
-        }) == 3_usize)
-    );
+    assert!((({ f_0(vec![1, 2, 3,],) }) == 3_usize));
     return 0;
 }

--- a/tests/unit/out/refcount/iterator_freshness.rs
+++ b/tests/unit/out/refcount/iterator_freshness.rs
@@ -19,9 +19,6 @@ fn main_0() -> i32 {
             .collect::<Vec<_>>(),
     ));
     let it: Value<Ptr<i32>> = Rc::new(RefCell::new((vec_.as_pointer() as Ptr<i32>)));
-    ({
-        let _a0: Ptr<i32> = (*it.borrow()).clone();
-        foo_0(_a0)
-    });
+    ({ foo_0((*it.borrow()).clone()) });
     return 0;
 }

--- a/tests/unit/out/refcount/kruskal.rs
+++ b/tests/unit/out/refcount/kruskal.rs
@@ -248,18 +248,8 @@ impl DisjointSet {
     pub fn merge(&self, x: i32, y: i32) {
         let x: Value<i32> = Rc::new(RefCell::new(x));
         let y: Value<i32> = Rc::new(RefCell::new(y));
-        let xset: Value<i32> = Rc::new(RefCell::new(
-            ({
-                let _x: i32 = (*x.borrow());
-                self.find(_x)
-            }),
-        ));
-        let yset: Value<i32> = Rc::new(RefCell::new(
-            ({
-                let _x: i32 = (*y.borrow());
-                self.find(_x)
-            }),
-        ));
+        let xset: Value<i32> = Rc::new(RefCell::new(({ self.find((*x.borrow())) })));
+        let yset: Value<i32> = Rc::new(RefCell::new(({ self.find((*y.borrow())) })));
         if ((*xset.borrow()) == (*yset.borrow())) {
             return;
         }
@@ -345,18 +335,9 @@ pub fn MSTKruskal_2(graph: Ptr<Graph>) -> f64 {
                 .weight
                 .borrow()),
         ));
-        if (({
-            let _x: i32 = (*x.borrow());
-            (*set.borrow()).find(_x)
-        }) != ({
-            let _x: i32 = (*y.borrow());
-            (*set.borrow()).find(_x)
-        })) {
-            ({
-                let _x: i32 = (*x.borrow());
-                let _y: i32 = (*y.borrow());
-                (*set.borrow()).merge(_x, _y)
-            });
+        if (({ (*set.borrow()).find((*x.borrow())) }) != ({ (*set.borrow()).find((*y.borrow())) }))
+        {
+            ({ (*set.borrow()).merge((*x.borrow()), (*y.borrow())) });
             (*total_weight.borrow_mut()) += (*w.borrow());
         }
         (*i.borrow_mut()).prefix_inc();
@@ -418,11 +399,6 @@ fn main_0() -> i32 {
         v: Rc::new(RefCell::new(3)),
         weight: Rc::new(RefCell::new(5_f64)),
     };
-    let total_weight: Value<f64> = Rc::new(RefCell::new(
-        ({
-            let _graph: Ptr<Graph> = graph.as_pointer();
-            MSTKruskal_2(_graph)
-        }),
-    ));
+    let total_weight: Value<f64> = Rc::new(RefCell::new(({ MSTKruskal_2(graph.as_pointer()) })));
     return ((*total_weight.borrow()) as i32);
 }

--- a/tests/unit/out/refcount/lambda_capture_pass.rs
+++ b/tests/unit/out/refcount/lambda_capture_pass.rs
@@ -9,20 +9,12 @@ use std::rc::{Rc, Weak};
 pub fn apply_0(fn_: impl Fn(i32) -> i32, x: i32) -> i32 {
     let fn_: Value<_> = Rc::new(RefCell::new(fn_));
     let x: Value<i32> = Rc::new(RefCell::new(x));
-    return ({
-        let _x: i32 = (*x.borrow());
-        (*fn_.borrow_mut())(_x)
-    })
-    .clone();
+    return ({ (*fn_.borrow_mut())((*x.borrow())) });
 }
 pub fn apply_1(fn_: impl Fn(i32) -> i32, x: i32) -> i32 {
     let fn_: Value<_> = Rc::new(RefCell::new(fn_));
     let x: Value<i32> = Rc::new(RefCell::new(x));
-    return ({
-        let _x: i32 = (*x.borrow());
-        (*fn_.borrow_mut())(_x)
-    })
-    .clone();
+    return ({ (*fn_.borrow_mut())((*x.borrow())) });
 }
 pub fn main() {
     std::process::exit(main_0());
@@ -35,19 +27,9 @@ fn main_0() -> i32 {
             return ((*x.borrow()) + (*base.borrow()));
         }),
     ));
-    assert!(
-        (({
-            let _fn: _ = (*add_base.borrow()).clone();
-            apply_0(_fn, 5)
-        }) == 15)
-    );
+    assert!((({ apply_0((*add_base.borrow()).clone(), 5,) }) == 15));
     (*base.borrow_mut()) = 100;
-    assert!(
-        (({
-            let _fn: _ = (*add_base.borrow()).clone();
-            apply_0(_fn, 5)
-        }) == 105)
-    );
+    assert!((({ apply_0((*add_base.borrow()).clone(), 5,) }) == 105));
     let factor: Value<i32> = Rc::new(RefCell::new(3));
     let scale: Value<_> = Rc::new(RefCell::new(
         (|x: i32| {
@@ -55,11 +37,6 @@ fn main_0() -> i32 {
             return ((*x.borrow()) * (*factor.borrow()));
         }),
     ));
-    assert!(
-        (({
-            let _fn: _ = (*scale.borrow()).clone();
-            apply_1(_fn, 4)
-        }) == 12)
-    );
+    assert!((({ apply_1((*scale.borrow()).clone(), 4,) }) == 12));
     return 0;
 }

--- a/tests/unit/out/refcount/linked_list.rs
+++ b/tests/unit/out/refcount/linked_list.rs
@@ -45,10 +45,7 @@ pub fn Append_1(head: Ptr<Node>, new_node: Ptr<Node>) {
         let __rhs = (*(*(*curr.borrow()).upgrade().deref()).next.borrow()).clone();
         (*curr.borrow_mut()) = __rhs;
     }
-    ({
-        let _next: Ptr<Node> = (new_node).clone();
-        (*(*curr.borrow()).upgrade().deref()).SetNext(_next)
-    });
+    ({ (*(*curr.borrow()).upgrade().deref()).SetNext((new_node).clone()) });
 }
 pub fn Delete_2(head: Ptr<Node>, val: i32) -> Ptr<Node> {
     let head: Value<Ptr<Node>> = Rc::new(RefCell::new(head));
@@ -146,70 +143,31 @@ fn main_0() -> i32 {
         let _new_node: Ptr<Node> = n7.as_pointer();
         Append_1(_head, _new_node)
     });
-    let __rhs = ({
-        let _head: Ptr<Node> = (*head.borrow()).clone();
-        Delete_2(_head, 5)
-    });
+    let __rhs = ({ Delete_2((*head.borrow()).clone(), 5) });
     (*head.borrow_mut()) = __rhs;
-    let __rhs = ({
-        let _head: Ptr<Node> = (*head.borrow()).clone();
-        Delete_2(_head, 0)
-    });
+    let __rhs = ({ Delete_2((*head.borrow()).clone(), 0) });
     (*head.borrow_mut()) = __rhs;
-    let __rhs = ({
-        let _head: Ptr<Node> = (*head.borrow()).clone();
-        let _val: i32 = -2_i32;
-        Delete_2(_head, _val)
-    });
+    let __rhs = ({ Delete_2((*head.borrow()).clone(), -2_i32) });
     (*head.borrow_mut()) = __rhs;
-    return (((((((*(*({
-        let _head: Ptr<Node> = (*head.borrow()).clone();
-        Find_0(_head, 0)
-    })
-    .upgrade()
-    .deref())
-    .val
-    .borrow())
+    return (((((((*(*({ Find_0((*head.borrow()).clone(), 0) }).upgrade().deref())
+        .val
+        .borrow())
         == 4)
-        && ((*(*({
-            let _head: Ptr<Node> = (*head.borrow()).clone();
-            Find_0(_head, 1)
-        })
-        .upgrade()
-        .deref())
-        .val
-        .borrow())
+        && ((*(*({ Find_0((*head.borrow()).clone(), 1) }).upgrade().deref())
+            .val
+            .borrow())
             == 3))
-        && ((*(*({
-            let _head: Ptr<Node> = (*head.borrow()).clone();
-            Find_0(_head, 2)
-        })
-        .upgrade()
-        .deref())
-        .val
-        .borrow())
+        && ((*(*({ Find_0((*head.borrow()).clone(), 2) }).upgrade().deref())
+            .val
+            .borrow())
             == 2))
-        && ((*(*({
-            let _head: Ptr<Node> = (*head.borrow()).clone();
-            Find_0(_head, 3)
-        })
-        .upgrade()
-        .deref())
-        .val
-        .borrow())
+        && ((*(*({ Find_0((*head.borrow()).clone(), 3) }).upgrade().deref())
+            .val
+            .borrow())
             == 1))
-        && (((*(*({
-            let _head: Ptr<Node> = (*head.borrow()).clone();
-            Find_0(_head, 4)
-        })
-        .upgrade()
-        .deref())
-        .val
-        .borrow())
+        && (((*(*({ Find_0((*head.borrow()).clone(), 4) }).upgrade().deref())
+            .val
+            .borrow())
             == -1_i32)
-            && (({
-                let _head: Ptr<Node> = (*head.borrow()).clone();
-                Find_0(_head, 5)
-            })
-            .is_null()))) as i32);
+            && (({ Find_0((*head.borrow()).clone(), 5) }).is_null()))) as i32);
 }

--- a/tests/unit/out/refcount/macros.rs
+++ b/tests/unit/out/refcount/macros.rs
@@ -28,8 +28,11 @@ fn main_0() -> i32 {
         Ptr::from_string_literal(b"main")
     );
     ({
-        let _func: Ptr<u8> = Ptr::from_string_literal(b"main");
-        log_0(Ptr::from_string_literal(b"macros.cpp"), 9, _func)
+        log_0(
+            Ptr::from_string_literal(b"macros.cpp"),
+            9,
+            Ptr::from_string_literal(b"main"),
+        )
     });
     return 0;
 }

--- a/tests/unit/out/refcount/map.rs
+++ b/tests/unit/out/refcount/map.rs
@@ -112,14 +112,15 @@ fn main_0() -> i32 {
             == 3_u32)
     );
     ({
-        let _x: u32 = ((m.as_pointer() as Ptr<BTreeMap<i16, Value<u32>>>)
-            .with_mut(|__v: &mut BTreeMap<i16, Value<u32>>| {
-                __v.entry(0_i16.clone())
-                    .or_insert_with(|| Rc::new(RefCell::new(<u32>::default())))
-                    .as_pointer()
-            })
-            .read());
-        foo_0(_x)
+        foo_0(
+            ((m.as_pointer() as Ptr<BTreeMap<i16, Value<u32>>>)
+                .with_mut(|__v: &mut BTreeMap<i16, Value<u32>>| {
+                    __v.entry(0_i16.clone())
+                        .or_insert_with(|| Rc::new(RefCell::new(<u32>::default())))
+                        .as_pointer()
+                })
+                .read()),
+        )
     });
     assert!(
         (((m.as_pointer() as Ptr<BTreeMap<i16, Value<u32>>>)
@@ -132,14 +133,13 @@ fn main_0() -> i32 {
             == 1_u32)
     );
     ({
-        let _x: Ptr<u32> = (m.as_pointer() as Ptr<BTreeMap<i16, Value<u32>>>).with_mut(
+        bar_1((m.as_pointer() as Ptr<BTreeMap<i16, Value<u32>>>).with_mut(
             |__v: &mut BTreeMap<i16, Value<u32>>| {
                 __v.entry(2_i16.clone())
                     .or_insert_with(|| Rc::new(RefCell::new(<u32>::default())))
                     .as_pointer()
             },
-        );
-        bar_1(_x)
+        ))
     });
     assert!(
         (((m.as_pointer() as Ptr<BTreeMap<i16, Value<u32>>>)

--- a/tests/unit/out/refcount/matmul.rs
+++ b/tests/unit/out/refcount/matmul.rs
@@ -51,11 +51,7 @@ pub fn matmul_1(
     let n2: Value<i32> = Rc::new(RefCell::new(n2));
     let p2: Value<i32> = Rc::new(RefCell::new(p2));
     let m3: Value<Option<Value<Box<[Option<Value<Box<[i32]>>>]>>>> = Rc::new(RefCell::new(
-        ({
-            let _n: i32 = (*n1.borrow());
-            let _p: i32 = (*p2.borrow());
-            matalloc_0(_n, _p, 0)
-        }),
+        ({ matalloc_0((*n1.borrow()), (*p2.borrow()), 0) }),
     ));
     let i: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while ((*i.borrow()) < (*n1.borrow())) {
@@ -92,18 +88,10 @@ fn main_0() -> i32 {
     let n: Value<i32> = Rc::new(RefCell::new(1));
     let p: Value<i32> = Rc::new(RefCell::new(10));
     let m1: Value<Option<Value<Box<[Option<Value<Box<[i32]>>>]>>>> = Rc::new(RefCell::new(
-        ({
-            let _n: i32 = (*n.borrow());
-            let _p: i32 = (*p.borrow());
-            matalloc_0(_n, _p, 1)
-        }),
+        ({ matalloc_0((*n.borrow()), (*p.borrow()), 1) }),
     ));
     let m2: Value<Option<Value<Box<[Option<Value<Box<[i32]>>>]>>>> = Rc::new(RefCell::new(
-        ({
-            let _n: i32 = (*p.borrow());
-            let _p: i32 = (*n.borrow());
-            matalloc_0(_n, _p, 2)
-        }),
+        ({ matalloc_0((*p.borrow()), (*n.borrow()), 2) }),
     ));
     let m3: Value<Option<Value<Box<[Option<Value<Box<[i32]>>>]>>>> = Rc::new(RefCell::new(
         ({

--- a/tests/unit/out/refcount/new_bst.rs
+++ b/tests/unit/out/refcount/new_bst.rs
@@ -32,9 +32,10 @@ pub fn find_0(node: Ptr<node_t>, value: i32) -> Ptr<node_t> {
     }) && (!((*(*(*node.borrow()).upgrade().deref()).left.borrow()).is_null()))
     {
         return ({
-            let _node: Ptr<node_t> = (*(*(*node.borrow()).upgrade().deref()).left.borrow()).clone();
-            let _value: i32 = (*value.borrow());
-            find_0(_node, _value)
+            find_0(
+                (*(*(*node.borrow()).upgrade().deref()).left.borrow()).clone(),
+                (*value.borrow()),
+            )
         });
     } else if ({
         let _lhs = (*value.borrow());
@@ -42,10 +43,10 @@ pub fn find_0(node: Ptr<node_t>, value: i32) -> Ptr<node_t> {
     }) && (!((*(*(*node.borrow()).upgrade().deref()).right.borrow()).is_null()))
     {
         return ({
-            let _node: Ptr<node_t> =
-                (*(*(*node.borrow()).upgrade().deref()).right.borrow()).clone();
-            let _value: i32 = (*value.borrow());
-            find_0(_node, _value)
+            find_0(
+                (*(*(*node.borrow()).upgrade().deref()).right.borrow()).clone(),
+                (*value.borrow()),
+            )
         });
     } else if {
         let _lhs = (*value.borrow());
@@ -70,9 +71,10 @@ pub fn insert_1(node: Ptr<node_t>, value: i32) -> Ptr<node_t> {
         _lhs < (*(*(*node.borrow()).upgrade().deref()).value.borrow())
     } {
         let __rhs = ({
-            let _node: Ptr<node_t> = (*(*(*node.borrow()).upgrade().deref()).left.borrow()).clone();
-            let _value: i32 = (*value.borrow());
-            insert_1(_node, _value)
+            insert_1(
+                (*(*(*node.borrow()).upgrade().deref()).left.borrow()).clone(),
+                (*value.borrow()),
+            )
         });
         (*(*(*node.borrow()).upgrade().deref()).left.borrow_mut()) = __rhs;
     } else if {
@@ -80,10 +82,10 @@ pub fn insert_1(node: Ptr<node_t>, value: i32) -> Ptr<node_t> {
         _lhs > (*(*(*node.borrow()).upgrade().deref()).value.borrow())
     } {
         let __rhs = ({
-            let _node: Ptr<node_t> =
-                (*(*(*node.borrow()).upgrade().deref()).right.borrow()).clone();
-            let _value: i32 = (*value.borrow());
-            insert_1(_node, _value)
+            insert_1(
+                (*(*(*node.borrow()).upgrade().deref()).right.borrow()).clone(),
+                (*value.borrow()),
+            )
         });
         (*(*(*node.borrow()).upgrade().deref()).right.borrow_mut()) = __rhs;
     }
@@ -92,17 +94,10 @@ pub fn insert_1(node: Ptr<node_t>, value: i32) -> Ptr<node_t> {
 pub fn del_2(node: Ptr<node_t>) {
     let node: Value<Ptr<node_t>> = Rc::new(RefCell::new(node));
     if !((*(*(*node.borrow()).upgrade().deref()).left.borrow()).is_null()) {
-        ({
-            let _node: Ptr<node_t> = (*(*(*node.borrow()).upgrade().deref()).left.borrow()).clone();
-            del_2(_node)
-        });
+        ({ del_2((*(*(*node.borrow()).upgrade().deref()).left.borrow()).clone()) });
     }
     if !((*(*(*node.borrow()).upgrade().deref()).right.borrow()).is_null()) {
-        ({
-            let _node: Ptr<node_t> =
-                (*(*(*node.borrow()).upgrade().deref()).right.borrow()).clone();
-            del_2(_node)
-        });
+        ({ del_2((*(*(*node.borrow()).upgrade().deref()).right.borrow()).clone()) });
     }
     (*node.borrow()).delete();
 }
@@ -115,81 +110,37 @@ fn main_0() -> i32 {
         right: Rc::new(RefCell::new(Ptr::<node_t>::null())),
         value: Rc::new(RefCell::new(0)),
     })));
-    let __rhs = ({
-        let _node: Ptr<node_t> = (*root.borrow()).clone();
-        insert_1(_node, 1)
-    });
+    let __rhs = ({ insert_1((*root.borrow()).clone(), 1) });
     (*root.borrow_mut()) = __rhs;
-    let __rhs = ({
-        let _node: Ptr<node_t> = (*root.borrow()).clone();
-        insert_1(_node, 2)
-    });
+    let __rhs = ({ insert_1((*root.borrow()).clone(), 2) });
     (*root.borrow_mut()) = __rhs;
-    let __rhs = ({
-        let _node: Ptr<node_t> = (*root.borrow()).clone();
-        insert_1(_node, 3)
-    });
+    let __rhs = ({ insert_1((*root.borrow()).clone(), 3) });
     (*root.borrow_mut()) = __rhs;
-    let __rhs = ({
-        let _node: Ptr<node_t> = (*root.borrow()).clone();
-        insert_1(_node, 4)
-    });
+    let __rhs = ({ insert_1((*root.borrow()).clone(), 4) });
     (*root.borrow_mut()) = __rhs;
     let out: Value<bool> = Rc::new(RefCell::new(
-        ((((((*(*({
-            let _node: Ptr<node_t> = (*root.borrow()).clone();
-            find_0(_node, 0)
-        })
-        .upgrade()
-        .deref())
-        .value
-        .borrow())
+        ((((((*(*({ find_0((*root.borrow()).clone(), 0) }).upgrade().deref())
+            .value
+            .borrow())
             == 0)
-            && ((*(*({
-                let _node: Ptr<node_t> = (*root.borrow()).clone();
-                find_0(_node, 1)
-            })
-            .upgrade()
-            .deref())
-            .value
-            .borrow())
+            && ((*(*({ find_0((*root.borrow()).clone(), 1) }).upgrade().deref())
+                .value
+                .borrow())
                 == 1))
-            && ((*(*({
-                let _node: Ptr<node_t> = (*root.borrow()).clone();
-                find_0(_node, 2)
-            })
-            .upgrade()
-            .deref())
-            .value
-            .borrow())
+            && ((*(*({ find_0((*root.borrow()).clone(), 2) }).upgrade().deref())
+                .value
+                .borrow())
                 == 2))
-            && ((*(*({
-                let _node: Ptr<node_t> = (*root.borrow()).clone();
-                find_0(_node, 3)
-            })
-            .upgrade()
-            .deref())
-            .value
-            .borrow())
+            && ((*(*({ find_0((*root.borrow()).clone(), 3) }).upgrade().deref())
+                .value
+                .borrow())
                 == 3))
-            && ((*(*({
-                let _node: Ptr<node_t> = (*root.borrow()).clone();
-                find_0(_node, 4)
-            })
-            .upgrade()
-            .deref())
-            .value
-            .borrow())
+            && ((*(*({ find_0((*root.borrow()).clone(), 4) }).upgrade().deref())
+                .value
+                .borrow())
                 == 4))
-            && (({
-                let _node: Ptr<node_t> = (*root.borrow()).clone();
-                find_0(_node, 5)
-            })
-            .is_null()),
+            && (({ find_0((*root.borrow()).clone(), 5) }).is_null()),
     ));
-    ({
-        let _node: Ptr<node_t> = (*root.borrow()).clone();
-        del_2(_node)
-    });
+    ({ del_2((*root.borrow()).clone()) });
     return ((*out.borrow()) as i32);
 }

--- a/tests/unit/out/refcount/no_direct_callee.rs
+++ b/tests/unit/out/refcount/no_direct_callee.rs
@@ -20,8 +20,5 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    return ({
-        let _fn: FnPtr<fn() -> bool> = FnPtr::<fn() -> bool>::new(test1_0);
-        test_1(_fn)
-    });
+    return ({ test_1(FnPtr::<fn() -> bool>::new(test1_0)) });
 }

--- a/tests/unit/out/refcount/pod.rs
+++ b/tests/unit/out/refcount/pod.rs
@@ -55,10 +55,7 @@ fn main_0() -> i32 {
         x2: Rc::new(RefCell::new((*(*p1.borrow()).x2.borrow()))),
         x3: Rc::new(RefCell::new((*(*p1.borrow()).x3.borrow()))),
     }));
-    ({
-        let _pod: Ptr<POD> = p2.as_pointer();
-        PODIncrement_0(_pod)
-    });
+    ({ PODIncrement_0(p2.as_pointer()) });
     return (((*(*p2.borrow()).x1.borrow()) + (*(*p2.borrow()).x2.borrow()))
         + (*(*p2.borrow()).x3.borrow()));
 }

--- a/tests/unit/out/refcount/pointer_array.rs
+++ b/tests/unit/out/refcount/pointer_array.rs
@@ -52,9 +52,6 @@ fn main_0() -> i32 {
             (x.as_pointer()),
         ]))),
     }));
-    ({
-        let _s: Ptr<StackArray> = s.as_pointer();
-        IncrementAll_0(_s)
-    });
+    ({ IncrementAll_0(s.as_pointer()) });
     return (*x.borrow());
 }

--- a/tests/unit/out/refcount/pointer_call_offset.rs
+++ b/tests/unit/out/refcount/pointer_call_offset.rs
@@ -26,12 +26,9 @@ fn main_0() -> i32 {
         (*i.borrow_mut()).prefix_inc();
     }
     let out: Value<i32> = Rc::new(RefCell::new(
-        (({
-            let _p: Ptr<i32> = ((*p1.borrow()).offset((1) as isize));
-            foo_0(_p)
-        })
-        .offset((3) as isize)
-        .read()),
+        (({ foo_0(((*p1.borrow()).offset((1) as isize))) })
+            .offset((3) as isize)
+            .read()),
     ));
     (*p1.borrow()).delete_array();
     return (*out.borrow());

--- a/tests/unit/out/refcount/pointers.rs
+++ b/tests/unit/out/refcount/pointers.rs
@@ -49,11 +49,7 @@ pub fn Update_0(t: Ptr<Test>) -> Ptr<Test> {
     let x: Value<i32> = Rc::new(RefCell::new(1));
     let y: Value<i32> = Rc::new(RefCell::new(2));
     (*x.borrow_mut()).prefix_inc();
-    ({
-        let _x: i32 = (*x.borrow());
-        let _y: i32 = (*y.borrow());
-        (*(*t.borrow()).upgrade().deref()).update(_x, _y)
-    });
+    ({ (*(*t.borrow()).upgrade().deref()).update((*x.borrow()), (*y.borrow())) });
     (*x.borrow_mut()) = (*(*(*t.borrow()).upgrade().deref()).x.borrow());
     (*y.borrow_mut()) = (*(*(*t.borrow()).upgrade().deref()).x.borrow());
     ({
@@ -70,12 +66,7 @@ fn main_0() -> i32 {
     let t1: Value<Test> = Rc::new(RefCell::new(Test {
         x: Rc::new(RefCell::new(100)),
     }));
-    let t2: Value<Ptr<Test>> = Rc::new(RefCell::new(
-        ({
-            let _t: Ptr<Test> = (t1.as_pointer());
-            Update_0(_t)
-        }),
-    ));
+    let t2: Value<Ptr<Test>> = Rc::new(RefCell::new(({ Update_0((t1.as_pointer())) })));
     let t3: Value<Ptr<Test>> = Rc::new(RefCell::new(Ptr::<Test>::null()));
     (*t3.borrow_mut()) = (*t2.borrow()).clone();
     (*(*(*t3.borrow()).upgrade().deref()).x.borrow_mut()) = 15;

--- a/tests/unit/out/refcount/printfs.rs
+++ b/tests/unit/out/refcount/printfs.rs
@@ -41,23 +41,19 @@ fn main_0() -> i32 {
         "{}",
         (Rc::new(RefCell::new(
             ({
-                let _v: Vec<u8> = Ptr::from_string_literal(b"foo")
-                    .to_c_string_iterator()
-                    .chain(std::iter::once(0))
-                    .collect::<Vec<u8>>();
-                fn_0(_v)
+                fn_0(
+                    Ptr::from_string_literal(b"foo")
+                        .to_c_string_iterator()
+                        .chain(std::iter::once(0))
+                        .collect::<Vec<u8>>(),
+                )
             })
         ))
         .as_pointer() as Ptr<u8>)
     );
     println!(
         "{}",
-        (({
-            let _v: Ptr<Vec<u8>> = s.as_pointer();
-            fn2_1(_v)
-        })
-        .to_strong()
-        .as_pointer() as Ptr<u8>)
+        (({ fn2_1(s.as_pointer(),) }).to_strong().as_pointer() as Ptr<u8>)
     );
     return 0;
 }

--- a/tests/unit/out/refcount/prvalue-as-lvalue.rs
+++ b/tests/unit/out/refcount/prvalue-as-lvalue.rs
@@ -15,9 +15,6 @@ pub fn main() {
 fn main_0() -> i32 {
     let a: Value<i32> = Rc::new(RefCell::new(1));
     let pa: Value<Ptr<i32>> = Rc::new(RefCell::new((a.as_pointer())));
-    let b: Ptr<i32> = ({
-        let _a: Ptr<i32> = (*pa.borrow()).clone();
-        foo_0(_a)
-    });
+    let b: Ptr<i32> = ({ foo_0((*pa.borrow()).clone()) });
     return (b.read());
 }

--- a/tests/unit/out/refcount/push_emplace_back.rs
+++ b/tests/unit/out/refcount/push_emplace_back.rs
@@ -166,10 +166,7 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let vecs: Value<Vec<Value<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
-    ({
-        let _dest: Ptr<Vec<Value<Vec<u8>>>> = (vecs.as_pointer());
-        push_param_0(_dest)
-    });
+    ({ push_param_0((vecs.as_pointer())) });
     assert!(((*vecs.borrow()).len() == 1_usize));
     assert!((*((vecs.as_pointer() as Ptr<Value<Vec<u8>>>)
         .offset(0_usize as isize)
@@ -180,10 +177,7 @@ fn main_0() -> i32 {
         .deref())
     .is_empty());
     let jpg: Value<JPEGData> = Rc::new(RefCell::new(<JPEGData>::default()));
-    ({
-        let _jpg: Ptr<JPEGData> = (jpg.as_pointer());
-        push_local_from_field_1(_jpg, true)
-    });
+    ({ push_local_from_field_1((jpg.as_pointer()), true) });
     assert!(((*(*jpg.borrow()).com_data.borrow()).len() == 1_usize));
     assert!(
         ((*(((*jpg.borrow()).com_data.as_pointer() as Ptr<Value<Vec<u8>>>)
@@ -228,18 +222,12 @@ fn main_0() -> i32 {
     );
     assert!((*(*jpg.borrow()).app_data.borrow()).is_empty());
     let chunks: Value<Vec<Chunk>> = Rc::new(RefCell::new(Vec::new()));
-    ({
-        let _comps: Ptr<Vec<Chunk>> = (chunks.as_pointer());
-        shrink_through_ptr_2(_comps)
-    });
+    ({ shrink_through_ptr_2((chunks.as_pointer())) });
     assert!((*chunks.borrow()).is_empty());
     let w: Value<Writer> = Rc::new(RefCell::new(<Writer>::default()));
     (*(*(*w.borrow()).chunk.borrow()).data.borrow_mut()) = 42;
     (*(*w.borrow()).output.borrow_mut()) = (chunks.as_pointer());
-    ({
-        let _bw: Ptr<Writer> = (w.as_pointer());
-        nested_push_move_3(_bw)
-    });
+    ({ nested_push_move_3((w.as_pointer())) });
     assert!(((*chunks.borrow()).len() == 1_usize));
     assert!(
         ((*(*(chunks.as_pointer() as Ptr<Chunk>)
@@ -250,10 +238,7 @@ fn main_0() -> i32 {
         .borrow())
             == 42)
     );
-    ({
-        let _jpg: Ptr<JPEGData> = (jpg.as_pointer());
-        emplace_local_from_field_4(_jpg, false)
-    });
+    ({ emplace_local_from_field_4((jpg.as_pointer()), false) });
     assert!(((*(*jpg.borrow()).app_data.borrow()).len() == 1_usize));
     assert!(
         ((*(((*jpg.borrow()).app_data.as_pointer() as Ptr<Value<Vec<u8>>>)
@@ -289,10 +274,7 @@ fn main_0() -> i32 {
     assert!(((*(*jpg.borrow()).com_data.borrow()).len() == 1_usize));
     (*(*(*w.borrow()).chunk.borrow()).data.borrow_mut()) = 99;
     (*(*w.borrow()).output.borrow_mut()) = (chunks.as_pointer());
-    ({
-        let _bw: Ptr<Writer> = (w.as_pointer());
-        nested_emplace_move_5(_bw)
-    });
+    ({ nested_emplace_move_5((w.as_pointer())) });
     assert!(((*chunks.borrow()).len() == 2_usize));
     assert!(
         ((*(*(chunks.as_pointer() as Ptr<Chunk>)
@@ -303,10 +285,7 @@ fn main_0() -> i32 {
         .borrow())
             == 99)
     );
-    ({
-        let _comps: Ptr<Vec<Chunk>> = (chunks.as_pointer());
-        self_ref_push_6(_comps)
-    });
+    ({ self_ref_push_6((chunks.as_pointer())) });
     assert!(((*chunks.borrow()).len() == 3_usize));
     assert!(
         ((*(*(chunks.as_pointer() as Ptr<Chunk>)

--- a/tests/unit/out/refcount/redundant_copy_in_conversion.rs
+++ b/tests/unit/out/refcount/redundant_copy_in_conversion.rs
@@ -42,10 +42,7 @@ fn main_0() -> i32 {
             1
         },
     ));
-    (*r.borrow_mut()) += ({
-        let _it: RefcountMapIter<i32, i32> = (*it0.borrow()).clone();
-        sink_0(_it)
-    });
+    (*r.borrow_mut()) += ({ sink_0((*it0.borrow()).clone()) });
     (*r.borrow_mut()) += if (*end.borrow()) == (*end.borrow()) {
         0
     } else {

--- a/tests/unit/out/refcount/ref_calls.rs
+++ b/tests/unit/out/refcount/ref_calls.rs
@@ -17,34 +17,13 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(5));
-    let y: Value<i32> = Rc::new(RefCell::new(
-        (({
-            let _x: Ptr<i32> = x.as_pointer();
-            foo_1(_x)
-        })
-        .read()),
-    ));
-    let z: Ptr<i32> = ({
-        let _x: Ptr<i32> = x.as_pointer();
-        foo_1(_x)
-    });
+    let y: Value<i32> = Rc::new(RefCell::new((({ foo_1(x.as_pointer()) }).read())));
+    let z: Ptr<i32> = ({ foo_1(x.as_pointer()) });
     return {
         let _lhs = {
-            let _lhs = ((({
-                let _x: Ptr<i32> = x.as_pointer();
-                foo_1(_x)
-            })
-            .read())
-                + (({
-                    let _x: Ptr<i32> = y.as_pointer();
-                    foo_1(_x)
-                })
-                .read()));
-            _lhs + (({
-                let _x: Ptr<i32> = (z).clone();
-                foo_1(_x)
-            })
-            .read())
+            let _lhs =
+                ((({ foo_1(x.as_pointer()) }).read()) + (({ foo_1(y.as_pointer()) }).read()));
+            _lhs + (({ foo_1((z).clone()) }).read())
         };
         _lhs + ({ bar_0() })
     };

--- a/tests/unit/out/refcount/references2.rs
+++ b/tests/unit/out/refcount/references2.rs
@@ -16,9 +16,6 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let a: Value<Option<Value<i32>>> = Rc::new(RefCell::new(Some(Rc::new(RefCell::new(5)))));
-    ({
-        let _p: Ptr<Option<Value<i32>>> = a.as_pointer();
-        change_0(_p)
-    });
+    ({ change_0(a.as_pointer()) });
     return (*(*a.borrow()).as_ref().unwrap().borrow());
 }

--- a/tests/unit/out/refcount/refs_as_args.rs
+++ b/tests/unit/out/refcount/refs_as_args.rs
@@ -48,10 +48,6 @@ pub fn main() {
 fn main_0() -> i32 {
     let x1: Value<i32> = Rc::new(RefCell::new(1));
     let x2: Value<i32> = Rc::new(RefCell::new(2));
-    ({
-        let _r1: Ptr<i32> = x1.as_pointer();
-        let _r2: Ptr<i32> = x2.as_pointer();
-        more_refs_0(3, 4, _r1, _r2)
-    });
+    ({ more_refs_0(3, 4, x1.as_pointer(), x2.as_pointer()) });
     return ((*x1.borrow()) + (*x2.borrow()));
 }

--- a/tests/unit/out/refcount/size_t_ssize_t.rs
+++ b/tests/unit/out/refcount/size_t_ssize_t.rs
@@ -64,10 +64,11 @@ fn main_0() -> i32 {
     assert!(((*sz.borrow()) == 21_usize));
     let fr: Value<usize> = Rc::new(RefCell::new(
         ({
-            let _a: usize = ((::std::mem::size_of::<i32>() as u64)
-                .wrapping_add(((*sz.borrow()) as u64)) as usize);
-            let _b: usize = ((*ul.borrow()) as usize);
-            add_sizes_0(_a, _b)
+            add_sizes_0(
+                ((::std::mem::size_of::<i32>() as u64).wrapping_add(((*sz.borrow()) as u64))
+                    as usize),
+                ((*ul.borrow()) as usize),
+            )
         }),
     ));
     assert!(
@@ -75,12 +76,7 @@ fn main_0() -> i32 {
             == ((::std::mem::size_of::<i32>() as usize).wrapping_add(21_usize) as usize)
                 .wrapping_add(10_usize))
     );
-    let fr2: Value<u64> = Rc::new(RefCell::new(
-        ({
-            let _x: u64 = ((*sz.borrow()) as u64);
-            take_ulong_1(_x)
-        }),
-    ));
+    let fr2: Value<u64> = Rc::new(RefCell::new(({ take_ulong_1(((*sz.borrow()) as u64)) })));
     assert!(((*fr2.borrow()) == 21_u64));
     let lo: Value<usize> = Rc::new(RefCell::new(
         ({
@@ -167,11 +163,7 @@ fn main_0() -> i32 {
     let s1: Value<isize> = Rc::new(RefCell::new(5_isize));
     let s2: Value<isize> = Rc::new(RefCell::new(12_isize));
     let sd: Value<isize> = Rc::new(RefCell::new(
-        ({
-            let _a: isize = (*s1.borrow());
-            let _b: isize = (*s2.borrow());
-            sub_signed_2(_a, _b)
-        }),
+        ({ sub_signed_2((*s1.borrow()), (*s2.borrow())) }),
     ));
     assert!(((*sd.borrow()) == (-7_i32 as isize)));
     assert!(((*sd.borrow()) < 0_isize));

--- a/tests/unit/out/refcount/string_literals.rs
+++ b/tests/unit/out/refcount/string_literals.rs
@@ -32,34 +32,16 @@ fn main_0() -> i32 {
         Rc::new(RefCell::new(vec![0u8; 1].into_boxed_slice()));
     let immutable_empty_arr: Value<Box<[u8]>> =
         Rc::new(RefCell::new(vec![0u8; 1].into_boxed_slice()));
-    ({
-        let _str: Ptr<u8> = (mutable_string_arr.as_pointer() as Ptr<u8>);
-        foo_mut_0(_str)
-    });
+    ({ foo_mut_0((mutable_string_arr.as_pointer() as Ptr<u8>)) });
     ({ foo_const_1(Ptr::from_string_literal(b"world")) });
-    ({
-        let _str: Ptr<u8> = (*immutable_string.borrow()).clone();
-        foo_const_1(_str)
-    });
-    ({
-        let _str: Ptr<u8> = (immutable_string_arr.as_pointer() as Ptr<u8>);
-        foo_const_1(_str)
-    });
+    ({ foo_const_1((*immutable_string.borrow()).clone()) });
+    ({ foo_const_1((immutable_string_arr.as_pointer() as Ptr<u8>)) });
     ({ foo_const_1(Ptr::from_string_literal(b"")) });
-    ({
-        let _str: Ptr<u8> = (*immutable_empty.borrow()).clone();
-        foo_const_1(_str)
-    });
-    ({
-        let _str: Ptr<u8> = (immutable_empty_arr.as_pointer() as Ptr<u8>);
-        foo_const_1(_str)
-    });
+    ({ foo_const_1((*immutable_empty.borrow()).clone()) });
+    ({ foo_const_1((immutable_empty_arr.as_pointer() as Ptr<u8>)) });
     let inited_through_init_list: Value<Box<[u8]>> = Rc::new(RefCell::new(Box::<[u8]>::from(
         b"papanasi cu smantana\0".as_slice(),
     )));
-    ({
-        let _str: Ptr<u8> = (inited_through_init_list.as_pointer() as Ptr<u8>);
-        foo_const_1(_str)
-    });
+    ({ foo_const_1((inited_through_init_list.as_pointer() as Ptr<u8>)) });
     return 0;
 }

--- a/tests/unit/out/refcount/string_literals_c.rs
+++ b/tests/unit/out/refcount/string_literals_c.rs
@@ -40,54 +40,21 @@ fn main_0() -> i32 {
     let immutable_empty_arr: Value<Box<[u8]>> =
         Rc::new(RefCell::new(vec![0u8; 1].into_boxed_slice()));
     ({ foo_mut_0(Ptr::from_string_literal(b"world")) });
-    ({
-        let _str: Ptr<u8> = (*mutable_string.borrow()).clone();
-        foo_mut_0(_str)
-    });
-    ({
-        let _str: Ptr<u8> = (mutable_string_arr.as_pointer() as Ptr<u8>);
-        foo_mut_0(_str)
-    });
+    ({ foo_mut_0((*mutable_string.borrow()).clone()) });
+    ({ foo_mut_0((mutable_string_arr.as_pointer() as Ptr<u8>)) });
     ({ foo_const_1(Ptr::from_string_literal(b"world")) });
-    ({
-        let _str: Ptr<u8> = (*mutable_string.borrow()).clone();
-        foo_const_1(_str)
-    });
-    ({
-        let _str: Ptr<u8> = (*immutable_string.borrow()).clone();
-        foo_const_1(_str)
-    });
-    ({
-        let _str: Ptr<u8> = (mutable_string_arr.as_pointer() as Ptr<u8>);
-        foo_const_1(_str)
-    });
-    ({
-        let _str: Ptr<u8> = (immutable_string_arr.as_pointer() as Ptr<u8>);
-        foo_const_1(_str)
-    });
+    ({ foo_const_1((*mutable_string.borrow()).clone()) });
+    ({ foo_const_1((*immutable_string.borrow()).clone()) });
+    ({ foo_const_1((mutable_string_arr.as_pointer() as Ptr<u8>)) });
+    ({ foo_const_1((immutable_string_arr.as_pointer() as Ptr<u8>)) });
     ({ foo_const_1(Ptr::from_string_literal(b"")) });
-    ({
-        let _str: Ptr<u8> = (*mutable_empty.borrow()).clone();
-        foo_const_1(_str)
-    });
-    ({
-        let _str: Ptr<u8> = (*immutable_empty.borrow()).clone();
-        foo_const_1(_str)
-    });
-    ({
-        let _str: Ptr<u8> = (mutable_empty_arr.as_pointer() as Ptr<u8>);
-        foo_const_1(_str)
-    });
-    ({
-        let _str: Ptr<u8> = (immutable_empty_arr.as_pointer() as Ptr<u8>);
-        foo_const_1(_str)
-    });
+    ({ foo_const_1((*mutable_empty.borrow()).clone()) });
+    ({ foo_const_1((*immutable_empty.borrow()).clone()) });
+    ({ foo_const_1((mutable_empty_arr.as_pointer() as Ptr<u8>)) });
+    ({ foo_const_1((immutable_empty_arr.as_pointer() as Ptr<u8>)) });
     let inited_through_init_list: Value<Box<[u8]>> = Rc::new(RefCell::new(Box::<[u8]>::from(
         b"papanasi cu smantana\0".as_slice(),
     )));
-    ({
-        let _str: Ptr<u8> = (inited_through_init_list.as_pointer() as Ptr<u8>);
-        foo_const_1(_str)
-    });
+    ({ foo_const_1((inited_through_init_list.as_pointer() as Ptr<u8>)) });
     return 0;
 }

--- a/tests/unit/out/refcount/string_literals_return.rs
+++ b/tests/unit/out/refcount/string_literals_return.rs
@@ -33,12 +33,7 @@ fn main_0() -> i32 {
     assert!(((((*c.borrow()).offset((0) as isize).read()) as i32) == (('p' as u8) as i32)));
     assert!(((((*c.borrow()).offset((7) as isize).read()) as i32) == (('e' as u8) as i32)));
     assert!(((((*c.borrow()).offset((8) as isize).read()) as i32) == (('\0' as u8) as i32)));
-    let d: Value<Ptr<u8>> = Rc::new(RefCell::new(
-        ({
-            let _x: i32 = -1_i32;
-            get_branch_2(_x)
-        }),
-    ));
+    let d: Value<Ptr<u8>> = Rc::new(RefCell::new(({ get_branch_2(-1_i32) })));
     assert!(((((*d.borrow()).offset((0) as isize).read()) as i32) == (('n' as u8) as i32)));
     assert!(((((*d.borrow()).offset((11) as isize).read()) as i32) == (('e' as u8) as i32)));
     assert!(((((*d.borrow()).offset((12) as isize).read()) as i32) == (('\0' as u8) as i32)));

--- a/tests/unit/out/refcount/string_literals_return_c.rs
+++ b/tests/unit/out/refcount/string_literals_return_c.rs
@@ -39,12 +39,7 @@ fn main_0() -> i32 {
     assert!(
         ((((((*c.borrow()).offset((8) as isize).read()) as i32) == ('\0' as i32)) as i32) != 0)
     );
-    let d: Value<Ptr<u8>> = Rc::new(RefCell::new(
-        ({
-            let _x: i32 = -1_i32;
-            get_branch_2(_x)
-        }),
-    ));
+    let d: Value<Ptr<u8>> = Rc::new(RefCell::new(({ get_branch_2(-1_i32) })));
     assert!(((((((*d.borrow()).offset((0) as isize).read()) as i32) == ('n' as i32)) as i32) != 0));
     assert!(
         ((((((*d.borrow()).offset((11) as isize).read()) as i32) == ('e' as i32)) as i32) != 0)

--- a/tests/unit/out/refcount/strlen.rs
+++ b/tests/unit/out/refcount/strlen.rs
@@ -26,8 +26,5 @@ fn main_0() -> i32 {
         ('o' as u8),
         ('\0' as u8),
     ])));
-    return (({
-        let _ptr: Ptr<u8> = ((string.as_pointer() as Ptr<u8>).offset(0 as isize));
-        strlen_0(_ptr)
-    }) as i32);
+    return (({ strlen_0(((string.as_pointer() as Ptr<u8>).offset(0 as isize))) }) as i32);
 }

--- a/tests/unit/out/refcount/strlen_diff.rs
+++ b/tests/unit/out/refcount/strlen_diff.rs
@@ -27,8 +27,5 @@ fn main_0() -> i32 {
         ('g' as u8),
         ('\0' as u8),
     ])));
-    return (({
-        let _s: Ptr<u8> = ((s.as_pointer() as Ptr<u8>).offset(0 as isize));
-        strlen_0(_s)
-    }) as i32);
+    return (({ strlen_0(((s.as_pointer() as Ptr<u8>).offset(0 as isize))) }) as i32);
 }

--- a/tests/unit/out/refcount/strlen_rec.rs
+++ b/tests/unit/out/refcount/strlen_rec.rs
@@ -10,11 +10,7 @@ pub fn strlen_0(s: Ptr<u8>, n: i32) -> i32 {
     let s: Value<Ptr<u8>> = Rc::new(RefCell::new(s));
     let n: Value<i32> = Rc::new(RefCell::new(n));
     return if (((*s.borrow()).read()) != 0) {
-        ({
-            let _s: Ptr<u8> = (*s.borrow()).offset((1) as isize);
-            let _n: i32 = ((*n.borrow()) + 1);
-            strlen_0(_s, _n)
-        })
+        ({ strlen_0((*s.borrow()).offset((1) as isize), ((*n.borrow()) + 1)) })
     } else {
         (*n.borrow())
     };
@@ -29,8 +25,5 @@ fn main_0() -> i32 {
         ('r' as u8),
         ('\0' as u8),
     ])));
-    return ({
-        let _s: Ptr<u8> = ((s.as_pointer() as Ptr<u8>).offset(0 as isize));
-        strlen_0(_s, 0)
-    });
+    return ({ strlen_0(((s.as_pointer() as Ptr<u8>).offset(0 as isize)), 0) });
 }

--- a/tests/unit/out/refcount/struct_ctor.rs
+++ b/tests/unit/out/refcount/struct_ctor.rs
@@ -61,12 +61,7 @@ fn main_0() -> i32 {
     let struct_with_ctor: Value<StructWithCtor> =
         Rc::new(RefCell::new(StructWithCtor::StructWithCtor(1, 2)));
     let x: Value<i32> = Rc::new(RefCell::new(3));
-    return (((((({
-        let _x: Ptr<i32> = x.as_pointer();
-        foo_0(_x)
-    })
-    .read())
-        == 3)
+    return (((((({ foo_0(x.as_pointer()) }).read()) == 3)
         && ((({ (*struct_with_ctor.borrow()).x1() }).read()) == 2))
         && ((({ (*struct_with_ctor.borrow()).x2() }).read()) == 1)) as i32);
 }

--- a/tests/unit/out/refcount/swap.rs
+++ b/tests/unit/out/refcount/swap.rs
@@ -33,24 +33,11 @@ fn main_0() -> i32 {
     let local: Value<i32> = Rc::new(RefCell::new(0));
     let a: Value<i32> = Rc::new(RefCell::new(1));
     let b: Value<i32> = Rc::new(RefCell::new(2));
-    let c: Value<i32> = Rc::new(RefCell::new(
-        ({
-            let _x: i32 = (*local.borrow());
-            identity_0(_x)
-        }),
-    ));
+    let c: Value<i32> = Rc::new(RefCell::new(({ identity_0((*local.borrow())) })));
     let p: Value<Ptr<i32>> = Rc::new(RefCell::new((a.as_pointer())));
     (*p.borrow_mut()) = (b.as_pointer());
     (*p.borrow_mut()) = (a.as_pointer());
-    ({
-        let _a: Ptr<i32> = (*p.borrow()).clone();
-        let _b: Ptr<i32> = (b.as_pointer());
-        swap_by_ptr_1(_a, _b)
-    });
-    ({
-        let _a: Ptr<i32> = a.as_pointer();
-        let _b: Ptr<i32> = c.as_pointer();
-        swap_by_ref_2(_a, _b)
-    });
+    ({ swap_by_ptr_1((*p.borrow()).clone(), (b.as_pointer())) });
+    ({ swap_by_ref_2(a.as_pointer(), c.as_pointer()) });
     return (*c.borrow());
 }

--- a/tests/unit/out/refcount/swap_extended.rs
+++ b/tests/unit/out/refcount/swap_extended.rs
@@ -33,30 +33,17 @@ fn main_0() -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(0));
     write!(libcc2rs::cout(), "{:}\n", (*x.borrow()),);
     let a: Value<i32> = Rc::new(RefCell::new(1));
-    let b: Value<i32> = Rc::new(RefCell::new(
-        ({
-            let _x: i32 = (*a.borrow());
-            identity_0(_x)
-        }),
-    ));
+    let b: Value<i32> = Rc::new(RefCell::new(({ identity_0((*a.borrow())) })));
     write!(libcc2rs::cout(), "{:}\n", (*b.borrow()),);
     let c: Value<i32> = Rc::new(RefCell::new(2));
     let p: Value<Ptr<i32>> = Rc::new(RefCell::new((c.as_pointer())));
     write!(libcc2rs::cout(), "{:}\n", ((*p.borrow()).read()),);
     let d: Value<i32> = Rc::new(RefCell::new(3));
     let e: Value<i32> = Rc::new(RefCell::new(4));
-    ({
-        let _a: Ptr<i32> = (d.as_pointer());
-        let _b: Ptr<i32> = (e.as_pointer());
-        swap_by_ptr_1(_a, _b)
-    });
+    ({ swap_by_ptr_1((d.as_pointer()), (e.as_pointer())) });
     let f: Value<i32> = Rc::new(RefCell::new(4));
     let g: Value<i32> = Rc::new(RefCell::new(5));
-    ({
-        let _a: Ptr<i32> = f.as_pointer();
-        let _b: Ptr<i32> = g.as_pointer();
-        swap_by_ref_2(_a, _b)
-    });
+    ({ swap_by_ref_2(f.as_pointer(), g.as_pointer()) });
     let h: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::alloc(6)));
     write!(libcc2rs::cout(), "{:}\n", ((*h.borrow()).read()),);
     (*h.borrow()).delete();
@@ -72,25 +59,19 @@ fn main_0() -> i32 {
         ((*i.borrow()).offset((1) as isize).read()),
     );
     (*i.borrow()).delete_array();
+    ({ swap_by_ptr_1(Ptr::alloc(7), Ptr::alloc(8)) });
     ({
-        let _a: Ptr<i32> = Ptr::alloc(7);
-        let _b: Ptr<i32> = Ptr::alloc(8);
-        swap_by_ptr_1(_a, _b)
+        swap_by_ptr_1(
+            Ptr::alloc(7).offset((0) as isize),
+            Ptr::alloc(8).offset((0) as isize),
+        )
     });
+    ({ swap_by_ref_2(Ptr::alloc(9), Ptr::alloc(10)) });
     ({
-        let _a: Ptr<i32> = Ptr::alloc(7).offset((0) as isize);
-        let _b: Ptr<i32> = Ptr::alloc(8).offset((0) as isize);
-        swap_by_ptr_1(_a, _b)
-    });
-    ({
-        let _a: Ptr<i32> = Ptr::alloc(9);
-        let _b: Ptr<i32> = Ptr::alloc(10);
-        swap_by_ref_2(_a, _b)
-    });
-    ({
-        let _a: Ptr<i32> = (Ptr::alloc(9)).offset((0) as isize);
-        let _b: Ptr<i32> = (Ptr::alloc(10)).offset((0) as isize);
-        swap_by_ref_2(_a, _b)
+        swap_by_ref_2(
+            (Ptr::alloc(9)).offset((0) as isize),
+            (Ptr::alloc(10)).offset((0) as isize),
+        )
     });
     let j: Value<Option<Value<i32>>> = Rc::new(RefCell::new(Ptr::alloc(11).to_owned_opt()));
     let k: Value<Ptr<i32>> = Rc::new(RefCell::new((*j.borrow()).as_pointer()));

--- a/tests/unit/out/refcount/switch_complex_cond.rs
+++ b/tests/unit/out/refcount/switch_complex_cond.rs
@@ -36,30 +36,9 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let p_val: Value<i32> = Rc::new(RefCell::new(5));
-    assert!(
-        (({
-            let _p: Ptr<i32> = (p_val.as_pointer());
-            switch_complex_cond_0(_p, 0)
-        }) == 2)
-    );
-    assert!(
-        (({
-            let _p: Ptr<i32> = (p_val.as_pointer());
-            switch_complex_cond_0(_p, 5)
-        }) == 3)
-    );
-    assert!(
-        (({
-            let _p: Ptr<i32> = (p_val.as_pointer());
-            let _bias: i32 = -5_i32;
-            switch_complex_cond_0(_p, _bias)
-        }) == 1)
-    );
-    assert!(
-        (({
-            let _p: Ptr<i32> = (p_val.as_pointer());
-            switch_complex_cond_0(_p, 99)
-        }) == 0)
-    );
+    assert!((({ switch_complex_cond_0((p_val.as_pointer()), 0,) }) == 2));
+    assert!((({ switch_complex_cond_0((p_val.as_pointer()), 5,) }) == 3));
+    assert!((({ switch_complex_cond_0((p_val.as_pointer()), -5_i32,) }) == 1));
+    assert!((({ switch_complex_cond_0((p_val.as_pointer()), 99,) }) == 0));
     return 0;
 }

--- a/tests/unit/out/refcount/switch_enum.rs
+++ b/tests/unit/out/refcount/switch_enum.rs
@@ -47,23 +47,8 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    assert!(
-        (({
-            let _c: Color = Color::kRed;
-            switch_enum_0(_c)
-        }) == 10)
-    );
-    assert!(
-        (({
-            let _c: Color = Color::kGreen;
-            switch_enum_0(_c)
-        }) == 20)
-    );
-    assert!(
-        (({
-            let _c: Color = Color::kBlue;
-            switch_enum_0(_c)
-        }) == 30)
-    );
+    assert!((({ switch_enum_0(Color::kRed,) }) == 10));
+    assert!((({ switch_enum_0(Color::kGreen,) }) == 20));
+    assert!((({ switch_enum_0(Color::kBlue,) }) == 30));
     return 0;
 }

--- a/tests/unit/out/refcount/switch_mixed_literal_cases.rs
+++ b/tests/unit/out/refcount/switch_mixed_literal_cases.rs
@@ -34,20 +34,10 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    assert!(
-        (({
-            let _x: i32 = -1_i32;
-            mixed_literal_cases_0(_x)
-        }) == 1)
-    );
+    assert!((({ mixed_literal_cases_0(-1_i32,) }) == 1));
     assert!((({ mixed_literal_cases_0(16,) }) == 2));
     assert!((({ mixed_literal_cases_0(65152,) }) == 3));
-    assert!(
-        (({
-            let _x: i32 = -255_i32;
-            mixed_literal_cases_0(_x)
-        }) == 4)
-    );
+    assert!((({ mixed_literal_cases_0(-255_i32,) }) == 4));
     assert!((({ mixed_literal_cases_0(7,) }) == 0));
     return 0;
 }

--- a/tests/unit/out/refcount/switch_on_call.rs
+++ b/tests/unit/out/refcount/switch_on_call.rs
@@ -13,10 +13,7 @@ pub fn double_it_0(v: i32) -> i32 {
 pub fn switch_on_call_1(x: i32) -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(x));
     'switch: {
-        let __match_cond = ({
-            let _v: i32 = (*x.borrow());
-            double_it_0(_v)
-        });
+        let __match_cond = ({ double_it_0((*x.borrow())) });
         match __match_cond {
             __v if __v == 0 => {
                 return 100;

--- a/tests/unit/out/refcount/templates.rs
+++ b/tests/unit/out/refcount/templates.rs
@@ -50,28 +50,9 @@ pub fn main() {
 fn main_0() -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(10));
     let y: Value<f64> = Rc::new(RefCell::new(((*x.borrow()) as f64)));
-    return (((((((({
-        let _x: i32 = (*x.borrow());
-        foo_0(_x)
-    }) as f64)
-        + ({
-            let _x: f64 = (*y.borrow());
-            foo_1(_x)
-        }))
-        + ((({
-            let _p: Ptr<i32> = (x.as_pointer());
-            bar_2(_p, true)
-        })
-        .read()) as f64))
-        + (({
-            let _p: Ptr<f64> = (y.as_pointer());
-            bar_3(_p, true)
-        })
-        .read()))
+    return (((((((({ foo_0((*x.borrow())) }) as f64) + ({ foo_1((*y.borrow())) }))
+        + ((({ bar_2((x.as_pointer()), true) }).read()) as f64))
+        + (({ bar_3((y.as_pointer()), true) }).read()))
         + (({ func_4(1, 2, 3) }) as f64))
-        + (({
-            let _x2: i32 = (*x.borrow());
-            let _x3: f64 = (*y.borrow());
-            func_5(2.0E+0, _x2, _x3)
-        }) as f64)) as i32);
+        + (({ func_5(2.0E+0, (*x.borrow()), (*y.borrow())) }) as f64)) as i32);
 }

--- a/tests/unit/out/refcount/unique_ptr.rs
+++ b/tests/unit/out/refcount/unique_ptr.rs
@@ -236,8 +236,8 @@ pub fn RndStuff_2() {
                 == -2_i32)
         );
         ({
-            let _k: i32 = -10_i32;
-            (*x3.borrow()).as_ref().unwrap().borrow()[((*i.borrow()) as usize) as usize].inc(_k)
+            (*x3.borrow()).as_ref().unwrap().borrow()[((*i.borrow()) as usize) as usize]
+                .inc(-10_i32)
         });
         assert!(
             ((*(*(*p3_1.borrow())
@@ -269,12 +269,6 @@ fn main_0() -> i32 {
         Rc::new(RefCell::new(Some(Rc::new(RefCell::new(SafePointer {
             ptr: Rc::new(RefCell::new((*x.borrow_mut()).take())),
         })))));
-    ({
-        let _safe_ptr: Ptr<Option<Value<SafePointer>>> = safe_ptr.as_pointer();
-        DoStuffWithSafePointer_0(_safe_ptr)
-    });
-    return ({
-        let _safe_ptr: Option<Value<SafePointer>> = (*safe_ptr.borrow_mut()).take();
-        Consume_1(_safe_ptr)
-    });
+    ({ DoStuffWithSafePointer_0(safe_ptr.as_pointer()) });
+    return ({ Consume_1((*safe_ptr.borrow_mut()).take()) });
 }

--- a/tests/unit/out/refcount/unique_ptr_const_deref.rs
+++ b/tests/unit/out/refcount/unique_ptr_const_deref.rs
@@ -32,12 +32,6 @@ pub fn main() {
 fn main_0() -> i32 {
     let h: Value<Holder> = Rc::new(RefCell::new(<Holder>::default()));
     (*(*h.borrow()).val.borrow_mut()) = Some(Rc::new(RefCell::new(10)));
-    ({
-        let _h: Ptr<Holder> = (h.as_pointer());
-        write_val_1(_h, 42)
-    });
-    return ({
-        let _h: Ptr<Holder> = (h.as_pointer());
-        read_val_0(_h)
-    });
+    ({ write_val_1((h.as_pointer()), 42) });
+    return ({ read_val_0((h.as_pointer())) });
 }

--- a/tests/unit/out/refcount/unique_ptr_small.rs
+++ b/tests/unit/out/refcount/unique_ptr_small.rs
@@ -16,9 +16,6 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let n: Value<Option<Value<i32>>> = Rc::new(RefCell::new(Some(Rc::new(RefCell::new(10)))));
-    ({
-        let _n: Ptr<Option<Value<i32>>> = n.as_pointer();
-        change_0(_n)
-    });
+    ({ change_0(n.as_pointer()) });
     return (*(*n.borrow()).as_ref().unwrap().borrow());
 }

--- a/tests/unit/out/refcount/unique_ptr_struct.rs
+++ b/tests/unit/out/refcount/unique_ptr_struct.rs
@@ -50,10 +50,7 @@ fn main_0() -> i32 {
         + (*(*(*p.borrow()).as_ref().unwrap().borrow()).y.borrow()));
     (*(*(*p.borrow()).as_ref().unwrap().borrow()).y.borrow_mut()) = __rhs;
     let s: Value<i32> = Rc::new(RefCell::new(
-        ({
-            let _p: Point = (*(*p.borrow()).as_ref().unwrap().borrow()).clone();
-            sum_0(_p)
-        }),
+        ({ sum_0((*(*p.borrow()).as_ref().unwrap().borrow()).clone()) }),
     ));
     return (*s.borrow());
 }

--- a/tests/unit/out/refcount/va_arg_chain.rs
+++ b/tests/unit/out/refcount/va_arg_chain.rs
@@ -19,22 +19,14 @@ pub fn extract_nth_0(n: i32, ap: VaList) -> i32 {
 pub fn middle_layer_1(n: i32, ap: VaList) -> i32 {
     let n: Value<i32> = Rc::new(RefCell::new(n));
     let ap: Value<VaList> = Rc::new(RefCell::new(ap));
-    return ({
-        let _n: i32 = (*n.borrow());
-        let _ap: VaList = (*ap.borrow()).clone();
-        extract_nth_0(_n, _ap)
-    });
+    return ({ extract_nth_0((*n.borrow()), (*ap.borrow()).clone()) });
 }
 pub fn top_level_2(n: i32, __args: &[VaArg]) -> i32 {
     let n: Value<i32> = Rc::new(RefCell::new(n));
     let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
     (*ap.borrow_mut()) = VaList::new(__args);
     let result: Value<i32> = Rc::new(RefCell::new(
-        ({
-            let _n: i32 = (*n.borrow());
-            let _ap: VaList = (*ap.borrow()).clone();
-            middle_layer_1(_n, _ap)
-        }),
+        ({ middle_layer_1((*n.borrow()), (*ap.borrow()).clone()) }),
     ));
     return (*result.borrow());
 }

--- a/tests/unit/out/refcount/va_arg_fn_ptr.rs
+++ b/tests/unit/out/refcount/va_arg_fn_ptr.rs
@@ -26,12 +26,7 @@ pub fn apply_unary_3(x: i32, __args: &[VaArg]) -> i32 {
     let fn_: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(
         ((*ap.borrow_mut()).arg::<FnPtr<fn(i32) -> i32>>()).clone(),
     ));
-    let result: Value<i32> = Rc::new(RefCell::new(
-        ({
-            let _arg0: i32 = (*x.borrow());
-            (*(*fn_.borrow()))(_arg0)
-        }),
-    ));
+    let result: Value<i32> = Rc::new(RefCell::new(({ (*(*fn_.borrow()))((*x.borrow())) })));
     return (*result.borrow());
 }
 pub fn apply_binary_4(a: i32, b: i32, __args: &[VaArg]) -> i32 {
@@ -43,11 +38,7 @@ pub fn apply_binary_4(a: i32, b: i32, __args: &[VaArg]) -> i32 {
         ((*ap.borrow_mut()).arg::<FnPtr<fn(i32, i32) -> i32>>()).clone(),
     ));
     let result: Value<i32> = Rc::new(RefCell::new(
-        ({
-            let _arg0: i32 = (*a.borrow());
-            let _arg1: i32 = (*b.borrow());
-            (*(*fn_.borrow()))(_arg0, _arg1)
-        }),
+        ({ (*(*fn_.borrow()))((*a.borrow()), (*b.borrow())) }),
     ));
     return (*result.borrow());
 }

--- a/tests/unit/out/refcount/va_arg_forward.rs
+++ b/tests/unit/out/refcount/va_arg_forward.rs
@@ -22,11 +22,7 @@ pub fn outer_1(count: i32, __args: &[VaArg]) -> i32 {
     let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
     (*ap.borrow_mut()) = VaList::new(__args);
     let result: Value<i32> = Rc::new(RefCell::new(
-        ({
-            let _count: i32 = (*count.borrow());
-            let _ap: VaList = (*ap.borrow()).clone();
-            inner_0(_count, _ap)
-        }),
+        ({ inner_0((*count.borrow()), (*ap.borrow()).clone()) }),
     ));
     return (*result.borrow());
 }

--- a/tests/unit/out/refcount/va_arg_non_primitive_ptrs.rs
+++ b/tests/unit/out/refcount/va_arg_non_primitive_ptrs.rs
@@ -81,25 +81,19 @@ pub fn main() {
 fn main_0() -> i32 {
     let s: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::<u8>::null()));
     assert!(
-        (((({
-            let _option: i32 = (opt::OPT_STRING_OUT as i32);
-            dispatch_0(_option, &[(s.as_pointer()).into()])
-        }) == 1) as i32)
+        (((({ dispatch_0((opt::OPT_STRING_OUT as i32), &[(s.as_pointer()).into(),]) }) == 1)
+            as i32)
             != 0)
     );
     assert!((((!((*s.borrow()).is_null())) as i32) != 0));
     assert!(
-        (((({
-            let _option: i32 = (opt::OPT_FILE as i32);
-            dispatch_0(_option, &[(libcc2rs::cout()).into()])
-        }) == 1) as i32)
+        (((({ dispatch_0((opt::OPT_FILE as i32), &[(libcc2rs::cout()).into(),]) }) == 1) as i32)
             != 0)
     );
     assert!(
         (((({
-            let _option: i32 = (opt::OPT_FILE as i32);
             dispatch_0(
-                _option,
+                (opt::OPT_FILE as i32),
                 &[((AnyPtr::default())
                     .cast::<::std::fs::File>()
                     .expect("ub:wrong type"))
@@ -113,18 +107,13 @@ fn main_0() -> i32 {
         next: Rc::new(RefCell::new(Ptr::<node>::null())),
     }));
     assert!(
-        (((({
-            let _option: i32 = (opt::OPT_NODE as i32);
-            dispatch_0(_option, &[(head.as_pointer()).into()])
-        }) == 42) as i32)
+        (((({ dispatch_0((opt::OPT_NODE as i32), &[(head.as_pointer()).into(),]) }) == 42) as i32)
             != 0)
     );
     let outp: Value<Ptr<node>> = Rc::new(RefCell::new((head.as_pointer())));
     assert!(
-        (((({
-            let _option: i32 = (opt::OPT_NODE_OUT as i32);
-            dispatch_0(_option, &[(outp.as_pointer()).into()])
-        }) == 2) as i32)
+        (((({ dispatch_0((opt::OPT_NODE_OUT as i32), &[(outp.as_pointer()).into(),]) }) == 2)
+            as i32)
             != 0)
     );
     assert!(((((*outp.borrow()).is_null()) as i32) != 0));

--- a/tests/unit/out/refcount/va_arg_printf.rs
+++ b/tests/unit/out/refcount/va_arg_printf.rs
@@ -20,11 +20,7 @@ pub fn logf_1(fmt: Ptr<u8>, __args: &[VaArg]) -> i32 {
     let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
     (*ap.borrow_mut()) = VaList::new(__args);
     let result: Value<i32> = Rc::new(RefCell::new(
-        ({
-            let _fmt: Ptr<u8> = (*fmt.borrow()).clone();
-            let _ap: VaList = (*ap.borrow()).clone();
-            logf_impl_0(_fmt, _ap)
-        }),
+        ({ logf_impl_0((*fmt.borrow()).clone(), (*ap.borrow()).clone()) }),
     ));
     return (*result.borrow());
 }

--- a/tests/unit/out/refcount/va_arg_snprintf.rs
+++ b/tests/unit/out/refcount/va_arg_snprintf.rs
@@ -26,16 +26,24 @@ fn main_0() -> i32 {
     ));
     assert!(
         (((({
-            let _buf: Ptr<u8> = (buf.as_pointer() as Ptr<u8>);
-            extract_first_0(_buf, 1, Ptr::from_string_literal(b"%d"), &[(42).into()])
+            extract_first_0(
+                (buf.as_pointer() as Ptr<u8>),
+                1,
+                Ptr::from_string_literal(b"%d"),
+                &[(42).into()],
+            )
         }) == 42) as i32)
             != 0)
     );
     assert!((((((*buf.borrow())[(0) as usize] as i32) == 42) as i32) != 0));
     assert!(
         (((({
-            let _buf: Ptr<u8> = (buf.as_pointer() as Ptr<u8>);
-            extract_first_0(_buf, 1, Ptr::from_string_literal(b"%d"), &[(65).into()])
+            extract_first_0(
+                (buf.as_pointer() as Ptr<u8>),
+                1,
+                Ptr::from_string_literal(b"%d"),
+                &[(65).into()],
+            )
         }) == 65) as i32)
             != 0)
     );

--- a/tests/unit/out/refcount/va_arg_struct_ctx.rs
+++ b/tests/unit/out/refcount/va_arg_struct_ctx.rs
@@ -41,14 +41,20 @@ fn main_0() -> i32 {
     (*(*ctx.borrow()).verbose.borrow_mut()) = 1;
     (*(*ctx.borrow()).last_error.borrow_mut()) = 0;
     ({
-        let _ctx: Ptr<context> = (ctx.as_pointer());
-        set_error_0(_ctx, Ptr::from_string_literal(b"error %d"), &[(42).into()])
+        set_error_0(
+            (ctx.as_pointer()),
+            Ptr::from_string_literal(b"error %d"),
+            &[(42).into()],
+        )
     });
     assert!(((((*(*ctx.borrow()).last_error.borrow()) == 42) as i32) != 0));
     (*(*ctx.borrow()).verbose.borrow_mut()) = 0;
     ({
-        let _ctx: Ptr<context> = (ctx.as_pointer());
-        set_error_0(_ctx, Ptr::from_string_literal(b"error %d"), &[(99).into()])
+        set_error_0(
+            (ctx.as_pointer()),
+            Ptr::from_string_literal(b"error %d"),
+            &[(99).into()],
+        )
     });
     assert!(((((*(*ctx.borrow()).last_error.borrow()) == 42) as i32) != 0));
     return 0;

--- a/tests/unit/out/refcount/vector.rs
+++ b/tests/unit/out/refcount/vector.rs
@@ -79,10 +79,7 @@ fn main_0() -> i32 {
         (*v2.borrow_mut()).insert(__off, 100);
         (v2.as_pointer() as Ptr<i32>).clone()
     };
-    ({
-        let _copy_vector: Vec<i32> = (*v2.borrow()).clone();
-        copy_0(_copy_vector)
-    });
+    ({ copy_0((*v2.borrow()).clone()) });
     assert!(((*v2.borrow()).len() == 3_usize));
     assert!(
         (((v2.as_pointer() as Ptr<i32>)

--- a/tests/unit/out/refcount/vector2.rs
+++ b/tests/unit/out/refcount/vector2.rs
@@ -90,10 +90,6 @@ fn main_0() -> i32 {
     (*v.borrow_mut()).push(6);
     (*v2.borrow_mut()).push(8);
     (*v2.borrow_mut()).push(9);
-    ({
-        let _v: Ptr<Vec<i32>> = v.as_pointer();
-        let _v3: Vec<i32> = (*v2.borrow()).clone();
-        fn_0(_v, _v3)
-    });
+    ({ fn_0(v.as_pointer(), (*v2.borrow()).clone()) });
     return 0;
 }

--- a/tests/unit/out/refcount/void_cast.rs
+++ b/tests/unit/out/refcount/void_cast.rs
@@ -120,13 +120,7 @@ fn main_0() -> i32 {
     let hp: Value<Ptr<Holder>> = Rc::new(RefCell::new((h.as_pointer())));
     (*(*(*hp.borrow()).upgrade().deref()).field.borrow_mut());
     let nt: Value<NonTrivial> = Rc::new(RefCell::new(<NonTrivial>::default()));
-    ({
-        let _x: Ptr<NonTrivial> = nt.as_pointer();
-        unused_ref_param_1(_x)
-    });
-    ({
-        let _p: Ptr<NonTrivial> = (nt.as_pointer());
-        unused_ptr_param_2(_p)
-    });
+    ({ unused_ref_param_1(nt.as_pointer()) });
+    ({ unused_ptr_param_2((nt.as_pointer())) });
     return 0;
 }

--- a/tests/unit/out/refcount/z_bit_cast.rs
+++ b/tests/unit/out/refcount/z_bit_cast.rs
@@ -17,26 +17,11 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let a1: Value<Box<[u32]>> = Rc::new(RefCell::new(Box::new([1_u32, 2_u32, 3_u32])));
-    ({
-        let _a1: Ptr<u32> = (a1.as_pointer() as Ptr<u32>);
-        decay_cast_0(_a1)
-    });
-    ({
-        let _a1: Ptr<u32> = ((a1.as_pointer() as Ptr<u32>).offset(0 as isize));
-        decay_cast_0(_a1)
-    });
-    ({
-        let _p: AnyPtr = ((a1.as_pointer() as Ptr<u32>) as Ptr<u32>).to_any();
-        bit_cast_1(_p)
-    });
-    ({
-        let _p: AnyPtr = (((a1.as_pointer() as Ptr<u32>).offset(0 as isize)) as Ptr<u32>).to_any();
-        bit_cast_1(_p)
-    });
-    ({
-        let _p: AnyPtr = ((a1.as_pointer()) as Ptr<u32>).to_any();
-        bit_cast_1(_p)
-    });
+    ({ decay_cast_0((a1.as_pointer() as Ptr<u32>)) });
+    ({ decay_cast_0(((a1.as_pointer() as Ptr<u32>).offset(0 as isize))) });
+    ({ bit_cast_1(((a1.as_pointer() as Ptr<u32>) as Ptr<u32>).to_any()) });
+    ({ bit_cast_1((((a1.as_pointer() as Ptr<u32>).offset(0 as isize)) as Ptr<u32>).to_any()) });
+    ({ bit_cast_1(((a1.as_pointer()) as Ptr<u32>).to_any()) });
     let ptr: Value<AnyPtr> = Rc::new(RefCell::new(
         ((a1.as_pointer() as Ptr<u32>) as Ptr<u32>).to_any(),
     ));

--- a/tests/unit/out/unsafe/07_unique.rs
+++ b/tests/unit/out/unsafe/07_unique.rs
@@ -25,9 +25,6 @@ unsafe fn main_0() -> i32 {
     let mut f_ptr2: *mut i32 = (&mut (*f.as_deref_mut().unwrap()) as *mut i32);
     (*f_ptr2) = 11;
     f = Some(Box::new(9));
-    f = (unsafe {
-        let _u: Option<Box<i32>> = f;
-        fn_0(_u)
-    });
+    f = (unsafe { fn_0(f) });
     return (*f.as_deref_mut().unwrap());
 }

--- a/tests/unit/out/unsafe/11_move.rs
+++ b/tests/unit/out/unsafe/11_move.rs
@@ -17,9 +17,6 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut n: Option<Box<i32>> = Some(Box::new(10));
-    (unsafe {
-        let _n: *mut Option<Box<i32>> = &mut n as *mut Option<Box<i32>>;
-        change_0(_n)
-    });
+    (unsafe { change_0(&mut n as *mut Option<Box<i32>>) });
     return (*n.as_deref_mut().unwrap());
 }

--- a/tests/unit/out/unsafe/alloc_array.rs
+++ b/tests/unit/out/unsafe/alloc_array.rs
@@ -39,14 +39,6 @@ unsafe fn main_0() -> i32 {
             .map(|_| <i32>::default())
             .collect::<Box<[_]>>(),
     );
-    (unsafe {
-        let _arr: *mut Option<Box<[i32]>> = &mut arr as *mut Option<Box<[i32]>>;
-        let _N: i32 = N;
-        All_0(_arr, _N, 1)
-    });
-    return (unsafe {
-        let _arr: Option<Box<[i32]>> = arr;
-        let _N: i32 = N;
-        Consume_1(_arr, _N)
-    });
+    (unsafe { All_0(&mut arr as *mut Option<Box<[i32]>>, N, 1) });
+    return (unsafe { Consume_1(arr, N) });
 }

--- a/tests/unit/out/unsafe/bst.rs
+++ b/tests/unit/out/unsafe/bst.rs
@@ -15,17 +15,9 @@ pub struct node_t {
 }
 pub unsafe fn find_0(mut node: *mut node_t, mut value: i32) -> *mut node_t {
     if ((value) < ((*node).value)) && (!(((*node).left).is_null())) {
-        return (unsafe {
-            let _node: *mut node_t = (*node).left;
-            let _value: i32 = value;
-            find_0(_node, _value)
-        });
+        return (unsafe { find_0((*node).left, value) });
     } else if ((value) > ((*node).value)) && (!(((*node).right).is_null())) {
-        return (unsafe {
-            let _node: *mut node_t = (*node).right;
-            let _value: i32 = value;
-            find_0(_node, _value)
-        });
+        return (unsafe { find_0((*node).right, value) });
     } else if ((value) == ((*node).value)) {
         return node;
     }
@@ -36,17 +28,9 @@ pub unsafe fn insert_1(mut node: *mut node_t, mut new_node: *mut node_t) -> *mut
         return new_node;
     }
     if (((*new_node).value) < ((*node).value)) {
-        (*node).left = (unsafe {
-            let _node: *mut node_t = (*node).left;
-            let _new_node: *mut node_t = new_node;
-            insert_1(_node, _new_node)
-        });
+        (*node).left = (unsafe { insert_1((*node).left, new_node) });
     } else if (((*new_node).value) > ((*node).value)) {
-        (*node).right = (unsafe {
-            let _node: *mut node_t = (*node).right;
-            let _new_node: *mut node_t = new_node;
-            insert_1(_node, _new_node)
-        });
+        (*node).right = (unsafe { insert_1((*node).right, new_node) });
     }
     return node;
 }
@@ -82,59 +66,14 @@ unsafe fn main_0() -> i32 {
         value: 4,
     }));
     let mut ptr1: *mut node_t = (&mut (*tree.as_deref_mut().unwrap()) as *mut node_t);
-    ptr1 = (unsafe {
-        let _node: *mut node_t = ptr1;
-        let _new_node: *mut node_t = (&mut (*n1.as_deref_mut().unwrap()) as *mut node_t);
-        insert_1(_node, _new_node)
-    });
-    ptr1 = (unsafe {
-        let _node: *mut node_t = ptr1;
-        let _new_node: *mut node_t = (&mut (*n2.as_deref_mut().unwrap()) as *mut node_t);
-        insert_1(_node, _new_node)
-    });
-    ptr1 = (unsafe {
-        let _node: *mut node_t = ptr1;
-        let _new_node: *mut node_t = (&mut (*n3.as_deref_mut().unwrap()) as *mut node_t);
-        insert_1(_node, _new_node)
-    });
-    ptr1 = (unsafe {
-        let _node: *mut node_t = ptr1;
-        let _new_node: *mut node_t = (&mut (*n4.as_deref_mut().unwrap()) as *mut node_t);
-        insert_1(_node, _new_node)
-    });
-    return (((((((((*(unsafe {
-        let _node: *mut node_t = ptr1;
-        find_0(_node, 0)
-    }))
-    .value)
-        == (0))
-        && (((*(unsafe {
-            let _node: *mut node_t = ptr1;
-            find_0(_node, 1)
-        }))
-        .value)
-            == (1)))
-        && (((*(unsafe {
-            let _node: *mut node_t = ptr1;
-            find_0(_node, 2)
-        }))
-        .value)
-            == (2)))
-        && (((*(unsafe {
-            let _node: *mut node_t = ptr1;
-            find_0(_node, 3)
-        }))
-        .value)
-            == (3)))
-        && (((*(unsafe {
-            let _node: *mut node_t = ptr1;
-            find_0(_node, 4)
-        }))
-        .value)
-            == (4)))
-        && ((unsafe {
-            let _node: *mut node_t = ptr1;
-            find_0(_node, 5)
-        })
-        .is_null())) as i32);
+    ptr1 = (unsafe { insert_1(ptr1, (&mut (*n1.as_deref_mut().unwrap()) as *mut node_t)) });
+    ptr1 = (unsafe { insert_1(ptr1, (&mut (*n2.as_deref_mut().unwrap()) as *mut node_t)) });
+    ptr1 = (unsafe { insert_1(ptr1, (&mut (*n3.as_deref_mut().unwrap()) as *mut node_t)) });
+    ptr1 = (unsafe { insert_1(ptr1, (&mut (*n4.as_deref_mut().unwrap()) as *mut node_t)) });
+    return (((((((((*(unsafe { find_0(ptr1, 0) })).value) == (0))
+        && (((*(unsafe { find_0(ptr1, 1) })).value) == (1)))
+        && (((*(unsafe { find_0(ptr1, 2) })).value) == (2)))
+        && (((*(unsafe { find_0(ptr1, 3) })).value) == (3)))
+        && (((*(unsafe { find_0(ptr1, 4) })).value) == (4)))
+        && ((unsafe { find_0(ptr1, 5) }).is_null())) as i32);
 }

--- a/tests/unit/out/unsafe/cast_array_to_pointer_decay.rs
+++ b/tests/unit/out/unsafe/cast_array_to_pointer_decay.rs
@@ -24,11 +24,5 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut a: [i32; 2] = [1, 2];
     let mut s: [u8; 4] = [('a' as u8), ('b' as u8), ('c' as u8), ('\0' as u8)];
-    return ((unsafe {
-        let _p: *mut i32 = a.as_mut_ptr();
-        deref_0(_p)
-    }) + (unsafe {
-        let _s: *mut u8 = s.as_mut_ptr();
-        strlen_1(_s)
-    }));
+    return ((unsafe { deref_0(a.as_mut_ptr()) }) + (unsafe { strlen_1(s.as_mut_ptr()) }));
 }

--- a/tests/unit/out/unsafe/class.rs
+++ b/tests/unit/out/unsafe/class.rs
@@ -30,16 +30,14 @@ impl Pair {
         return ((unsafe { self.GetFirst() })
             + (unsafe {
                 let _field: *mut i32 = &mut self.first as *mut i32;
-                let _new_val: i32 = new_first;
-                self.Set(_field, _new_val)
+                self.Set(_field, new_first)
             }));
     }
     pub unsafe fn SetSecond(&mut self, mut new_second: i32) -> i32 {
         return ((unsafe { self.GetSecond() })
             + (unsafe {
                 let _field: *mut i32 = &mut self.second as *mut i32;
-                let _new_val: i32 = new_second;
-                self.Set(_field, _new_val)
+                self.Set(_field, new_second)
             }));
     }
 }
@@ -64,10 +62,7 @@ pub unsafe fn RandomRoute_0(route: *mut Route) -> i32 {
         });
     } else {
         return (unsafe {
-            let _new_second: i32 = (unsafe {
-                let _new_first: i32 = -10_i32;
-                (*route).path.SetFirst(_new_first)
-            });
+            let _new_second: i32 = (unsafe { (*route).path.SetFirst(-10_i32) });
             (*route).path.SetSecond(_new_second)
         });
     }
@@ -93,16 +88,8 @@ unsafe fn main_0() -> i32 {
         },
         cost: 10_f64,
     };
-    let mut old_cost: f64 = (unsafe {
-        let _new_cost: f64 = (unsafe { route2.SetCost(15_f64) });
-        route1.SetCost(_new_cost)
-    });
-    return (((((unsafe {
-        let _route: *mut Route = &mut route1 as *mut Route;
-        RandomRoute_0(_route)
-    }) + (unsafe {
-        let _route: *mut Route = &mut route2 as *mut Route;
-        RandomRoute_0(_route)
-    })) as f64)
+    let mut old_cost: f64 = (unsafe { route1.SetCost((unsafe { route2.SetCost(15_f64) })) });
+    return (((((unsafe { RandomRoute_0(&mut route1 as *mut Route) })
+        + (unsafe { RandomRoute_0(&mut route2 as *mut Route) })) as f64)
         + (old_cost)) as i32);
 }

--- a/tests/unit/out/unsafe/complex_function.rs
+++ b/tests/unit/out/unsafe/complex_function.rs
@@ -57,60 +57,22 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut x1: i32 = 0;
-    let mut x2: i32 = (unsafe {
-        let _x: i32 = x1;
-        foo_0(_x)
-    });
-    let mut x3: i32 = (((unsafe {
-        let _x: i32 = x2;
-        foo_0(_x)
-    }) + (unsafe {
-        let _x: i32 = x1;
-        foo_0(_x)
-    })) + (1));
+    let mut x2: i32 = (unsafe { foo_0(x1) });
+    let mut x3: i32 = (((unsafe { foo_0(x2) }) + (unsafe { foo_0(x1) })) + (1));
     x2 += 1;
-    x2 += (unsafe {
-        let _x: i32 = x1;
-        foo_0(_x)
-    });
-    x3 += (((unsafe {
-        let _x: i32 = x2;
-        foo_0(_x)
-    }) + (unsafe {
-        let _x: i32 = x3;
-        foo_0(_x)
-    })) + (1));
+    x2 += (unsafe { foo_0(x1) });
+    x3 += (((unsafe { foo_0(x2) }) + (unsafe { foo_0(x3) })) + (1));
     let mut p1: *mut i32 = (&mut x1 as *mut i32);
-    let mut p2: *mut i32 = (unsafe {
-        let _x: *mut i32 = p1;
-        ptr_1(_x)
-    });
+    let mut p2: *mut i32 = (unsafe { ptr_1(p1) });
     p1 = p2;
-    p2 = (unsafe {
-        let _x: *mut i32 = p1;
-        ptr_1(_x)
-    });
+    p2 = (unsafe { ptr_1(p1) });
     let r1: *mut i32 = &mut x1 as *mut i32;
-    let r2: *mut i32 = (unsafe {
-        let _x: *mut i32 = &mut x1 as *mut i32;
-        bar_2(_x)
-    });
-    let r3: *mut i32 = (unsafe {
-        let _x: *mut i32 = r1;
-        bar_2(_x)
-    });
+    let r2: *mut i32 = (unsafe { bar_2(&mut x1 as *mut i32) });
+    let r3: *mut i32 = (unsafe { bar_2(r1) });
     (*r2) += x1;
     (*r3) += (*r1);
-    let mut x4: i32 = (((unsafe {
-        let _x: i32 = x3;
-        foo_0(_x)
-    }) + (*(unsafe {
-        let _x: *mut i32 = (&mut x3 as *mut i32);
-        ptr_1(_x)
-    }))) + (*(unsafe {
-        let _x: *mut i32 = &mut x2 as *mut i32;
-        bar_2(_x)
-    })));
+    let mut x4: i32 = (((unsafe { foo_0(x3) }) + (*(unsafe { ptr_1((&mut x3 as *mut i32)) })))
+        + (*(unsafe { bar_2(&mut x2 as *mut i32) })));
     let mut a: X1 = X1 { v: 0 };
     let mut b: X2 = X2 {
         v: &mut a as *mut X1,
@@ -130,127 +92,106 @@ unsafe fn main_0() -> i32 {
     let r7: *mut X3 = &mut d.v as *mut X3;
     let r8: *mut i32 = &mut (*(unsafe { (*(unsafe { d.v.get() })).get() })).v as *mut i32;
     let mut x5: i32 = (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v;
-    (*(unsafe {
-        let _x: *mut i32 = &mut x1 as *mut i32;
-        bar_2(_x)
-    })) += 10;
-    (*(unsafe {
-        let _x: *mut i32 = &mut x1 as *mut i32;
-        bar_2(_x)
-    }))
-    .postfix_inc();
+    (*(unsafe { bar_2(&mut x1 as *mut i32) })) += 10;
+    (*(unsafe { bar_2(&mut x1 as *mut i32) })).postfix_inc();
     let mut bar_out: i32 = (*(unsafe {
-        let _x: *mut i32 =
-            &mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v as *mut i32;
-        bar_2(_x)
+        bar_2(
+            &mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v as *mut i32,
+        )
     }));
-    let mut bar_inc: i32 = (*(unsafe {
-        let _x: *mut i32 = &mut x1 as *mut i32;
-        bar_2(_x)
-    }))
-    .prefix_inc();
-    bar_inc = (*(unsafe {
-        let _x: *mut i32 = &mut x1 as *mut i32;
-        bar_2(_x)
-    }))
-    .postfix_inc();
-    bar_inc = (((*(unsafe {
-        let _x: *mut i32 = &mut x1 as *mut i32;
-        bar_2(_x)
-    })) + (unsafe {
-        let _x: i32 = x4;
-        foo_0(_x)
-    })) + (1));
+    let mut bar_inc: i32 = (*(unsafe { bar_2(&mut x1 as *mut i32) })).prefix_inc();
+    bar_inc = (*(unsafe { bar_2(&mut x1 as *mut i32) })).postfix_inc();
+    bar_inc = (((*(unsafe { bar_2(&mut x1 as *mut i32) })) + (unsafe { foo_0(x4) })) + (1));
     (*(unsafe {
-        let _x: *mut i32 =
-            &mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v as *mut i32;
-        bar_2(_x)
+        bar_2(
+            &mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v as *mut i32,
+        )
     })) += 10;
     (*(unsafe {
-        let _x: *mut i32 =
-            &mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v as *mut i32;
-        bar_2(_x)
+        bar_2(
+            &mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v as *mut i32,
+        )
     }))
     .postfix_inc();
     let mut bar_inc2: i32 = (*(unsafe {
-        let _x: *mut i32 =
-            &mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v as *mut i32;
-        bar_2(_x)
+        bar_2(
+            &mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v as *mut i32,
+        )
     }))
     .prefix_inc();
     bar_inc2 = (*(unsafe {
-        let _x: *mut i32 =
-            &mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v as *mut i32;
-        bar_2(_x)
+        bar_2(
+            &mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v as *mut i32,
+        )
     }))
     .postfix_inc();
+    (*(unsafe { ptr_1((&mut x1 as *mut i32)) })).prefix_inc();
+    (*(unsafe { ptr_1((&mut x1 as *mut i32)) })) += 1;
     (*(unsafe {
-        let _x: *mut i32 = (&mut x1 as *mut i32);
-        ptr_1(_x)
+        ptr_1(
+            (&mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v
+                as *mut i32),
+        )
     }))
     .prefix_inc();
     (*(unsafe {
-        let _x: *mut i32 = (&mut x1 as *mut i32);
-        ptr_1(_x)
-    })) += 1;
-    (*(unsafe {
-        let _x: *mut i32 = (&mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() }))
-            .v as *mut i32);
-        ptr_1(_x)
-    }))
-    .prefix_inc();
-    (*(unsafe {
-        let _x: *mut i32 = (&mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() }))
-            .v as *mut i32);
-        ptr_1(_x)
+        ptr_1(
+            (&mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v
+                as *mut i32),
+        )
     })) += 1;
     (*(&mut (*(unsafe {
-        let _x: *mut i32 = (&mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() }))
-            .v as *mut i32);
-        ptr_1(_x)
+        ptr_1(
+            (&mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v
+                as *mut i32),
+        )
     })) as *mut i32)) += 1;
     let mut ptr1: i32 = (*(unsafe {
-        let _x: *mut i32 = (&mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() }))
-            .v as *mut i32);
-        ptr_1(_x)
+        ptr_1(
+            (&mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v
+                as *mut i32),
+        )
     }))
     .postfix_inc();
     let ptr2: *mut i32 = &mut (*(unsafe {
-        let _x: *mut i32 = (&mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() }))
-            .v as *mut i32);
-        ptr_1(_x)
+        ptr_1(
+            (&mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v
+                as *mut i32),
+        )
     })) as *mut i32;
     let mut ptr3: *mut i32 = (&mut (*(unsafe {
-        let _x: *mut i32 = (&mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() }))
-            .v as *mut i32);
-        ptr_1(_x)
+        ptr_1(
+            (&mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v
+                as *mut i32),
+        )
     })) as *mut i32);
     let mut vptr: i32 = (*(unsafe {
-        let _x: *mut i32 = (&mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() }))
-            .v as *mut i32);
-        ptr_1(_x)
+        ptr_1(
+            (&mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v
+                as *mut i32),
+        )
     }));
     let mut pref: *mut i32 = (unsafe {
-        let _x: *mut i32 =
-            &mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v as *mut i32;
-        bar_2(_x)
+        bar_2(
+            &mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v as *mut i32,
+        )
     });
     (*(unsafe {
-        let _x: *mut i32 =
-            &mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v as *mut i32;
-        bar_2(_x)
+        bar_2(
+            &mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v as *mut i32,
+        )
     }))
     .postfix_inc();
     return (((*(unsafe {
-        let _x: *mut i32 = (&mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() }))
-            .v as *mut i32);
-        ptr_1(_x)
+        ptr_1(
+            (&mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v
+                as *mut i32),
+        )
     })) + (*(unsafe {
-        let _x: *mut i32 =
-            &mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v as *mut i32;
-        bar_2(_x)
+        bar_2(
+            &mut (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v as *mut i32,
+        )
     }))) + (unsafe {
-        let _x: i32 = (*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v;
-        foo_0(_x)
+        foo_0((*(unsafe { (*(unsafe { (*(unsafe { d.get() })).get() })).get() })).v)
     }));
 }

--- a/tests/unit/out/unsafe/doubly_linked_list.rs
+++ b/tests/unit/out/unsafe/doubly_linked_list.rs
@@ -44,10 +44,7 @@ pub unsafe fn Append_2(head: *mut Node, new_node: *mut Node) {
     'loop_: while !(((*curr).next).is_null()) {
         curr = (*curr).next;
     }
-    (unsafe {
-        let _n: *mut Node = (new_node);
-        (*curr).SetNext(_n)
-    });
+    (unsafe { (*curr).SetNext((new_node)) });
     (unsafe {
         let _p: *mut Node = curr;
         (*new_node).SetPrev(_p)
@@ -164,258 +161,48 @@ unsafe fn main_0() -> i32 {
         let _new_node: *mut Node = &mut n7 as *mut Node;
         Append_2(_head, _new_node)
     });
-    head = (unsafe {
-        let _head: *mut Node = head;
-        Delete_3(_head, 5)
-    });
-    head = (unsafe {
-        let _head: *mut Node = head;
-        Delete_3(_head, 0)
-    });
-    head = (unsafe {
-        let _head: *mut Node = head;
-        let _val: i32 = -2_i32;
-        Delete_3(_head, _val)
-    });
-    let mut tail: *mut Node = (unsafe {
-        let _head: *mut Node = head;
-        Tail_4(_head)
-    });
-    assert!(
-        (((*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 0)
-        }))
-        .val)
-            == (4))
-    );
-    assert!(
-        (((*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 1)
-        }))
-        .val)
-            == (3))
-    );
-    assert!(
-        (((*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 2)
-        }))
-        .val)
-            == (2))
-    );
-    assert!(
-        (((*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 3)
-        }))
-        .val)
-            == (1))
-    );
-    assert!(
-        (((*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 4)
-        }))
-        .val)
-            == (-1_i32))
-    );
-    assert!((unsafe {
-        let _head: *mut Node = head;
-        Find_0(_head, 5)
-    })
-    .is_null());
-    assert!(
-        (((*(unsafe {
-            let _tail: *mut Node = tail;
-            FindBack_1(_tail, 0)
-        }))
-        .val)
-            == (-1_i32))
-    );
-    assert!(
-        (((*(unsafe {
-            let _tail: *mut Node = tail;
-            FindBack_1(_tail, 1)
-        }))
-        .val)
-            == (1))
-    );
-    assert!(
-        (((*(unsafe {
-            let _tail: *mut Node = tail;
-            FindBack_1(_tail, 2)
-        }))
-        .val)
-            == (2))
-    );
-    assert!(
-        (((*(unsafe {
-            let _tail: *mut Node = tail;
-            FindBack_1(_tail, 3)
-        }))
-        .val)
-            == (3))
-    );
-    assert!(
-        (((*(unsafe {
-            let _tail: *mut Node = tail;
-            FindBack_1(_tail, 4)
-        }))
-        .val)
-            == (4))
-    );
-    assert!(((*(unsafe {
-        let _tail: *mut Node = tail;
-        FindBack_1(_tail, 4)
-    }))
-    .prev)
-        .is_null());
-    assert!(
-        (((*(*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 0)
-        }))
-        .next)
-            .val)
-            == (3))
-    );
-    assert!(
-        (((*(*(*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 1)
-        }))
-        .next)
-            .next)
-            .val)
-            == (1))
-    );
-    assert!(
-        (((*(*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 2)
-        }))
-        .prev)
-            .val)
-            == (3))
-    );
-    assert!(((*(unsafe {
-        let _head: *mut Node = head;
-        Find_0(_head, 4)
-    }))
-    .next)
-        .is_null());
-    assert!(
-        (((*(*(*(unsafe {
-            let _tail: *mut Node = tail;
-            FindBack_1(_tail, 1)
-        }))
-        .prev)
-            .prev)
-            .val)
-            == (3))
-    );
-    (*(*(unsafe {
-        let _head: *mut Node = head;
-        Find_0(_head, 0)
-    }))
-    .next)
-        .val = 30;
-    assert!(
-        (((*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 1)
-        }))
-        .val)
-            == (30))
-    );
-    (*(*(unsafe {
-        let _head: *mut Node = head;
-        Find_0(_head, 1)
-    }))
-    .next)
-        .val = (((*(unsafe {
-        let _head: *mut Node = head;
-        Find_0(_head, 0)
-    }))
-    .val)
-        + ((*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 3)
-        }))
-        .val));
-    assert!(
-        (((*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 2)
-        }))
-        .val)
-            == ((4) + (1)))
-    );
-    let mut sum: i32 = ((((((*(unsafe {
-        let _head: *mut Node = head;
-        Find_0(_head, 0)
-    }))
-    .val)
-        + ((*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 1)
-        }))
-        .val))
-        + ((*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 2)
-        }))
-        .val))
-        + ((*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 3)
-        }))
-        .val))
-        + ((*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 4)
-        }))
-        .val));
+    head = (unsafe { Delete_3(head, 5) });
+    head = (unsafe { Delete_3(head, 0) });
+    head = (unsafe { Delete_3(head, -2_i32) });
+    let mut tail: *mut Node = (unsafe { Tail_4(head) });
+    assert!((((*(unsafe { Find_0(head, 0,) })).val) == (4)));
+    assert!((((*(unsafe { Find_0(head, 1,) })).val) == (3)));
+    assert!((((*(unsafe { Find_0(head, 2,) })).val) == (2)));
+    assert!((((*(unsafe { Find_0(head, 3,) })).val) == (1)));
+    assert!((((*(unsafe { Find_0(head, 4,) })).val) == (-1_i32)));
+    assert!((unsafe { Find_0(head, 5,) }).is_null());
+    assert!((((*(unsafe { FindBack_1(tail, 0,) })).val) == (-1_i32)));
+    assert!((((*(unsafe { FindBack_1(tail, 1,) })).val) == (1)));
+    assert!((((*(unsafe { FindBack_1(tail, 2,) })).val) == (2)));
+    assert!((((*(unsafe { FindBack_1(tail, 3,) })).val) == (3)));
+    assert!((((*(unsafe { FindBack_1(tail, 4,) })).val) == (4)));
+    assert!(((*(unsafe { FindBack_1(tail, 4,) })).prev).is_null());
+    assert!((((*(*(unsafe { Find_0(head, 0,) })).next).val) == (3)));
+    assert!((((*(*(*(unsafe { Find_0(head, 1,) })).next).next).val) == (1)));
+    assert!((((*(*(unsafe { Find_0(head, 2,) })).prev).val) == (3)));
+    assert!(((*(unsafe { Find_0(head, 4,) })).next).is_null());
+    assert!((((*(*(*(unsafe { FindBack_1(tail, 1,) })).prev).prev).val) == (3)));
+    (*(*(unsafe { Find_0(head, 0) })).next).val = 30;
+    assert!((((*(unsafe { Find_0(head, 1,) })).val) == (30)));
+    (*(*(unsafe { Find_0(head, 1) })).next).val =
+        (((*(unsafe { Find_0(head, 0) })).val) + ((*(unsafe { Find_0(head, 3) })).val));
+    assert!((((*(unsafe { Find_0(head, 2,) })).val) == ((4) + (1))));
+    let mut sum: i32 = ((((((*(unsafe { Find_0(head, 0) })).val)
+        + ((*(unsafe { Find_0(head, 1) })).val))
+        + ((*(unsafe { Find_0(head, 2) })).val))
+        + ((*(unsafe { Find_0(head, 3) })).val))
+        + ((*(unsafe { Find_0(head, 4) })).val));
     assert!(((sum) == (((((4) + (30)) + (5)) + (1)) + (-1_i32))));
     assert!(
-        ((((*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 0)
-        }))
-        .val)
-            + ((*(unsafe {
-                let _tail: *mut Node = tail;
-                FindBack_1(_tail, 0)
-            }))
-            .val))
+        ((((*(unsafe { Find_0(head, 0,) })).val) + ((*(unsafe { FindBack_1(tail, 0,) })).val))
             == ((4) + (-1_i32)))
     );
     assert!(
-        (((*(*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 2)
-        }))
-        .next)
-            .val)
-            == ((*(unsafe {
-                let _tail: *mut Node = tail;
-                FindBack_1(_tail, 1)
-            }))
-            .val))
+        (((*(*(unsafe { Find_0(head, 2,) })).next).val)
+            == ((*(unsafe { FindBack_1(tail, 1,) })).val))
     );
     assert!(
-        (((*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 0)
-        }))
-        .prev)
-            == ((*(unsafe {
-                let _tail: *mut Node = tail;
-                FindBack_1(_tail, 4)
-            }))
-            .prev))
+        (((*(unsafe { Find_0(head, 0,) })).prev) == ((*(unsafe { FindBack_1(tail, 4,) })).prev))
     );
     return 0;
 }

--- a/tests/unit/out/unsafe/enum_int_interop.rs
+++ b/tests/unit/out/unsafe/enum_int_interop.rs
@@ -168,17 +168,11 @@ unsafe fn main_0() -> i32 {
     assert!(((oi) == (10)));
     o = Option::from(20);
     assert!(((o as i32) == (Option::OPT_B as i32)));
-    let mut rc: i32 = (unsafe {
-        let _option: i32 = (o as i32);
-        classify_option_5(_option)
-    });
+    let mut rc: i32 = (unsafe { classify_option_5((o as i32)) });
     assert!(((rc) == (2)));
     rc = (unsafe { classify_option_5(20) });
     assert!(((rc) == (2)));
-    rc = (unsafe {
-        let _option: i32 = (Option::OPT_C as i32);
-        classify_option_5(_option)
-    });
+    rc = (unsafe { classify_option_5((Option::OPT_C as i32)) });
     assert!(((rc) == (3)));
     let mut t: Tag = Tag::TAG_ONE;
     assert!(((t as i32) == (1)));

--- a/tests/unit/out/unsafe/enum_int_interop_c.rs
+++ b/tests/unit/out/unsafe/enum_int_interop_c.rs
@@ -168,17 +168,11 @@ unsafe fn main_0() -> i32 {
     assert!(((((oi) == (10)) as i32) != 0));
     o = Option::from(20);
     assert!(((((o as u32) == ((Option::OPT_B as i32) as u32)) as i32) != 0));
-    let mut rc: i32 = (unsafe {
-        let _option: i32 = (o as i32);
-        classify_option_5(_option)
-    });
+    let mut rc: i32 = (unsafe { classify_option_5((o as i32)) });
     assert!(((((rc) == (2)) as i32) != 0));
     rc = (unsafe { classify_option_5(20) });
     assert!(((((rc) == (2)) as i32) != 0));
-    rc = (unsafe {
-        let _option: i32 = (Option::OPT_C as i32);
-        classify_option_5(_option)
-    });
+    rc = (unsafe { classify_option_5((Option::OPT_C as i32)) });
     assert!(((((rc) == (3)) as i32) != 0));
     let mut t: Tag_enum = Tag_enum::TAG_ONE;
     assert!(((((t as u32) == (1_u32)) as i32) != 0));

--- a/tests/unit/out/unsafe/expr_as_bool_c.rs
+++ b/tests/unit/out/unsafe/expr_as_bool_c.rs
@@ -72,45 +72,13 @@ unsafe fn main_0() -> i32 {
     let mut both: i32 = (((!(p1).is_null()) && (!(p2).is_null())) as i32);
     assert!(((((either) == (1)) as i32) != 0));
     assert!(((((both) == (0)) as i32) != 0));
-    assert!(
-        ((((unsafe {
-            let _rc: i32 = -1_i32;
-            cmp_eq_0(_rc)
-        }) == (1)) as i32)
-            != 0)
-    );
+    assert!(((((unsafe { cmp_eq_0(-1_i32,) }) == (1)) as i32) != 0));
     assert!(((((unsafe { cmp_eq_0(0,) }) == (0)) as i32) != 0));
+    assert!(((((unsafe { cmp_or_ptr_1(p1, p2,) }) == (1)) as i32) != 0));
     assert!(
-        ((((unsafe {
-            let _p: *const u8 = p1;
-            let _q: *const u8 = p2;
-            cmp_or_ptr_1(_p, _q)
-        }) == (1)) as i32)
-            != 0)
+        ((((unsafe { cmp_or_ptr_1(std::ptr::null(), std::ptr::null(),) }) == (0)) as i32) != 0)
     );
-    assert!(
-        ((((unsafe {
-            let _p: *const u8 = std::ptr::null();
-            let _q: *const u8 = std::ptr::null();
-            cmp_or_ptr_1(_p, _q)
-        }) == (0)) as i32)
-            != 0)
-    );
-    assert!(
-        ((((unsafe {
-            let _s1: *const u8 = std::ptr::null();
-            let _s2: *const u8 = std::ptr::null();
-            both_null_2(_s1, _s2)
-        }) == (1)) as i32)
-            != 0)
-    );
-    assert!(
-        ((((unsafe {
-            let _s1: *const u8 = p1;
-            let _s2: *const u8 = std::ptr::null();
-            both_null_2(_s1, _s2)
-        }) == (0)) as i32)
-            != 0)
-    );
+    assert!(((((unsafe { both_null_2(std::ptr::null(), std::ptr::null(),) }) == (1)) as i32) != 0));
+    assert!(((((unsafe { both_null_2(p1, std::ptr::null(),) }) == (0)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/expr_as_bool_cpp.rs
+++ b/tests/unit/out/unsafe/expr_as_bool_cpp.rs
@@ -69,40 +69,11 @@ unsafe fn main_0() -> i32 {
     let mut both: i32 = (((!(p1).is_null()) && (!(p2).is_null())) as i32);
     assert!(((either) == (1)));
     assert!(((both) == (0)));
-    assert!(
-        ((unsafe {
-            let _rc: i32 = -1_i32;
-            cmp_eq_0(_rc)
-        }) == (1))
-    );
+    assert!(((unsafe { cmp_eq_0(-1_i32,) }) == (1)));
     assert!(((unsafe { cmp_eq_0(0,) }) == (0)));
-    assert!(
-        ((unsafe {
-            let _p: *const u8 = p1;
-            let _q: *const u8 = p2;
-            cmp_or_ptr_1(_p, _q)
-        }) == (1))
-    );
-    assert!(
-        ((unsafe {
-            let _p: *const u8 = std::ptr::null();
-            let _q: *const u8 = std::ptr::null();
-            cmp_or_ptr_1(_p, _q)
-        }) == (0))
-    );
-    assert!(
-        ((unsafe {
-            let _s1: *const u8 = std::ptr::null();
-            let _s2: *const u8 = std::ptr::null();
-            both_null_2(_s1, _s2)
-        }) == (1))
-    );
-    assert!(
-        ((unsafe {
-            let _s1: *const u8 = p1;
-            let _s2: *const u8 = std::ptr::null();
-            both_null_2(_s1, _s2)
-        }) == (0))
-    );
+    assert!(((unsafe { cmp_or_ptr_1(p1, p2,) }) == (1)));
+    assert!(((unsafe { cmp_or_ptr_1(std::ptr::null(), std::ptr::null(),) }) == (0)));
+    assert!(((unsafe { both_null_2(std::ptr::null(), std::ptr::null(),) }) == (1)));
+    assert!(((unsafe { both_null_2(p1, std::ptr::null(),) }) == (0)));
     return 0;
 }

--- a/tests/unit/out/unsafe/fatorial.rs
+++ b/tests/unit/out/unsafe/fatorial.rs
@@ -10,11 +10,7 @@ pub unsafe fn fatorial_0(mut n: i32) -> i32 {
     if ((n) == (0)) {
         return 1;
     }
-    return ((n)
-        * (unsafe {
-            let _n: i32 = ((n) - (1));
-            fatorial_0(_n)
-        }));
+    return ((n) * (unsafe { fatorial_0(((n) - (1))) }));
 }
 pub unsafe fn fatorial_by_ref_1(n: *mut i32) {
     if ((*n) == (1)) {
@@ -22,10 +18,7 @@ pub unsafe fn fatorial_by_ref_1(n: *mut i32) {
         return;
     }
     let mut n_1: i32 = ((*n) - (1));
-    (unsafe {
-        let _n: *mut i32 = &mut n_1 as *mut i32;
-        fatorial_by_ref_1(_n)
-    });
+    (unsafe { fatorial_by_ref_1(&mut n_1 as *mut i32) });
     (*n) *= n_1;
 }
 pub unsafe fn fatorial_by_ptr_2(mut n: *mut i32) {
@@ -34,10 +27,7 @@ pub unsafe fn fatorial_by_ptr_2(mut n: *mut i32) {
         return;
     }
     let mut n_1: i32 = ((*n) - (1));
-    (unsafe {
-        let _n: *mut i32 = (&mut n_1 as *mut i32);
-        fatorial_by_ptr_2(_n)
-    });
+    (unsafe { fatorial_by_ptr_2((&mut n_1 as *mut i32)) });
     (*n) *= n_1;
 }
 pub fn main() {
@@ -47,17 +37,8 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut n1: i32 = 2;
-    (unsafe {
-        let _n: *mut i32 = (&mut n1 as *mut i32);
-        fatorial_by_ptr_2(_n)
-    });
+    (unsafe { fatorial_by_ptr_2((&mut n1 as *mut i32)) });
     let mut n: i32 = ((n1) + (1));
-    (unsafe {
-        let _n: *mut i32 = &mut n as *mut i32;
-        fatorial_by_ref_1(_n)
-    });
-    return (unsafe {
-        let _n: i32 = n;
-        fatorial_0(_n)
-    });
+    (unsafe { fatorial_by_ref_1(&mut n as *mut i32) });
+    return (unsafe { fatorial_0(n) });
 }

--- a/tests/unit/out/unsafe/fcall.rs
+++ b/tests/unit/out/unsafe/fcall.rs
@@ -10,54 +10,28 @@ pub unsafe fn f2_0(mut x: f64, mut y: f64) -> f64 {
     return ((x) - (y));
 }
 pub unsafe fn f3_1(mut x: f64, mut y: f64, mut z: f64) -> f64 {
-    return ((unsafe {
-        let _x: f64 = x;
-        let _y: f64 = y;
-        f2_0(_x, _y)
-    }) + (z));
+    return ((unsafe { f2_0(x, y) }) + (z));
 }
 pub unsafe fn f1_2(mut x: f64, mut y: f64) -> f64 {
-    let mut z1: f64 = (unsafe {
-        let _x: f64 = x;
-        let _y: f64 = y;
-        f2_0(_x, _y)
-    });
-    if ((unsafe {
-        let _x: f64 = z1;
-        let _y: f64 = y;
-        f2_0(_x, _y)
-    }) < (0_f64))
-    {
+    let mut z1: f64 = (unsafe { f2_0(x, y) });
+    if ((unsafe { f2_0(z1, y) }) < (0_f64)) {
         let mut z2: f64 = -(unsafe {
-            let _x: f64 = z1;
-            let _y: f64 = (unsafe {
-                let _x: f64 = x;
-                let _y: f64 = y;
-                f2_0(_x, _y)
-            });
+            let _y: f64 = (unsafe { f2_0(x, y) });
             let _z: f64 = y;
-            f3_1(_x, _y, _z)
+            f3_1(z1, _y, _z)
         });
         return (unsafe {
-            let _x: f64 = (unsafe {
-                let _x: f64 = z2;
-                let _y: f64 = (unsafe {
-                    let _x: f64 = z1;
-                    let _y: f64 = z2;
-                    let _z: f64 = x;
-                    f3_1(_x, _y, _z)
-                });
-                f2_0(_x, _y)
-            });
-            let _y: f64 = y;
-            f2_0(_x, _y)
+            f2_0(
+                (unsafe {
+                    let _x: f64 = z2;
+                    let _y: f64 = (unsafe { f3_1(z1, z2, x) });
+                    f2_0(_x, _y)
+                }),
+                y,
+            )
         });
     }
-    return (unsafe {
-        let _x: f64 = z1;
-        let _y: f64 = x;
-        f2_0(_x, _y)
-    });
+    return (unsafe { f2_0(z1, x) });
 }
 pub fn main() {
     unsafe {

--- a/tests/unit/out/unsafe/fft.rs
+++ b/tests/unit/out/unsafe/fft.rs
@@ -82,16 +82,10 @@ pub unsafe fn fft_3(a: *mut Option<Box<[Complex]>>, mut N: i32) -> Option<Box<[C
         };
         i.postfix_inc();
     }
-    let mut y0: Option<Box<[Complex]>> = (unsafe {
-        let _a: *mut Option<Box<[Complex]>> = &mut A0 as *mut Option<Box<[Complex]>>;
-        let _N: i32 = ((N) / (2));
-        fft_3(_a, _N)
-    });
-    let mut y1: Option<Box<[Complex]>> = (unsafe {
-        let _a: *mut Option<Box<[Complex]>> = &mut A1 as *mut Option<Box<[Complex]>>;
-        let _N: i32 = ((N) / (2));
-        fft_3(_a, _N)
-    });
+    let mut y0: Option<Box<[Complex]>> =
+        (unsafe { fft_3(&mut A0 as *mut Option<Box<[Complex]>>, ((N) / (2))) });
+    let mut y1: Option<Box<[Complex]>> =
+        (unsafe { fft_3(&mut A1 as *mut Option<Box<[Complex]>>, ((N) / (2))) });
     let mut k: i32 = 0;
     'loop_: while ((k) < ((N) / (2))) {
         let mut yk: Complex = (unsafe {
@@ -110,12 +104,13 @@ pub unsafe fn fft_3(a: *mut Option<Box<[Complex]>>, mut N: i32) -> Option<Box<[C
         let mut yk_n2: Complex = (unsafe {
             let _z1: Complex = y0.as_mut().unwrap()[(k as usize)].clone();
             let _z2: Complex = (unsafe {
-                let _z1: Complex = (unsafe {
-                    let _z1: Complex = w.as_mut().unwrap()[(k as usize)].clone();
-                    let _z2: Complex = y1.as_mut().unwrap()[(k as usize)].clone();
-                    Product_0(_z1, _z2)
-                });
-                Neg_2(_z1)
+                Neg_2(
+                    (unsafe {
+                        let _z1: Complex = w.as_mut().unwrap()[(k as usize)].clone();
+                        let _z2: Complex = y1.as_mut().unwrap()[(k as usize)].clone();
+                        Product_0(_z1, _z2)
+                    }),
+                )
             });
             Sum_1(_z1, _z2)
         });
@@ -147,11 +142,8 @@ unsafe fn main_0() -> i32 {
         };
         i.postfix_inc();
     }
-    let mut b: Option<Box<[Complex]>> = (unsafe {
-        let _a: *mut Option<Box<[Complex]>> = &mut a as *mut Option<Box<[Complex]>>;
-        let _N: i32 = N;
-        fft_3(_a, _N)
-    });
+    let mut b: Option<Box<[Complex]>> =
+        (unsafe { fft_3(&mut a as *mut Option<Box<[Complex]>>, N) });
     let mut reals: Option<Box<[i32]>> = Some(
         (0..(N as usize))
             .map(|_| <i32>::default())

--- a/tests/unit/out/unsafe/fn_ptr.rs
+++ b/tests/unit/out/unsafe/fn_ptr.rs
@@ -13,10 +13,7 @@ pub unsafe fn foo_1(
     mut fn_: Option<unsafe fn(*mut ::libc::c_void) -> i32>,
     mut pi: *mut i32,
 ) -> i32 {
-    return (unsafe {
-        let _arg0: *mut ::libc::c_void = (pi as *mut i32 as *mut ::libc::c_void);
-        (fn_).unwrap()(_arg0)
-    });
+    return (unsafe { (fn_).unwrap()((pi as *mut i32 as *mut ::libc::c_void)) });
 }
 pub fn main() {
     unsafe {
@@ -31,12 +28,6 @@ unsafe fn main_0() -> i32 {
     assert!(!((fn_).is_none()));
     assert!(((fn_) == (Some(my_foo_0))));
     let mut a: i32 = 10;
-    assert!(
-        ((unsafe {
-            let _fn: Option<unsafe fn(*mut ::libc::c_void) -> i32> = fn_;
-            let _pi: *mut i32 = (&mut a as *mut i32);
-            foo_1(_fn, _pi)
-        }) == (a))
-    );
+    assert!(((unsafe { foo_1(fn_, (&mut a as *mut i32),) }) == (a)));
     return 0;
 }

--- a/tests/unit/out/unsafe/fn_ptr_as_condition.rs
+++ b/tests/unit/out/unsafe/fn_ptr_as_condition.rs
@@ -11,10 +11,7 @@ pub unsafe fn double_it_0(mut x: *mut i32) {
 }
 pub unsafe fn maybe_call_1(mut cb: Option<unsafe fn(*mut i32)>, mut x: *mut i32) {
     if !(cb).is_none() {
-        (unsafe {
-            let _arg0: *mut i32 = x;
-            (cb).unwrap()(_arg0)
-        });
+        (unsafe { (cb).unwrap()(x) });
     }
 }
 pub fn main() {
@@ -24,18 +21,10 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut a: i32 = 5;
-    (unsafe {
-        let _cb: Option<unsafe fn(*mut i32)> = Some(double_it_0);
-        let _x: *mut i32 = (&mut a as *mut i32);
-        maybe_call_1(_cb, _x)
-    });
+    (unsafe { maybe_call_1(Some(double_it_0), (&mut a as *mut i32)) });
     assert!(((a) == (10)));
     let mut b: i32 = 5;
-    (unsafe {
-        let _cb: Option<unsafe fn(*mut i32)> = None;
-        let _x: *mut i32 = (&mut b as *mut i32);
-        maybe_call_1(_cb, _x)
-    });
+    (unsafe { maybe_call_1(None, (&mut b as *mut i32)) });
     assert!(((b) == (5)));
     let mut fn_: Option<unsafe fn(*mut i32)> = None;
     if !!(fn_).is_none() {
@@ -43,10 +32,7 @@ unsafe fn main_0() -> i32 {
     }
     let mut c: i32 = 3;
     if !(fn_).is_none() {
-        (unsafe {
-            let _arg0: *mut i32 = (&mut c as *mut i32);
-            (fn_).unwrap()(_arg0)
-        });
+        (unsafe { (fn_).unwrap()((&mut c as *mut i32)) });
     }
     assert!(((c) == (6)));
     return 0;

--- a/tests/unit/out/unsafe/fn_ptr_cast.rs
+++ b/tests/unit/out/unsafe/fn_ptr_cast.rs
@@ -53,9 +53,10 @@ pub unsafe fn test_call_through_cast_5() {
     >(Some(add_offset_4));
     let mut val: i32 = 100;
     let mut result: i32 = (unsafe {
-        let _arg0: *mut ::libc::c_void =
-            ((&mut val as *mut i32) as *mut i32 as *mut ::libc::c_void);
-        (gfn).unwrap()(_arg0, 42)
+        (gfn).unwrap()(
+            ((&mut val as *mut i32) as *mut i32 as *mut ::libc::c_void),
+            42,
+        )
     });
     assert!(((result) == (142)));
 }

--- a/tests/unit/out/unsafe/fn_ptr_conditional.rs
+++ b/tests/unit/out/unsafe/fn_ptr_conditional.rs
@@ -32,10 +32,7 @@ pub unsafe fn apply_4(mut fn_: Option<unsafe fn(i32) -> i32>, mut x: i32) -> i32
     } else {
         Some(identity_2)
     };
-    return (unsafe {
-        let _arg0: i32 = x;
-        (actual).unwrap()(_arg0)
-    });
+    return (unsafe { (actual).unwrap()(x) });
 }
 pub fn main() {
     unsafe {
@@ -44,27 +41,9 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     assert!(((unsafe { (unsafe { pick_3(1,) }).unwrap()(10,) }) == (11)));
-    assert!(
-        ((unsafe {
-            (unsafe {
-                let _mode: i32 = -1_i32;
-                pick_3(_mode)
-            })
-            .unwrap()(10)
-        }) == (9))
-    );
+    assert!(((unsafe { (unsafe { pick_3(-1_i32,) }).unwrap()(10,) }) == (9)));
     assert!(((unsafe { (unsafe { pick_3(0,) }).unwrap()(10,) }) == (10)));
-    assert!(
-        ((unsafe {
-            let _fn: Option<unsafe fn(i32) -> i32> = Some(inc_0);
-            apply_4(_fn, 5)
-        }) == (6))
-    );
-    assert!(
-        ((unsafe {
-            let _fn: Option<unsafe fn(i32) -> i32> = None;
-            apply_4(_fn, 5)
-        }) == (5))
-    );
+    assert!(((unsafe { apply_4(Some(inc_0), 5,) }) == (6)));
+    assert!(((unsafe { apply_4(None, 5,) }) == (5)));
     return 0;
 }

--- a/tests/unit/out/unsafe/fn_ptr_default_arg.rs
+++ b/tests/unit/out/unsafe/fn_ptr_default_arg.rs
@@ -12,10 +12,7 @@ pub unsafe fn identity_0(mut x: i32) -> i32 {
 pub unsafe fn apply_1(mut x: i32, mut fn_: Option<Option<unsafe fn(i32) -> i32>>) -> i32 {
     let mut fn_: Option<unsafe fn(i32) -> i32> = fn_.unwrap_or(None);
     if !(fn_).is_none() {
-        return (unsafe {
-            let _arg0: i32 = x;
-            (fn_).unwrap()(_arg0)
-        });
+        return (unsafe { (fn_).unwrap()(x) });
     }
     return x;
 }
@@ -25,32 +22,12 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    assert!(
-        ((unsafe {
-            let _fn: Option<unsafe fn(i32) -> i32> = Default::default();
-            apply_1(5, Some(_fn))
-        }) == (5))
-    );
-    assert!(
-        ((unsafe {
-            let _fn: Option<unsafe fn(i32) -> i32> = None;
-            apply_1(5, Some(_fn))
-        }) == (5))
-    );
-    assert!(
-        ((unsafe {
-            let _fn: Option<unsafe fn(i32) -> i32> = Some(identity_0);
-            apply_1(5, Some(_fn))
-        }) == (5))
-    );
+    assert!(((unsafe { apply_1(5, Some(Default::default()),) }) == (5)));
+    assert!(((unsafe { apply_1(5, Some(None),) }) == (5)));
+    assert!(((unsafe { apply_1(5, Some(Some(identity_0)),) }) == (5)));
     let mut negate: Option<unsafe fn(i32) -> i32> = Some(|x: i32| {
         return -x;
     });
-    assert!(
-        ((unsafe {
-            let _fn: Option<unsafe fn(i32) -> i32> = negate;
-            apply_1(5, Some(_fn))
-        }) == (-5_i32))
-    );
+    assert!(((unsafe { apply_1(5, Some(negate),) }) == (-5_i32)));
     return 0;
 }

--- a/tests/unit/out/unsafe/fn_ptr_global.rs
+++ b/tests/unit/out/unsafe/fn_ptr_global.rs
@@ -18,10 +18,7 @@ pub unsafe fn set_op_3(mut fn_: Option<unsafe fn(i32) -> i32>) {
 }
 pub unsafe fn call_op_4(mut x: i32) -> i32 {
     if !(g_op_2).is_none() {
-        return (unsafe {
-            let _arg0: i32 = x;
-            (g_op_2).unwrap()(_arg0)
-        });
+        return (unsafe { (g_op_2).unwrap()(x) });
     }
     return x;
 }
@@ -32,23 +29,14 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     assert!(((unsafe { call_op_4(5,) }) == (5)));
-    (unsafe {
-        let _fn: Option<unsafe fn(i32) -> i32> = Some(double_it_0);
-        set_op_3(_fn)
-    });
+    (unsafe { set_op_3(Some(double_it_0)) });
     assert!(!((g_op_2).is_none()));
     assert!(((g_op_2) == (Some(double_it_0))));
     assert!(((unsafe { call_op_4(5,) }) == (10)));
-    (unsafe {
-        let _fn: Option<unsafe fn(i32) -> i32> = Some(triple_it_1);
-        set_op_3(_fn)
-    });
+    (unsafe { set_op_3(Some(triple_it_1)) });
     assert!(((g_op_2) == (Some(triple_it_1))));
     assert!(((unsafe { call_op_4(5,) }) == (15)));
-    (unsafe {
-        let _fn: Option<unsafe fn(i32) -> i32> = None;
-        set_op_3(_fn)
-    });
+    (unsafe { set_op_3(None) });
     assert!((g_op_2).is_none());
     assert!(((unsafe { call_op_4(5,) }) == (5)));
     return 0;

--- a/tests/unit/out/unsafe/fn_ptr_stdlib_compare.rs
+++ b/tests/unit/out/unsafe/fn_ptr_stdlib_compare.rs
@@ -50,11 +50,8 @@ unsafe fn main_0() -> i32 {
             Option<unsafe fn(*mut ::libc::c_void, usize, usize, *mut ::libc::FILE) -> usize>,
         >(Some(my_alternative_fread_0));
     assert!(
-        ((unsafe {
-            let _arg0: *mut ::libc::c_void = std::ptr::null_mut();
-            let _arg3: *mut ::libc::FILE = std::ptr::null_mut();
-            (f3).unwrap()(_arg0, 0_usize, 0_usize, _arg3)
-        }) == (22_usize))
+        ((unsafe { (f3).unwrap()(std::ptr::null_mut(), 0_usize, 0_usize, std::ptr::null_mut(),) })
+            == (22_usize))
     );
     let mut __do_while = true;
     'loop_: while __do_while || (0 != 0) {
@@ -108,9 +105,12 @@ unsafe fn main_0() -> i32 {
             (buf.as_mut_ptr() as *mut u8 as *mut ::libc::c_void)
         };
         let mut n: usize = (unsafe {
-            let _arg0: *mut ::libc::c_void = (buf.as_mut_ptr() as *mut u8 as *mut ::libc::c_void);
-            let _arg3: *mut ::libc::FILE = stream;
-            (fn1).unwrap()(_arg0, 1_usize, 10_usize, _arg3)
+            (fn1).unwrap()(
+                (buf.as_mut_ptr() as *mut u8 as *mut ::libc::c_void),
+                1_usize,
+                10_usize,
+                stream,
+            )
         });
         assert!(((n) == (10_usize)));
         let mut i: i32 = 0;
@@ -148,11 +148,8 @@ unsafe fn main_0() -> i32 {
             Option<unsafe fn(*const ::libc::c_void, usize, usize, *mut ::libc::FILE) -> usize>,
         >(Some(my_alternative_fwrite_1));
     assert!(
-        ((unsafe {
-            let _arg0: *const ::libc::c_void = std::ptr::null();
-            let _arg3: *mut ::libc::FILE = std::ptr::null_mut();
-            (g3).unwrap()(_arg0, 0_usize, 0_usize, _arg3)
-        }) == (33_usize))
+        ((unsafe { (g3).unwrap()(std::ptr::null(), 0_usize, 0_usize, std::ptr::null_mut(),) })
+            == (33_usize))
     );
     let mut __do_while = true;
     'loop_: while __do_while || (0 != 0) {
@@ -196,10 +193,12 @@ unsafe fn main_0() -> i32 {
             (buf.as_mut_ptr() as *mut u8 as *mut ::libc::c_void)
         };
         let mut n: usize = (unsafe {
-            let _arg0: *const ::libc::c_void =
-                (buf.as_mut_ptr() as *const u8 as *const ::libc::c_void);
-            let _arg3: *mut ::libc::FILE = stream;
-            (gn1).unwrap()(_arg0, 1_usize, 10_usize, _arg3)
+            (gn1).unwrap()(
+                (buf.as_mut_ptr() as *const u8 as *const ::libc::c_void),
+                1_usize,
+                10_usize,
+                stream,
+            )
         });
         assert!(((n) == (10_usize)));
         libc::fclose(stream);

--- a/tests/unit/out/unsafe/fn_ptr_void_return.rs
+++ b/tests/unit/out/unsafe/fn_ptr_void_return.rs
@@ -13,10 +13,7 @@ pub unsafe fn zero_out_1(mut x: *mut i32) {
     (*x) = 0;
 }
 pub unsafe fn run_2(mut fn_: Option<unsafe fn(*mut i32)>, mut x: *mut i32) {
-    (unsafe {
-        let _arg0: *mut i32 = x;
-        (fn_).unwrap()(_arg0)
-    });
+    (unsafe { (fn_).unwrap()(x) });
 }
 pub fn main() {
     unsafe {
@@ -25,25 +22,14 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut a: i32 = 42;
-    (unsafe {
-        let _fn: Option<unsafe fn(*mut i32)> = Some(negate_0);
-        let _x: *mut i32 = (&mut a as *mut i32);
-        run_2(_fn, _x)
-    });
+    (unsafe { run_2(Some(negate_0), (&mut a as *mut i32)) });
     assert!(((a) == (-42_i32)));
-    (unsafe {
-        let _fn: Option<unsafe fn(*mut i32)> = Some(zero_out_1);
-        let _x: *mut i32 = (&mut a as *mut i32);
-        run_2(_fn, _x)
-    });
+    (unsafe { run_2(Some(zero_out_1), (&mut a as *mut i32)) });
     assert!(((a) == (0)));
     let mut fn_: Option<unsafe fn(*mut i32)> = Some(negate_0);
     assert!(!((fn_).is_none()));
     let mut b: i32 = 10;
-    (unsafe {
-        let _arg0: *mut i32 = (&mut b as *mut i32);
-        (fn_).unwrap()(_arg0)
-    });
+    (unsafe { (fn_).unwrap()((&mut b as *mut i32)) });
     assert!(((b) == (-10_i32)));
     return 0;
 }

--- a/tests/unit/out/unsafe/fn_ptr_vtable.rs
+++ b/tests/unit/out/unsafe/fn_ptr_vtable.rs
@@ -48,16 +48,8 @@ unsafe fn main_0() -> i32 {
     assert!(!((vt.get).is_none()));
     assert!(!((vt.destroy).is_none()));
     let mut obj: *mut ::libc::c_void = (unsafe { (vt.create).unwrap()(42) });
-    assert!(
-        ((unsafe {
-            let _arg0: *mut ::libc::c_void = obj;
-            (vt.get).unwrap()(_arg0)
-        }) == (42))
-    );
-    (unsafe {
-        let _arg0: *mut ::libc::c_void = obj;
-        (vt.destroy).unwrap()(_arg0)
-    });
+    assert!(((unsafe { (vt.get).unwrap()(obj,) }) == (42)));
+    (unsafe { (vt.destroy).unwrap()(obj) });
     assert!(((storage_0) == (0)));
     (vt.get) = None;
     assert!((vt.get).is_none());

--- a/tests/unit/out/unsafe/function_overloading.rs
+++ b/tests/unit/out/unsafe/function_overloading.rs
@@ -47,14 +47,8 @@ unsafe fn main_0() -> i32 {
     let mut x: i32 = 1;
     let mut out: i32 = 0;
     out += (unsafe { foo_0(0) });
-    out += (unsafe {
-        let _x: *mut i32 = (&mut x as *mut i32);
-        foo_1(_x)
-    });
-    out += (unsafe {
-        let _x: *mut i32 = &mut x as *mut i32;
-        bar_4(_x)
-    });
+    out += (unsafe { foo_1((&mut x as *mut i32)) });
+    out += (unsafe { bar_4(&mut x as *mut i32) });
     out += (unsafe {
         let _x: *mut i32 = (&mut x as *mut i32);
         let _y: *mut i32 = (&mut x as *mut i32);
@@ -67,11 +61,7 @@ unsafe fn main_0() -> i32 {
         foo_2(_x, _y)
     });
     let mut bar: i32 = 5;
-    out += (((bar) + (unsafe { foo_0(0) }))
-        + (unsafe {
-            let _x: *mut i32 = (&mut x as *mut i32);
-            foo_1(_x)
-        }));
+    out += (((bar) + (unsafe { foo_0(0) })) + (unsafe { foo_1((&mut x as *mut i32)) }));
     let mut foo1: Foo = Foo {};
     let foo2: Foo = Foo {};
     (unsafe { foo1.foo() });

--- a/tests/unit/out/unsafe/goto_aggregate_default.rs
+++ b/tests/unit/out/unsafe/goto_aggregate_default.rs
@@ -42,13 +42,7 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    assert!(
-        ((((unsafe {
-            let _n: i32 = -1_i32;
-            agg_0(_n)
-        }) == (0)) as i32)
-            != 0)
-    );
+    assert!(((((unsafe { agg_0(-1_i32,) }) == (0)) as i32) != 0));
     assert!(((((unsafe { agg_0(1,) }) == (1)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/goto_cleanup.rs
+++ b/tests/unit/out/unsafe/goto_cleanup.rs
@@ -79,13 +79,7 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    assert!(
-        ((((unsafe {
-            let _n: i32 = -1_i32;
-            early_0(_n)
-        }) == (-1_i32)) as i32)
-            != 0)
-    );
+    assert!(((((unsafe { early_0(-1_i32,) }) == (-1_i32)) as i32) != 0));
     assert!(((((unsafe { early_0(5,) }) == (100)) as i32) != 0));
     assert!(((((unsafe { from_loop_1(2,) }) == (999)) as i32) != 0));
     assert!(((((unsafe { from_loop_1(10,) }) == (7)) as i32) != 0));

--- a/tests/unit/out/unsafe/goto_multi_label.rs
+++ b/tests/unit/out/unsafe/goto_multi_label.rs
@@ -37,12 +37,6 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     assert!(((((unsafe { classify_0(5,) }) == (5)) as i32) != 0));
     assert!(((((unsafe { classify_0(0,) }) == (0)) as i32) != 0));
-    assert!(
-        ((((unsafe {
-            let _n: i32 = -2_i32;
-            classify_0(_n)
-        }) == (-1_i32)) as i32)
-            != 0)
-    );
+    assert!(((((unsafe { classify_0(-2_i32,) }) == (-1_i32)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/huffman.rs
+++ b/tests/unit/out/unsafe/huffman.rs
@@ -85,10 +85,7 @@ impl MinHeap {
                     &mut (*self.arr.as_mut().unwrap()[(idx as usize)]) as *mut MinHeapNode;
                 Swap_0(_a, _b)
             });
-            (unsafe {
-                let _idx: i32 = smallest;
-                self.Heapify(_idx)
-            });
+            (unsafe { self.Heapify(smallest) });
         }
     }
     pub unsafe fn ExtractMin(&mut self) -> *mut MinHeapNode {
@@ -128,10 +125,7 @@ impl MinHeap {
         }
         let mut i: i32 = (((self.size) - (2)) / (2));
         'loop_: while ((i) >= (0)) {
-            (unsafe {
-                let _idx: i32 = i;
-                self.Heapify(_idx)
-            });
+            (unsafe { self.Heapify(i) });
             i.prefix_dec();
         }
     }
@@ -159,10 +153,7 @@ pub unsafe fn Huffman_2(
     freq: *mut Option<Box<[i32]>>,
     mut size: i32,
 ) -> Option<Box<MinHeap>> {
-    let mut minHeap: Option<Box<MinHeap>> = (unsafe {
-        let _capacity: i32 = size;
-        AllocMinHeap_1(_capacity)
-    });
+    let mut minHeap: Option<Box<MinHeap>> = (unsafe { AllocMinHeap_1(size) });
     (unsafe {
         let _data: *mut Option<Box<[u8]>> = data;
         let _freq: *mut Option<Box<[i32]>> = freq;
@@ -175,15 +166,12 @@ pub unsafe fn Huffman_2(
         let mut right: *mut MinHeapNode =
             (unsafe { (*minHeap.as_deref_mut().unwrap()).ExtractMin() });
         let mut top: *mut MinHeapNode = (unsafe {
-            let _freq: i32 = (((*left).freq) + ((*right).freq));
-            (*minHeap.as_deref_mut().unwrap()).Alloc(('$' as u8), _freq)
+            (*minHeap.as_deref_mut().unwrap())
+                .Alloc(('$' as u8), (((*left).freq) + ((*right).freq)))
         });
         (*top).left = left;
         (*top).right = right;
-        (unsafe {
-            let _node: *mut MinHeapNode = top;
-            (*minHeap.as_deref_mut().unwrap()).Insert(_node)
-        });
+        (unsafe { (*minHeap.as_deref_mut().unwrap()).Insert(top) });
     }
     return minHeap;
 }
@@ -269,12 +257,13 @@ pub unsafe fn HuffmanCodes_5(
     let mut top: i32 = 0;
     let mut next: i32 = 0;
     (unsafe {
-        let _root: *mut MinHeapNode = root;
-        let _arr: *mut Option<Box<[i32]>> = &mut arr as *mut Option<Box<[i32]>>;
-        let _top: i32 = top;
-        let _out: *mut Option<Box<[i32]>> = &mut out as *mut Option<Box<[i32]>>;
-        let _next: *mut i32 = &mut next as *mut i32;
-        CollectCodes_4(_root, _arr, _top, _out, _next)
+        CollectCodes_4(
+            root,
+            &mut arr as *mut Option<Box<[i32]>>,
+            top,
+            &mut out as *mut Option<Box<[i32]>>,
+            &mut next as *mut i32,
+        )
     });
     return out;
 }
@@ -311,10 +300,11 @@ unsafe fn main_0() -> i32 {
         i.prefix_inc();
     }
     let mut out: Option<Box<[i32]>> = (unsafe {
-        let _data: *mut Option<Box<[u8]>> = &mut data as *mut Option<Box<[u8]>>;
-        let _freq: *mut Option<Box<[i32]>> = &mut freq as *mut Option<Box<[i32]>>;
-        let _size: i32 = size;
-        HuffmanCodes_5(_data, _freq, _size)
+        HuffmanCodes_5(
+            &mut data as *mut Option<Box<[u8]>>,
+            &mut freq as *mut Option<Box<[i32]>>,
+            size,
+        )
     });
     return ((((((((out.as_mut().unwrap()[(0_usize)]) == (0))
         && ((out.as_mut().unwrap()[(1_usize)]) == (100)))

--- a/tests/unit/out/unsafe/implicit_autoref.rs
+++ b/tests/unit/out/unsafe/implicit_autoref.rs
@@ -36,10 +36,7 @@ unsafe fn main_0() -> i32 {
     assert!((((&mut (*p))[(1_usize)]) == (30)));
     assert!(((b) == (40)));
     assert!((((&mut (*hp)).v[(1_usize)]) == (60)));
-    (unsafe {
-        let _p: *mut i32 = (&mut (&mut (*p))[0_usize as usize]);
-        write_through_0(_p)
-    });
+    (unsafe { write_through_0((&mut (&mut (*p))[0_usize as usize])) });
     assert!((((&mut (*p))[(0_usize)]) == (42)));
     return 0;
 }

--- a/tests/unit/out/unsafe/init_list.rs
+++ b/tests/unit/out/unsafe/init_list.rs
@@ -19,9 +19,6 @@ unsafe fn main_0() -> i32 {
     let mut carr2: [i32; 3] = [1, 0_i32, 0_i32];
     let mut arr: Vec<i32> = vec![1, 2, 3];
     let mut vec_: Vec<i32> = vec![1, 2, 3];
-    (unsafe {
-        let _list: Vec<i32> = vec![1, 2, 3, 4];
-        f_0(_list)
-    });
+    (unsafe { f_0(vec![1, 2, 3, 4]) });
     return 0;
 }

--- a/tests/unit/out/unsafe/initializer_list.rs
+++ b/tests/unit/out/unsafe/initializer_list.rs
@@ -18,11 +18,6 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    assert!(
-        ((unsafe {
-            let _bytes: Vec<i32> = vec![1, 2, 3];
-            f_0(_bytes)
-        }) == (3_usize))
-    );
+    assert!(((unsafe { f_0(vec![1, 2, 3,],) }) == (3_usize)));
     return 0;
 }

--- a/tests/unit/out/unsafe/iterator_freshness.rs
+++ b/tests/unit/out/unsafe/iterator_freshness.rs
@@ -17,9 +17,6 @@ unsafe fn main_0() -> i32 {
         .map(|_| <i32>::default())
         .collect::<Vec<_>>();
     let mut it: *mut i32 = vec_.as_mut_ptr();
-    (unsafe {
-        let _a0: *mut i32 = it;
-        foo_0(_a0)
-    });
+    (unsafe { foo_0(it) });
     return 0;
 }

--- a/tests/unit/out/unsafe/kruskal.rs
+++ b/tests/unit/out/unsafe/kruskal.rs
@@ -119,14 +119,8 @@ impl DisjointSet {
         return self.parent.as_mut().unwrap()[(x as usize)];
     }
     pub unsafe fn merge(&mut self, mut x: i32, mut y: i32) {
-        let mut xset: i32 = (unsafe {
-            let _x: i32 = x;
-            self.find(_x)
-        });
-        let mut yset: i32 = (unsafe {
-            let _x: i32 = y;
-            self.find(_x)
-        });
+        let mut xset: i32 = (unsafe { self.find(x) });
+        let mut yset: i32 = (unsafe { self.find(y) });
         if ((xset) == (yset)) {
             return;
         }
@@ -178,18 +172,8 @@ pub unsafe fn MSTKruskal_2(graph: *mut Graph) -> f64 {
         let mut x: i32 = (*graph).edges.as_mut().unwrap()[(i as usize)].u;
         let mut y: i32 = (*graph).edges.as_mut().unwrap()[(i as usize)].v;
         let mut w: f64 = (*graph).edges.as_mut().unwrap()[(i as usize)].weight;
-        if ((unsafe {
-            let _x: i32 = x;
-            set.find(_x)
-        }) != (unsafe {
-            let _x: i32 = y;
-            set.find(_x)
-        })) {
-            (unsafe {
-                let _x: i32 = x;
-                let _y: i32 = y;
-                set.merge(_x, _y)
-            });
+        if ((unsafe { set.find(x) }) != (unsafe { set.find(y) })) {
+            (unsafe { set.merge(x, y) });
             total_weight += w;
         }
         i.prefix_inc();
@@ -238,9 +222,6 @@ unsafe fn main_0() -> i32 {
         v: 3,
         weight: 5_f64,
     };
-    let mut total_weight: f64 = (unsafe {
-        let _graph: *mut Graph = &mut graph as *mut Graph;
-        MSTKruskal_2(_graph)
-    });
+    let mut total_weight: f64 = (unsafe { MSTKruskal_2(&mut graph as *mut Graph) });
     return (total_weight as i32);
 }

--- a/tests/unit/out/unsafe/lambda_capture_pass.rs
+++ b/tests/unit/out/unsafe/lambda_capture_pass.rs
@@ -7,16 +7,10 @@ use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn apply_0(mut fn_: impl Fn(i32) -> i32, mut x: i32) -> i32 {
-    return (unsafe {
-        let _x: i32 = x;
-        fn_(_x)
-    });
+    return (unsafe { fn_(x) });
 }
 pub unsafe fn apply_1(mut fn_: impl Fn(i32) -> i32, mut x: i32) -> i32 {
-    return (unsafe {
-        let _x: i32 = x;
-        fn_(_x)
-    });
+    return (unsafe { fn_(x) });
 }
 pub fn main() {
     unsafe {
@@ -27,31 +21,37 @@ unsafe fn main_0() -> i32 {
     let mut base: i32 = 10;
     assert!(
         ((unsafe {
-            let _fn: _ = (|x: i32| {
-                return ((x) + (base));
-            })
-            .clone();
-            apply_0(_fn, 5)
+            apply_0(
+                (|x: i32| {
+                    return ((x) + (base));
+                })
+                .clone(),
+                5,
+            )
         }) == (15))
     );
     base = 100;
     assert!(
         ((unsafe {
-            let _fn: _ = (|x: i32| {
-                return ((x) + (base));
-            })
-            .clone();
-            apply_0(_fn, 5)
+            apply_0(
+                (|x: i32| {
+                    return ((x) + (base));
+                })
+                .clone(),
+                5,
+            )
         }) == (105))
     );
     let mut factor: i32 = 3;
     assert!(
         ((unsafe {
-            let _fn: _ = (|x: i32| {
-                return ((x) * (factor));
-            })
-            .clone();
-            apply_1(_fn, 4)
+            apply_1(
+                (|x: i32| {
+                    return ((x) * (factor));
+                })
+                .clone(),
+                4,
+            )
         }) == (12))
     );
     return 0;

--- a/tests/unit/out/unsafe/linked_list.rs
+++ b/tests/unit/out/unsafe/linked_list.rs
@@ -31,10 +31,7 @@ pub unsafe fn Append_1(head: *mut Node, new_node: *mut Node) {
     'loop_: while !(((*curr).next).is_null()) {
         curr = (*curr).next;
     }
-    (unsafe {
-        let _next: *mut Node = (new_node);
-        (*curr).SetNext(_next)
-    });
+    (unsafe { (*curr).SetNext((new_node)) });
 }
 pub unsafe fn Delete_2(mut head: *mut Node, mut val: i32) -> *mut Node {
     let mut curr: *mut Node = head;
@@ -127,52 +124,13 @@ unsafe fn main_0() -> i32 {
         let _new_node: *mut Node = &mut n7 as *mut Node;
         Append_1(_head, _new_node)
     });
-    head = (unsafe {
-        let _head: *mut Node = head;
-        Delete_2(_head, 5)
-    });
-    head = (unsafe {
-        let _head: *mut Node = head;
-        Delete_2(_head, 0)
-    });
-    head = (unsafe {
-        let _head: *mut Node = head;
-        let _val: i32 = -2_i32;
-        Delete_2(_head, _val)
-    });
-    return ((((((((*(unsafe {
-        let _head: *mut Node = head;
-        Find_0(_head, 0)
-    }))
-    .val)
-        == (4))
-        && (((*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 1)
-        }))
-        .val)
-            == (3)))
-        && (((*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 2)
-        }))
-        .val)
-            == (2)))
-        && (((*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 3)
-        }))
-        .val)
-            == (1)))
-        && ((((*(unsafe {
-            let _head: *mut Node = head;
-            Find_0(_head, 4)
-        }))
-        .val)
-            == (-1_i32))
-            && ((unsafe {
-                let _head: *mut Node = head;
-                Find_0(_head, 5)
-            })
-            .is_null()))) as i32);
+    head = (unsafe { Delete_2(head, 5) });
+    head = (unsafe { Delete_2(head, 0) });
+    head = (unsafe { Delete_2(head, -2_i32) });
+    return ((((((((*(unsafe { Find_0(head, 0) })).val) == (4))
+        && (((*(unsafe { Find_0(head, 1) })).val) == (3)))
+        && (((*(unsafe { Find_0(head, 2) })).val) == (2)))
+        && (((*(unsafe { Find_0(head, 3) })).val) == (1)))
+        && ((((*(unsafe { Find_0(head, 4) })).val) == (-1_i32))
+            && ((unsafe { Find_0(head, 5) }).is_null()))) as i32);
 }

--- a/tests/unit/out/unsafe/macros.rs
+++ b/tests/unit/out/unsafe/macros.rs
@@ -21,9 +21,6 @@ unsafe fn main_0() -> i32 {
         8,
         b"main\0".as_ptr(),
     );
-    (unsafe {
-        let _func: *const u8 = b"main\0".as_ptr();
-        log_0(b"macros.cpp\0".as_ptr(), 9, _func)
-    });
+    (unsafe { log_0(b"macros.cpp\0".as_ptr(), 9, b"main\0".as_ptr()) });
     return 0;
 }

--- a/tests/unit/out/unsafe/malloc_realloc_free.rs
+++ b/tests/unit/out/unsafe/malloc_realloc_free.rs
@@ -65,19 +65,13 @@ unsafe fn main_0() -> i32 {
     let mut __do_while = true;
     'loop_: while __do_while || (0 != 0) {
         __do_while = false;
-        let mut p: *mut i32 = ((unsafe {
-            let _arg0: usize = ::std::mem::size_of::<i32>();
-            (pmalloc).unwrap()(_arg0)
-        }) as *mut i32);
+        let mut p: *mut i32 =
+            ((unsafe { (pmalloc).unwrap()(::std::mem::size_of::<i32>()) }) as *mut i32);
         (*p) = 42;
         assert!(((((*p) == (42)) as i32) != 0));
-        (unsafe {
-            let _arg0: *mut ::libc::c_void = (p as *mut i32 as *mut ::libc::c_void);
-            (pfree).unwrap()(_arg0)
-        });
+        (unsafe { (pfree).unwrap()((p as *mut i32 as *mut ::libc::c_void)) });
         let mut arr: *mut i32 = ((unsafe {
-            let _arg0: usize = (4_usize).wrapping_mul((::std::mem::size_of::<i32>() as usize));
-            (pmalloc).unwrap()(_arg0)
+            (pmalloc).unwrap()((4_usize).wrapping_mul((::std::mem::size_of::<i32>() as usize)))
         }) as *mut i32);
         let mut i: i32 = 0;
         'loop_: while ((((i) < (4)) as i32) != 0) {
@@ -86,20 +80,17 @@ unsafe fn main_0() -> i32 {
         }
         assert!(((((*arr.offset((0) as isize)) == (0)) as i32) != 0));
         assert!(((((*arr.offset((3) as isize)) == (30)) as i32) != 0));
-        (unsafe {
-            let _arg0: *mut ::libc::c_void = (arr as *mut i32 as *mut ::libc::c_void);
-            (pfree).unwrap()(_arg0)
-        });
+        (unsafe { (pfree).unwrap()((arr as *mut i32 as *mut ::libc::c_void)) });
         let mut grow: *mut i32 = ((unsafe {
-            let _arg0: usize = (2_usize).wrapping_mul((::std::mem::size_of::<i32>() as usize));
-            (pmalloc).unwrap()(_arg0)
+            (pmalloc).unwrap()((2_usize).wrapping_mul((::std::mem::size_of::<i32>() as usize)))
         }) as *mut i32);
         (*grow.offset((0) as isize)) = 1;
         (*grow.offset((1) as isize)) = 2;
         grow = ((unsafe {
-            let _arg0: *mut ::libc::c_void = (grow as *mut i32 as *mut ::libc::c_void);
-            let _arg1: usize = (4_usize).wrapping_mul((::std::mem::size_of::<i32>() as usize));
-            (prealloc).unwrap()(_arg0, _arg1)
+            (prealloc).unwrap()(
+                (grow as *mut i32 as *mut ::libc::c_void),
+                (4_usize).wrapping_mul((::std::mem::size_of::<i32>() as usize)),
+            )
         }) as *mut i32);
         (*grow.offset((2) as isize)) = 3;
         (*grow.offset((3) as isize)) = 4;
@@ -107,23 +98,15 @@ unsafe fn main_0() -> i32 {
         assert!(((((*grow.offset((1) as isize)) == (2)) as i32) != 0));
         assert!(((((*grow.offset((2) as isize)) == (3)) as i32) != 0));
         assert!(((((*grow.offset((3) as isize)) == (4)) as i32) != 0));
-        (unsafe {
-            let _arg0: *mut ::libc::c_void = (grow as *mut i32 as *mut ::libc::c_void);
-            (pfree).unwrap()(_arg0)
-        });
-        let mut zeros: *mut i32 = ((unsafe {
-            let _arg1: usize = ::std::mem::size_of::<i32>();
-            (pcalloc).unwrap()(4_usize, _arg1)
-        }) as *mut i32);
+        (unsafe { (pfree).unwrap()((grow as *mut i32 as *mut ::libc::c_void)) });
+        let mut zeros: *mut i32 =
+            ((unsafe { (pcalloc).unwrap()(4_usize, ::std::mem::size_of::<i32>()) }) as *mut i32);
         let mut i: i32 = 0;
         'loop_: while ((((i) < (4)) as i32) != 0) {
             assert!(((((*zeros.offset((i) as isize)) == (0)) as i32) != 0));
             i.postfix_inc();
         }
-        (unsafe {
-            let _arg0: *mut ::libc::c_void = (zeros as *mut i32 as *mut ::libc::c_void);
-            (pfree).unwrap()(_arg0)
-        });
+        (unsafe { (pfree).unwrap()((zeros as *mut i32 as *mut ::libc::c_void)) });
     }
     return 0;
 }

--- a/tests/unit/out/unsafe/map.rs
+++ b/tests/unit/out/unsafe/map.rs
@@ -32,15 +32,9 @@ unsafe fn main_0() -> i32 {
     assert!(((*m.entry(0_i16).or_default().as_mut()) == (1_u32)));
     assert!(((*m.entry(1_i16).or_default().as_mut()) == (4_u32)));
     assert!(((*m.entry(2_i16).or_default().as_mut()) == (3_u32)));
-    (unsafe {
-        let _x: u32 = (*m.entry(0_i16).or_default().as_mut());
-        foo_0(_x)
-    });
+    (unsafe { foo_0((*m.entry(0_i16).or_default().as_mut())) });
     assert!(((*m.entry(0_i16).or_default().as_mut()) == (1_u32)));
-    (unsafe {
-        let _x: *mut u32 = &mut (*m.entry(2_i16).or_default().as_mut()) as *mut u32;
-        bar_1(_x)
-    });
+    (unsafe { bar_1(&mut (*m.entry(2_i16).or_default().as_mut()) as *mut u32) });
     assert!(((*m.entry(2_i16).or_default().as_mut()) == (4_u32)));
     (*m.entry(0_i16).or_default().as_mut()) = (*m.entry(0_i16).or_default().as_mut())
         .wrapping_add((*m.entry(2_i16).or_default().as_mut()));

--- a/tests/unit/out/unsafe/matmul.rs
+++ b/tests/unit/out/unsafe/matmul.rs
@@ -36,11 +36,7 @@ pub unsafe fn matmul_1(
     mut n2: i32,
     mut p2: i32,
 ) -> Option<Box<[Option<Box<[i32]>>]>> {
-    let mut m3: Option<Box<[Option<Box<[i32]>>]>> = (unsafe {
-        let _n: i32 = n1;
-        let _p: i32 = p2;
-        matalloc_0(_n, _p, 0)
-    });
+    let mut m3: Option<Box<[Option<Box<[i32]>>]>> = (unsafe { matalloc_0(n1, p2, 0) });
     let mut i: i32 = 0;
     'loop_: while ((i) < (n1)) {
         let mut j: i32 = 0;
@@ -67,16 +63,8 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut n: i32 = 1;
     let mut p: i32 = 10;
-    let mut m1: Option<Box<[Option<Box<[i32]>>]>> = (unsafe {
-        let _n: i32 = n;
-        let _p: i32 = p;
-        matalloc_0(_n, _p, 1)
-    });
-    let mut m2: Option<Box<[Option<Box<[i32]>>]>> = (unsafe {
-        let _n: i32 = p;
-        let _p: i32 = n;
-        matalloc_0(_n, _p, 2)
-    });
+    let mut m1: Option<Box<[Option<Box<[i32]>>]>> = (unsafe { matalloc_0(n, p, 1) });
+    let mut m2: Option<Box<[Option<Box<[i32]>>]>> = (unsafe { matalloc_0(p, n, 2) });
     let mut m3: Option<Box<[Option<Box<[i32]>>]>> = (unsafe {
         let _m1: Option<Box<[Option<Box<[i32]>>]>> = m1;
         let _n1: i32 = n;

--- a/tests/unit/out/unsafe/new_bst.rs
+++ b/tests/unit/out/unsafe/new_bst.rs
@@ -15,17 +15,9 @@ pub struct node_t {
 }
 pub unsafe fn find_0(mut node: *mut node_t, mut value: i32) -> *mut node_t {
     if ((value) < ((*node).value)) && (!(((*node).left).is_null())) {
-        return (unsafe {
-            let _node: *mut node_t = (*node).left;
-            let _value: i32 = value;
-            find_0(_node, _value)
-        });
+        return (unsafe { find_0((*node).left, value) });
     } else if ((value) > ((*node).value)) && (!(((*node).right).is_null())) {
-        return (unsafe {
-            let _node: *mut node_t = (*node).right;
-            let _value: i32 = value;
-            find_0(_node, _value)
-        });
+        return (unsafe { find_0((*node).right, value) });
     } else if ((value) == ((*node).value)) {
         return node;
     }
@@ -40,32 +32,18 @@ pub unsafe fn insert_1(mut node: *mut node_t, mut value: i32) -> *mut node_t {
         })) as *mut node_t);
     }
     if ((value) < ((*node).value)) {
-        (*node).left = (unsafe {
-            let _node: *mut node_t = (*node).left;
-            let _value: i32 = value;
-            insert_1(_node, _value)
-        });
+        (*node).left = (unsafe { insert_1((*node).left, value) });
     } else if ((value) > ((*node).value)) {
-        (*node).right = (unsafe {
-            let _node: *mut node_t = (*node).right;
-            let _value: i32 = value;
-            insert_1(_node, _value)
-        });
+        (*node).right = (unsafe { insert_1((*node).right, value) });
     }
     return node;
 }
 pub unsafe fn del_2(mut node: *mut node_t) {
     if !(((*node).left).is_null()) {
-        (unsafe {
-            let _node: *mut node_t = (*node).left;
-            del_2(_node)
-        });
+        (unsafe { del_2((*node).left) });
     }
     if !(((*node).right).is_null()) {
-        (unsafe {
-            let _node: *mut node_t = (*node).right;
-            del_2(_node)
-        });
+        (unsafe { del_2((*node).right) });
     }
     ::std::mem::drop(Box::from_raw(node));
 }
@@ -80,60 +58,16 @@ unsafe fn main_0() -> i32 {
         right: std::ptr::null_mut(),
         value: 0,
     })) as *mut node_t);
-    root = (unsafe {
-        let _node: *mut node_t = root;
-        insert_1(_node, 1)
-    });
-    root = (unsafe {
-        let _node: *mut node_t = root;
-        insert_1(_node, 2)
-    });
-    root = (unsafe {
-        let _node: *mut node_t = root;
-        insert_1(_node, 3)
-    });
-    root = (unsafe {
-        let _node: *mut node_t = root;
-        insert_1(_node, 4)
-    });
-    let mut out: bool = (((((((*(unsafe {
-        let _node: *mut node_t = root;
-        find_0(_node, 0)
-    }))
-    .value)
-        == (0))
-        && (((*(unsafe {
-            let _node: *mut node_t = root;
-            find_0(_node, 1)
-        }))
-        .value)
-            == (1)))
-        && (((*(unsafe {
-            let _node: *mut node_t = root;
-            find_0(_node, 2)
-        }))
-        .value)
-            == (2)))
-        && (((*(unsafe {
-            let _node: *mut node_t = root;
-            find_0(_node, 3)
-        }))
-        .value)
-            == (3)))
-        && (((*(unsafe {
-            let _node: *mut node_t = root;
-            find_0(_node, 4)
-        }))
-        .value)
-            == (4)))
-        && ((unsafe {
-            let _node: *mut node_t = root;
-            find_0(_node, 5)
-        })
-        .is_null());
-    (unsafe {
-        let _node: *mut node_t = root;
-        del_2(_node)
-    });
+    root = (unsafe { insert_1(root, 1) });
+    root = (unsafe { insert_1(root, 2) });
+    root = (unsafe { insert_1(root, 3) });
+    root = (unsafe { insert_1(root, 4) });
+    let mut out: bool = (((((((*(unsafe { find_0(root, 0) })).value) == (0))
+        && (((*(unsafe { find_0(root, 1) })).value) == (1)))
+        && (((*(unsafe { find_0(root, 2) })).value) == (2)))
+        && (((*(unsafe { find_0(root, 3) })).value) == (3)))
+        && (((*(unsafe { find_0(root, 4) })).value) == (4)))
+        && ((unsafe { find_0(root, 5) }).is_null());
+    (unsafe { del_2(root) });
     return (out as i32);
 }

--- a/tests/unit/out/unsafe/no_direct_callee.rs
+++ b/tests/unit/out/unsafe/no_direct_callee.rs
@@ -21,8 +21,5 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    return (unsafe {
-        let _fn: Option<unsafe fn() -> bool> = Some(test1_0);
-        test_1(_fn)
-    });
+    return (unsafe { test_1(Some(test1_0)) });
 }

--- a/tests/unit/out/unsafe/pod.rs
+++ b/tests/unit/out/unsafe/pod.rs
@@ -34,9 +34,6 @@ unsafe fn main_0() -> i32 {
         x2: p1.x2,
         x3: p1.x3,
     };
-    (unsafe {
-        let _pod: *mut POD = &mut p2 as *mut POD;
-        PODIncrement_0(_pod)
-    });
+    (unsafe { PODIncrement_0(&mut p2 as *mut POD) });
     return (((p2.x1) + (p2.x2)) + (p2.x3));
 }

--- a/tests/unit/out/unsafe/pointer_array.rs
+++ b/tests/unit/out/unsafe/pointer_array.rs
@@ -39,9 +39,6 @@ unsafe fn main_0() -> i32 {
             (&mut x as *mut i32),
         ],
     };
-    (unsafe {
-        let _s: *mut StackArray = &mut s as *mut StackArray;
-        IncrementAll_0(_s)
-    });
+    (unsafe { IncrementAll_0(&mut s as *mut StackArray) });
     return x;
 }

--- a/tests/unit/out/unsafe/pointer_call_offset.rs
+++ b/tests/unit/out/unsafe/pointer_call_offset.rs
@@ -22,11 +22,8 @@ unsafe fn main_0() -> i32 {
         (*p1.offset((i) as isize)) = (i as i32);
         i.prefix_inc();
     }
-    let mut out: i32 = (*(unsafe {
-        let _p: *mut i32 = (&mut (*p1.offset((1) as isize)) as *mut i32);
-        foo_0(_p)
-    })
-    .offset((3) as isize));
+    let mut out: i32 =
+        (*(unsafe { foo_0((&mut (*p1.offset((1) as isize)) as *mut i32)) }).offset((3) as isize));
 
     ::std::mem::drop(Box::from_raw(::std::slice::from_raw_parts_mut(
         p1,

--- a/tests/unit/out/unsafe/pointers.rs
+++ b/tests/unit/out/unsafe/pointers.rs
@@ -29,11 +29,7 @@ pub unsafe fn Update_0(mut t: *mut Test) -> *mut Test {
     let mut x: i32 = 1;
     let mut y: i32 = 2;
     x.prefix_inc();
-    (unsafe {
-        let _x: i32 = x;
-        let _y: i32 = y;
-        (*t).update(_x, _y)
-    });
+    (unsafe { (*t).update(x, y) });
     x = (*t).x;
     y = (*t).x;
     (unsafe {
@@ -50,10 +46,7 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut t1: Test = Test { x: 100 };
-    let mut t2: *mut Test = (unsafe {
-        let _t: *mut Test = (&mut t1 as *mut Test);
-        Update_0(_t)
-    });
+    let mut t2: *mut Test = (unsafe { Update_0((&mut t1 as *mut Test)) });
     let mut t3: *mut Test = std::ptr::null_mut();
     t3 = t2;
     (*t3).x = 15;

--- a/tests/unit/out/unsafe/printfs.rs
+++ b/tests/unit/out/unsafe/printfs.rs
@@ -46,22 +46,17 @@ unsafe fn main_0() -> i32 {
     printf(
         b"%s\n\0".as_ptr() as *const i8,
         (unsafe {
-            let _v: Vec<u8> = {
+            fn_0({
                 let s = b"foo\0".as_ptr();
                 std::slice::from_raw_parts(s, (0..).take_while(|&i| *s.add(i) != 0).count() + 1)
                     .to_vec()
-            };
-            fn_0(_v)
+            })
         })
         .as_ptr(),
     );
     printf(
         b"%s\n\0".as_ptr() as *const i8,
-        (*(unsafe {
-            let _v: *const Vec<u8> = &s as *const Vec<u8>;
-            fn2_1(_v)
-        }))
-        .as_ptr(),
+        (*(unsafe { fn2_1(&s as *const Vec<u8>) })).as_ptr(),
     );
     return 0;
 }

--- a/tests/unit/out/unsafe/prvalue-as-lvalue.rs
+++ b/tests/unit/out/unsafe/prvalue-as-lvalue.rs
@@ -17,9 +17,6 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut a: i32 = 1;
     let mut pa: *mut i32 = (&mut a as *mut i32);
-    let b: *const i32 = (unsafe {
-        let _a: *const i32 = &(*pa) as *const i32;
-        foo_0(_a)
-    });
+    let b: *const i32 = (unsafe { foo_0(&(*pa) as *const i32) });
     return (*b);
 }

--- a/tests/unit/out/unsafe/push_emplace_back.rs
+++ b/tests/unit/out/unsafe/push_emplace_back.rs
@@ -84,17 +84,11 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut vecs: Vec<Vec<u8>> = Vec::new();
-    (unsafe {
-        let _dest: *mut Vec<Vec<u8>> = (&mut vecs as *mut Vec<Vec<u8>>);
-        push_param_0(_dest)
-    });
+    (unsafe { push_param_0((&mut vecs as *mut Vec<Vec<u8>>)) });
     assert!(((vecs.len()) == (1_usize)));
     assert!(vecs[(0_usize)].is_empty());
     let mut jpg: JPEGData = <JPEGData>::default();
-    (unsafe {
-        let _jpg: *mut JPEGData = (&mut jpg as *mut JPEGData);
-        push_local_from_field_1(_jpg, true)
-    });
+    (unsafe { push_local_from_field_1((&mut jpg as *mut JPEGData), true) });
     assert!(((jpg.com_data.len()) == (1_usize)));
     assert!(((jpg.com_data[(0_usize)].len()) == (3_usize)));
     assert!(((jpg.com_data[(0_usize)][(0_usize)] as i32) == (1)));
@@ -102,24 +96,15 @@ unsafe fn main_0() -> i32 {
     assert!(((jpg.com_data[(0_usize)][(2_usize)] as i32) == (3)));
     assert!(jpg.app_data.is_empty());
     let mut chunks: Vec<Chunk> = Vec::new();
-    (unsafe {
-        let _comps: *mut Vec<Chunk> = (&mut chunks as *mut Vec<Chunk>);
-        shrink_through_ptr_2(_comps)
-    });
+    (unsafe { shrink_through_ptr_2((&mut chunks as *mut Vec<Chunk>)) });
     assert!(chunks.is_empty());
     let mut w: Writer = <Writer>::default();
     w.chunk.data = 42;
     w.output = (&mut chunks as *mut Vec<Chunk>);
-    (unsafe {
-        let _bw: *mut Writer = (&mut w as *mut Writer);
-        nested_push_move_3(_bw)
-    });
+    (unsafe { nested_push_move_3((&mut w as *mut Writer)) });
     assert!(((chunks.len()) == (1_usize)));
     assert!(((chunks[(0_usize)].data) == (42)));
-    (unsafe {
-        let _jpg: *mut JPEGData = (&mut jpg as *mut JPEGData);
-        emplace_local_from_field_4(_jpg, false)
-    });
+    (unsafe { emplace_local_from_field_4((&mut jpg as *mut JPEGData), false) });
     assert!(((jpg.app_data.len()) == (1_usize)));
     assert!(((jpg.app_data[(0_usize)].len()) == (3_usize)));
     assert!(((jpg.app_data[(0_usize)][(0_usize)] as i32) == (1)));
@@ -127,16 +112,10 @@ unsafe fn main_0() -> i32 {
     assert!(((jpg.com_data.len()) == (1_usize)));
     w.chunk.data = 99;
     w.output = (&mut chunks as *mut Vec<Chunk>);
-    (unsafe {
-        let _bw: *mut Writer = (&mut w as *mut Writer);
-        nested_emplace_move_5(_bw)
-    });
+    (unsafe { nested_emplace_move_5((&mut w as *mut Writer)) });
     assert!(((chunks.len()) == (2_usize)));
     assert!(((chunks[(1_usize)].data) == (99)));
-    (unsafe {
-        let _comps: *mut Vec<Chunk> = (&mut chunks as *mut Vec<Chunk>);
-        self_ref_push_6(_comps)
-    });
+    (unsafe { self_ref_push_6((&mut chunks as *mut Vec<Chunk>)) });
     assert!(((chunks.len()) == (3_usize)));
     assert!(((chunks[(2_usize)].data) == (42)));
     return 0;

--- a/tests/unit/out/unsafe/redundant_copy_in_conversion.rs
+++ b/tests/unit/out/unsafe/redundant_copy_in_conversion.rs
@@ -24,10 +24,7 @@ unsafe fn main_0() -> i32 {
         UnsafeMapIterator::find_key(&m as *const BTreeMap<i32, Box<i32>>, &0);
     let mut const_it: UnsafeMapIterator<i32, i32> = it0.clone();
     let mut r: i32 = if const_it == end.clone() { 0 } else { 1 };
-    r += (unsafe {
-        let _it: UnsafeMapIterator<i32, i32> = it0.clone();
-        sink_0(_it)
-    });
+    r += (unsafe { sink_0(it0.clone()) });
     r += if end == end { 0 } else { 1 };
     return r;
 }

--- a/tests/unit/out/unsafe/ref_calls.rs
+++ b/tests/unit/out/unsafe/ref_calls.rs
@@ -19,22 +19,10 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut x: i32 = 5;
-    let mut y: i32 = (*(unsafe {
-        let _x: *mut i32 = &mut x as *mut i32;
-        foo_1(_x)
-    }));
-    let z: *mut i32 = (unsafe {
-        let _x: *mut i32 = &mut x as *mut i32;
-        foo_1(_x)
-    });
-    return ((((*(unsafe {
-        let _x: *mut i32 = &mut x as *mut i32;
-        foo_1(_x)
-    })) + (*(unsafe {
-        let _x: *mut i32 = &mut y as *mut i32;
-        foo_1(_x)
-    }))) + (*(unsafe {
-        let _x: *mut i32 = z;
-        foo_1(_x)
-    }))) + (unsafe { bar_0() }));
+    let mut y: i32 = (*(unsafe { foo_1(&mut x as *mut i32) }));
+    let z: *mut i32 = (unsafe { foo_1(&mut x as *mut i32) });
+    return ((((*(unsafe { foo_1(&mut x as *mut i32) }))
+        + (*(unsafe { foo_1(&mut y as *mut i32) })))
+        + (*(unsafe { foo_1(z) })))
+        + (unsafe { bar_0() }));
 }

--- a/tests/unit/out/unsafe/references2.rs
+++ b/tests/unit/out/unsafe/references2.rs
@@ -17,9 +17,6 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut a: Option<Box<i32>> = Some(Box::new(5));
-    (unsafe {
-        let _p: *mut Option<Box<i32>> = &mut a as *mut Option<Box<i32>>;
-        change_0(_p)
-    });
+    (unsafe { change_0(&mut a as *mut Option<Box<i32>>) });
     return (*a.as_deref_mut().unwrap());
 }

--- a/tests/unit/out/unsafe/refs_as_args.rs
+++ b/tests/unit/out/unsafe/refs_as_args.rs
@@ -25,10 +25,6 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut x1: i32 = 1;
     let x2: i32 = 2;
-    (unsafe {
-        let _r1: *mut i32 = &mut x1 as *mut i32;
-        let _r2: *const i32 = &x2 as *const i32;
-        more_refs_0(3, 4, _r1, _r2)
-    });
+    (unsafe { more_refs_0(3, 4, &mut x1 as *mut i32, &x2 as *const i32) });
     return ((x1) + (x2));
 }

--- a/tests/unit/out/unsafe/size_t_ssize_t.rs
+++ b/tests/unit/out/unsafe/size_t_ssize_t.rs
@@ -50,19 +50,17 @@ unsafe fn main_0() -> i32 {
     sz = (sz).wrapping_add(1_usize);
     assert!(((sz) == (21_usize)));
     let mut fr: usize = (unsafe {
-        let _a: usize = ((::std::mem::size_of::<i32>() as u64).wrapping_add((sz as u64)) as usize);
-        let _b: usize = (ul as usize);
-        add_sizes_0(_a, _b)
+        add_sizes_0(
+            ((::std::mem::size_of::<i32>() as u64).wrapping_add((sz as u64)) as usize),
+            (ul as usize),
+        )
     });
     assert!(
         ((fr)
             == (((::std::mem::size_of::<i32>() as usize).wrapping_add(21_usize) as usize)
                 .wrapping_add(10_usize)))
     );
-    let mut fr2: u64 = (unsafe {
-        let _x: u64 = (sz as u64);
-        take_ulong_1(_x)
-    });
+    let mut fr2: u64 = (unsafe { take_ulong_1((sz as u64)) });
     assert!(((fr2) == (21_u64)));
     let mut lo: usize = ({
         let mut __tmp_0 = (sz as u64);
@@ -123,11 +121,7 @@ unsafe fn main_0() -> i32 {
     assert!(((arr[(idx)]) == (2_usize)));
     let mut s1: isize = 5_isize;
     let mut s2: isize = 12_isize;
-    let mut sd: isize = (unsafe {
-        let _a: isize = s1;
-        let _b: isize = s2;
-        sub_signed_2(_a, _b)
-    });
+    let mut sd: isize = (unsafe { sub_signed_2(s1, s2) });
     assert!(((sd) == (-7_i32 as isize)));
     assert!(((sd) < (0_isize)));
     let mut l: i64 = 3_i64;

--- a/tests/unit/out/unsafe/string_literals.rs
+++ b/tests/unit/out/unsafe/string_literals.rs
@@ -21,32 +21,14 @@ unsafe fn main_0() -> i32 {
     let mut immutable_empty: *const u8 = b"\0".as_ptr();
     let mut mutable_empty_arr: [u8; 1] = [0u8; 1];
     let immutable_empty_arr: [u8; 1] = [0u8; 1];
-    (unsafe {
-        let _str: *mut u8 = mutable_string_arr.as_mut_ptr();
-        foo_mut_0(_str)
-    });
+    (unsafe { foo_mut_0(mutable_string_arr.as_mut_ptr()) });
     (unsafe { foo_const_1(b"world\0".as_ptr()) });
-    (unsafe {
-        let _str: *const u8 = immutable_string;
-        foo_const_1(_str)
-    });
-    (unsafe {
-        let _str: *const u8 = immutable_string_arr.as_ptr();
-        foo_const_1(_str)
-    });
+    (unsafe { foo_const_1(immutable_string) });
+    (unsafe { foo_const_1(immutable_string_arr.as_ptr()) });
     (unsafe { foo_const_1(b"\0".as_ptr()) });
-    (unsafe {
-        let _str: *const u8 = immutable_empty;
-        foo_const_1(_str)
-    });
-    (unsafe {
-        let _str: *const u8 = immutable_empty_arr.as_ptr();
-        foo_const_1(_str)
-    });
+    (unsafe { foo_const_1(immutable_empty) });
+    (unsafe { foo_const_1(immutable_empty_arr.as_ptr()) });
     let inited_through_init_list: [u8; 21] = *b"papanasi cu smantana\0";
-    (unsafe {
-        let _str: *const u8 = inited_through_init_list.as_ptr();
-        foo_const_1(_str)
-    });
+    (unsafe { foo_const_1(inited_through_init_list.as_ptr()) });
     return 0;
 }

--- a/tests/unit/out/unsafe/string_literals_c.rs
+++ b/tests/unit/out/unsafe/string_literals_c.rs
@@ -33,52 +33,19 @@ unsafe fn main_0() -> i32 {
     let mut mutable_empty_arr: [u8; 1] = [0u8; 1];
     let immutable_empty_arr: [u8; 1] = [0u8; 1];
     (unsafe { foo_mut_0(b"world\0".as_ptr().cast_mut()) });
-    (unsafe {
-        let _str: *mut u8 = mutable_string;
-        foo_mut_0(_str)
-    });
-    (unsafe {
-        let _str: *mut u8 = mutable_string_arr.as_mut_ptr();
-        foo_mut_0(_str)
-    });
+    (unsafe { foo_mut_0(mutable_string) });
+    (unsafe { foo_mut_0(mutable_string_arr.as_mut_ptr()) });
     (unsafe { foo_const_1((b"world\0".as_ptr().cast_mut()).cast_const()) });
-    (unsafe {
-        let _str: *const u8 = (mutable_string).cast_const();
-        foo_const_1(_str)
-    });
-    (unsafe {
-        let _str: *const u8 = immutable_string;
-        foo_const_1(_str)
-    });
-    (unsafe {
-        let _str: *const u8 = (mutable_string_arr.as_mut_ptr()).cast_const();
-        foo_const_1(_str)
-    });
-    (unsafe {
-        let _str: *const u8 = immutable_string_arr.as_ptr();
-        foo_const_1(_str)
-    });
+    (unsafe { foo_const_1((mutable_string).cast_const()) });
+    (unsafe { foo_const_1(immutable_string) });
+    (unsafe { foo_const_1((mutable_string_arr.as_mut_ptr()).cast_const()) });
+    (unsafe { foo_const_1(immutable_string_arr.as_ptr()) });
     (unsafe { foo_const_1((b"\0".as_ptr().cast_mut()).cast_const()) });
-    (unsafe {
-        let _str: *const u8 = (mutable_empty).cast_const();
-        foo_const_1(_str)
-    });
-    (unsafe {
-        let _str: *const u8 = immutable_empty;
-        foo_const_1(_str)
-    });
-    (unsafe {
-        let _str: *const u8 = (mutable_empty_arr.as_mut_ptr()).cast_const();
-        foo_const_1(_str)
-    });
-    (unsafe {
-        let _str: *const u8 = immutable_empty_arr.as_ptr();
-        foo_const_1(_str)
-    });
+    (unsafe { foo_const_1((mutable_empty).cast_const()) });
+    (unsafe { foo_const_1(immutable_empty) });
+    (unsafe { foo_const_1((mutable_empty_arr.as_mut_ptr()).cast_const()) });
+    (unsafe { foo_const_1(immutable_empty_arr.as_ptr()) });
     let inited_through_init_list: [u8; 21] = *b"papanasi cu smantana\0";
-    (unsafe {
-        let _str: *const u8 = inited_through_init_list.as_ptr();
-        foo_const_1(_str)
-    });
+    (unsafe { foo_const_1(inited_through_init_list.as_ptr()) });
     return 0;
 }

--- a/tests/unit/out/unsafe/string_literals_return.rs
+++ b/tests/unit/out/unsafe/string_literals_return.rs
@@ -34,10 +34,7 @@ unsafe fn main_0() -> i32 {
     assert!((((*c.offset((0) as isize)) as i32) == (('p' as u8) as i32)));
     assert!((((*c.offset((7) as isize)) as i32) == (('e' as u8) as i32)));
     assert!((((*c.offset((8) as isize)) as i32) == (('\0' as u8) as i32)));
-    let mut d: *const u8 = (unsafe {
-        let _x: i32 = -1_i32;
-        get_branch_2(_x)
-    });
+    let mut d: *const u8 = (unsafe { get_branch_2(-1_i32) });
     assert!((((*d.offset((0) as isize)) as i32) == (('n' as u8) as i32)));
     assert!((((*d.offset((11) as isize)) as i32) == (('e' as u8) as i32)));
     assert!((((*d.offset((12) as isize)) as i32) == (('\0' as u8) as i32)));

--- a/tests/unit/out/unsafe/string_literals_return_c.rs
+++ b/tests/unit/out/unsafe/string_literals_return_c.rs
@@ -34,10 +34,7 @@ unsafe fn main_0() -> i32 {
     assert!((((((*c.offset((0) as isize)) as i32) == ('p' as i32)) as i32) != 0));
     assert!((((((*c.offset((7) as isize)) as i32) == ('e' as i32)) as i32) != 0));
     assert!((((((*c.offset((8) as isize)) as i32) == ('\0' as i32)) as i32) != 0));
-    let mut d: *const u8 = (unsafe {
-        let _x: i32 = -1_i32;
-        get_branch_2(_x)
-    });
+    let mut d: *const u8 = (unsafe { get_branch_2(-1_i32) });
     assert!((((((*d.offset((0) as isize)) as i32) == ('n' as i32)) as i32) != 0));
     assert!((((((*d.offset((11) as isize)) as i32) == ('e' as i32)) as i32) != 0));
     assert!((((((*d.offset((12) as isize)) as i32) == ('\0' as i32)) as i32) != 0));

--- a/tests/unit/out/unsafe/strlen.rs
+++ b/tests/unit/out/unsafe/strlen.rs
@@ -27,8 +27,5 @@ unsafe fn main_0() -> i32 {
         ('o' as u8),
         ('\0' as u8),
     ];
-    return ((unsafe {
-        let _ptr: *mut u8 = (&mut string[(0) as usize] as *mut u8);
-        strlen_0(_ptr)
-    }) as i32);
+    return ((unsafe { strlen_0((&mut string[(0) as usize] as *mut u8)) }) as i32);
 }

--- a/tests/unit/out/unsafe/strlen_diff.rs
+++ b/tests/unit/out/unsafe/strlen_diff.rs
@@ -28,8 +28,5 @@ unsafe fn main_0() -> i32 {
         ('g' as u8),
         ('\0' as u8),
     ];
-    return ((unsafe {
-        let _s: *const u8 = (&s[(0) as usize] as *const u8);
-        strlen_0(_s)
-    }) as i32);
+    return ((unsafe { strlen_0((&s[(0) as usize] as *const u8)) }) as i32);
 }

--- a/tests/unit/out/unsafe/strlen_rec.rs
+++ b/tests/unit/out/unsafe/strlen_rec.rs
@@ -8,11 +8,7 @@ use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn strlen_0(mut s: *const u8, mut n: i32) -> i32 {
     return if ((*s) != 0) {
-        (unsafe {
-            let _s: *const u8 = s.offset((1) as isize);
-            let _n: i32 = ((n) + (1));
-            strlen_0(_s, _n)
-        })
+        (unsafe { strlen_0(s.offset((1) as isize), ((n) + (1))) })
     } else {
         n
     };
@@ -24,8 +20,5 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let s: [u8; 4] = [('s' as u8), ('t' as u8), ('r' as u8), ('\0' as u8)];
-    return (unsafe {
-        let _s: *const u8 = (&s[(0) as usize] as *const u8);
-        strlen_0(_s, 0)
-    });
+    return (unsafe { strlen_0((&s[(0) as usize] as *const u8), 0) });
 }

--- a/tests/unit/out/unsafe/struct_ctor.rs
+++ b/tests/unit/out/unsafe/struct_ctor.rs
@@ -37,10 +37,7 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut struct_with_ctor: StructWithCtor = StructWithCtor::StructWithCtor(1, 2);
     let mut x: i32 = 3;
-    return (((((*(unsafe {
-        let _x: *mut i32 = &mut x as *mut i32;
-        foo_0(_x)
-    })) == (3))
+    return (((((*(unsafe { foo_0(&mut x as *mut i32) })) == (3))
         && ((*(unsafe { struct_with_ctor.x1() })) == (2)))
         && ((*(unsafe { struct_with_ctor.x2() })) == (1))) as i32);
 }

--- a/tests/unit/out/unsafe/swap.rs
+++ b/tests/unit/out/unsafe/swap.rs
@@ -28,22 +28,11 @@ unsafe fn main_0() -> i32 {
     let mut local: i32 = 0;
     let mut a: i32 = 1;
     let mut b: i32 = 2;
-    let mut c: i32 = (unsafe {
-        let _x: i32 = local;
-        identity_0(_x)
-    });
+    let mut c: i32 = (unsafe { identity_0(local) });
     let mut p: *mut i32 = (&mut a as *mut i32);
     p = (&mut (b) as *mut i32);
     p = (&mut a as *mut i32);
-    (unsafe {
-        let _a: *mut i32 = p;
-        let _b: *mut i32 = (&mut b as *mut i32);
-        swap_by_ptr_1(_a, _b)
-    });
-    (unsafe {
-        let _a: *mut i32 = &mut a as *mut i32;
-        let _b: *mut i32 = &mut c as *mut i32;
-        swap_by_ref_2(_a, _b)
-    });
+    (unsafe { swap_by_ptr_1(p, (&mut b as *mut i32)) });
+    (unsafe { swap_by_ref_2(&mut a as *mut i32, &mut c as *mut i32) });
     return c;
 }

--- a/tests/unit/out/unsafe/swap_extended.rs
+++ b/tests/unit/out/unsafe/swap_extended.rs
@@ -38,10 +38,7 @@ unsafe fn main_0() -> i32 {
         x,
     );
     let mut a: i32 = 1;
-    let mut b: i32 = (unsafe {
-        let _x: i32 = a;
-        identity_0(_x)
-    });
+    let mut b: i32 = (unsafe { identity_0(a) });
     write!(
         std::fs::File::from_raw_fd(
             std::io::stdout()
@@ -68,18 +65,10 @@ unsafe fn main_0() -> i32 {
     );
     let mut d: i32 = 3;
     let mut e: i32 = 4;
-    (unsafe {
-        let _a: *mut i32 = (&mut d as *mut i32);
-        let _b: *mut i32 = (&mut e as *mut i32);
-        swap_by_ptr_1(_a, _b)
-    });
+    (unsafe { swap_by_ptr_1((&mut d as *mut i32), (&mut e as *mut i32)) });
     let mut f: i32 = 4;
     let mut g: i32 = 5;
-    (unsafe {
-        let _a: *mut i32 = &mut f as *mut i32;
-        let _b: *mut i32 = &mut g as *mut i32;
-        swap_by_ref_2(_a, _b)
-    });
+    (unsafe { swap_by_ref_2(&mut f as *mut i32, &mut g as *mut i32) });
     let mut h: *mut i32 = (Box::leak(Box::new(6)) as *mut i32);
     write!(
         std::fs::File::from_raw_fd(
@@ -112,26 +101,28 @@ unsafe fn main_0() -> i32 {
         libcc2rs::malloc_usable_size(i as *mut ::libc::c_void) / ::std::mem::size_of::<i32>(),
     )));
     (unsafe {
-        let _a: *mut i32 = (Box::leak(Box::new(7)) as *mut i32);
-        let _b: *mut i32 = (Box::leak(Box::new(8)) as *mut i32);
-        swap_by_ptr_1(_a, _b)
+        swap_by_ptr_1(
+            (Box::leak(Box::new(7)) as *mut i32),
+            (Box::leak(Box::new(8)) as *mut i32),
+        )
     });
     (unsafe {
-        let _a: *mut i32 = (Box::leak(Box::new(7)) as *mut i32).offset((0) as isize);
-        let _b: *mut i32 = (Box::leak(Box::new(8)) as *mut i32).offset((0) as isize);
-        swap_by_ptr_1(_a, _b)
+        swap_by_ptr_1(
+            (Box::leak(Box::new(7)) as *mut i32).offset((0) as isize),
+            (Box::leak(Box::new(8)) as *mut i32).offset((0) as isize),
+        )
     });
     (unsafe {
-        let _a: *mut i32 = &mut (*(Box::leak(Box::new(9)) as *mut i32)) as *mut i32;
-        let _b: *mut i32 = &mut (*(Box::leak(Box::new(10)) as *mut i32)) as *mut i32;
-        swap_by_ref_2(_a, _b)
+        swap_by_ref_2(
+            &mut (*(Box::leak(Box::new(9)) as *mut i32)) as *mut i32,
+            &mut (*(Box::leak(Box::new(10)) as *mut i32)) as *mut i32,
+        )
     });
     (unsafe {
-        let _a: *mut i32 =
-            &mut (*(Box::leak(Box::new(9)) as *mut i32).offset((0) as isize)) as *mut i32;
-        let _b: *mut i32 =
-            &mut (*(Box::leak(Box::new(10)) as *mut i32).offset((0) as isize)) as *mut i32;
-        swap_by_ref_2(_a, _b)
+        swap_by_ref_2(
+            &mut (*(Box::leak(Box::new(9)) as *mut i32).offset((0) as isize)) as *mut i32,
+            &mut (*(Box::leak(Box::new(10)) as *mut i32).offset((0) as isize)) as *mut i32,
+        )
     });
     let mut j: Option<Box<i32>> = Some(Box::from_raw((Box::leak(Box::new(11)) as *mut i32)));
     let mut k: *mut i32 = j

--- a/tests/unit/out/unsafe/switch_complex_cond.rs
+++ b/tests/unit/out/unsafe/switch_complex_cond.rs
@@ -33,30 +33,9 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut p_val: i32 = 5;
-    assert!(
-        ((unsafe {
-            let _p: *mut i32 = (&mut p_val as *mut i32);
-            switch_complex_cond_0(_p, 0)
-        }) == (2))
-    );
-    assert!(
-        ((unsafe {
-            let _p: *mut i32 = (&mut p_val as *mut i32);
-            switch_complex_cond_0(_p, 5)
-        }) == (3))
-    );
-    assert!(
-        ((unsafe {
-            let _p: *mut i32 = (&mut p_val as *mut i32);
-            let _bias: i32 = -5_i32;
-            switch_complex_cond_0(_p, _bias)
-        }) == (1))
-    );
-    assert!(
-        ((unsafe {
-            let _p: *mut i32 = (&mut p_val as *mut i32);
-            switch_complex_cond_0(_p, 99)
-        }) == (0))
-    );
+    assert!(((unsafe { switch_complex_cond_0((&mut p_val as *mut i32), 0,) }) == (2)));
+    assert!(((unsafe { switch_complex_cond_0((&mut p_val as *mut i32), 5,) }) == (3)));
+    assert!(((unsafe { switch_complex_cond_0((&mut p_val as *mut i32), -5_i32,) }) == (1)));
+    assert!(((unsafe { switch_complex_cond_0((&mut p_val as *mut i32), 99,) }) == (0)));
     return 0;
 }

--- a/tests/unit/out/unsafe/switch_enum.rs
+++ b/tests/unit/out/unsafe/switch_enum.rs
@@ -48,23 +48,8 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    assert!(
-        ((unsafe {
-            let _c: Color = Color::kRed;
-            switch_enum_0(_c)
-        }) == (10))
-    );
-    assert!(
-        ((unsafe {
-            let _c: Color = Color::kGreen;
-            switch_enum_0(_c)
-        }) == (20))
-    );
-    assert!(
-        ((unsafe {
-            let _c: Color = Color::kBlue;
-            switch_enum_0(_c)
-        }) == (30))
-    );
+    assert!(((unsafe { switch_enum_0(Color::kRed,) }) == (10)));
+    assert!(((unsafe { switch_enum_0(Color::kGreen,) }) == (20)));
+    assert!(((unsafe { switch_enum_0(Color::kBlue,) }) == (30)));
     return 0;
 }

--- a/tests/unit/out/unsafe/switch_mixed_literal_cases.rs
+++ b/tests/unit/out/unsafe/switch_mixed_literal_cases.rs
@@ -35,20 +35,10 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    assert!(
-        ((unsafe {
-            let _x: i32 = -1_i32;
-            mixed_literal_cases_0(_x)
-        }) == (1))
-    );
+    assert!(((unsafe { mixed_literal_cases_0(-1_i32,) }) == (1)));
     assert!(((unsafe { mixed_literal_cases_0(16,) }) == (2)));
     assert!(((unsafe { mixed_literal_cases_0(65152,) }) == (3)));
-    assert!(
-        ((unsafe {
-            let _x: i32 = -255_i32;
-            mixed_literal_cases_0(_x)
-        }) == (4))
-    );
+    assert!(((unsafe { mixed_literal_cases_0(-255_i32,) }) == (4)));
     assert!(((unsafe { mixed_literal_cases_0(7,) }) == (0)));
     return 0;
 }

--- a/tests/unit/out/unsafe/switch_on_call.rs
+++ b/tests/unit/out/unsafe/switch_on_call.rs
@@ -11,10 +11,7 @@ pub unsafe fn double_it_0(mut v: i32) -> i32 {
 }
 pub unsafe fn switch_on_call_1(mut x: i32) -> i32 {
     'switch: {
-        let __match_cond = (unsafe {
-            let _v: i32 = x;
-            double_it_0(_v)
-        });
+        let __match_cond = (unsafe { double_it_0(x) });
         match __match_cond {
             __v if __v == 0 => {
                 return 100;

--- a/tests/unit/out/unsafe/tag_vs_identifier_collision.rs
+++ b/tests/unit/out/unsafe/tag_vs_identifier_collision.rs
@@ -101,12 +101,7 @@ unsafe fn main_0() -> i32 {
     let mut w: widget = <widget>::default();
     w.id = 7;
     w.mode = widget_enum::MODE_ACTIVE;
-    assert!(
-        ((unsafe {
-            let _w: *mut widget = (&mut w as *mut widget);
-            is_active_0(_w)
-        }) != 0)
-    );
+    assert!(((unsafe { is_active_0((&mut w as *mut widget),) }) != 0));
     w.mode = widget_enum::MODE_DONE;
     assert!(((((w.mode as u32) == ((widget_enum::MODE_DONE as i32) as u32)) as i32) != 0));
     let mut p: point_struct = <point_struct>::default();

--- a/tests/unit/out/unsafe/templates.rs
+++ b/tests/unit/out/unsafe/templates.rs
@@ -32,26 +32,9 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut x: i32 = 10;
     let mut y: f64 = (x as f64);
-    return ((((((((unsafe {
-        let _x: i32 = x;
-        foo_0(_x)
-    }) as f64)
-        + (unsafe {
-            let _x: f64 = y;
-            foo_1(_x)
-        }))
-        + ((*(unsafe {
-            let _p: *mut i32 = (&mut x as *mut i32);
-            bar_2(_p, true)
-        })) as f64))
-        + (*(unsafe {
-            let _p: *mut f64 = (&mut y as *mut f64);
-            bar_3(_p, true)
-        })))
+    return ((((((((unsafe { foo_0(x) }) as f64) + (unsafe { foo_1(y) }))
+        + ((*(unsafe { bar_2((&mut x as *mut i32), true) })) as f64))
+        + (*(unsafe { bar_3((&mut y as *mut f64), true) })))
         + ((unsafe { func_4(1, 2, 3) }) as f64))
-        + ((unsafe {
-            let _x2: i32 = x;
-            let _x3: f64 = y;
-            func_5(2.0E+0, _x2, _x3)
-        }) as f64)) as i32);
+        + ((unsafe { func_5(2.0E+0, x, y) }) as f64)) as i32);
 }

--- a/tests/unit/out/unsafe/union_struct_dual_use.rs
+++ b/tests/unit/out/unsafe/union_struct_dual_use.rs
@@ -40,13 +40,7 @@ unsafe fn main_0() -> i32 {
     let mut standalone: Inner = <Inner>::default();
     standalone.a = 3;
     standalone.b = 4;
-    assert!(
-        ((((unsafe {
-            let _i: *mut Inner = (&mut standalone as *mut Inner);
-            sum_inner_0(_i)
-        }) == (7)) as i32)
-            != 0)
-    );
+    assert!(((((unsafe { sum_inner_0((&mut standalone as *mut Inner),) }) == (7)) as i32) != 0));
     let mut outer: Outer = <Outer>::default();
     {
         let byte_0 = ((&mut outer as *mut Outer) as *mut Outer as *mut ::libc::c_void) as *mut u8;
@@ -57,13 +51,7 @@ unsafe fn main_0() -> i32 {
     };
     outer.u.inner.a = 3;
     outer.u.inner.b = 4;
-    assert!(
-        ((((unsafe {
-            let _i: *mut Inner = (&mut outer.u.inner as *mut Inner);
-            sum_inner_0(_i)
-        }) == (7)) as i32)
-            != 0)
-    );
+    assert!(((((unsafe { sum_inner_0((&mut outer.u.inner as *mut Inner),) }) == (7)) as i32) != 0));
     assert!((((((outer.u.raw_[(0) as usize] as u8) as i32) == (3)) as i32) != 0));
     assert!((((((outer.u.raw_[(4) as usize] as u8) as i32) == (4)) as i32) != 0));
     return 0;

--- a/tests/unit/out/unsafe/union_void_ptr_sized_deref.rs
+++ b/tests/unit/out/unsafe/union_void_ptr_sized_deref.rs
@@ -75,24 +75,15 @@ unsafe fn main_0() -> i32 {
     let mut s: Sink = <Sink>::default();
     s.width = Width_enum::W_64;
     s.out.handle = ((&mut buf64 as *mut i64) as *mut i64 as *mut ::libc::c_void);
-    (unsafe {
-        let _s: *mut Sink = (&mut s as *mut Sink);
-        write_count_1(_s, 1234605616436508552_i64)
-    });
+    (unsafe { write_count_1((&mut s as *mut Sink), 1234605616436508552_i64) });
     assert!(((((buf64) == (1234605616436508552_i64)) as i32) != 0));
     s.width = Width_enum::W_32;
     s.out.handle = ((&mut buf32 as *mut i32) as *mut i32 as *mut ::libc::c_void);
-    (unsafe {
-        let _s: *mut Sink = (&mut s as *mut Sink);
-        write_count_1(_s, 305419896_i64)
-    });
+    (unsafe { write_count_1((&mut s as *mut Sink), 305419896_i64) });
     assert!(((((buf32) == (305419896)) as i32) != 0));
     s.width = Width_enum::W_16;
     s.out.handle = ((&mut buf16 as *mut i16) as *mut i16 as *mut ::libc::c_void);
-    (unsafe {
-        let _s: *mut Sink = (&mut s as *mut Sink);
-        write_count_1(_s, 4660_i64)
-    });
+    (unsafe { write_count_1((&mut s as *mut Sink), 4660_i64) });
     assert!(((((buf16 as i32) == (4660)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/unique_ptr.rs
+++ b/tests/unit/out/unsafe/unique_ptr.rs
@@ -136,10 +136,7 @@ pub unsafe fn RndStuff_2() {
     'loop_: while ((i) < (50)) {
         assert!((((*p3_1.offset((i) as isize)).x) == (-1_i32)));
         assert!((((*p3_1.offset((i) as isize)).y) == (-2_i32)));
-        (unsafe {
-            let _k: i32 = -10_i32;
-            x3.as_mut().unwrap()[(i as usize)].inc(_k)
-        });
+        (unsafe { x3.as_mut().unwrap()[(i as usize)].inc(-10_i32) });
         assert!((((*p3_1.offset((i) as isize)).x) == (-11_i32)));
         assert!((((*p3_1.offset((i) as isize)).y) == (-12_i32)));
         i.prefix_inc();
@@ -153,13 +150,6 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut x: Option<Box<i32>> = Some(Box::new(0));
     let mut safe_ptr: Option<Box<SafePointer>> = Some(Box::new(SafePointer { ptr: x }));
-    (unsafe {
-        let _safe_ptr: *mut Option<Box<SafePointer>> =
-            &mut safe_ptr as *mut Option<Box<SafePointer>>;
-        DoStuffWithSafePointer_0(_safe_ptr)
-    });
-    return (unsafe {
-        let _safe_ptr: Option<Box<SafePointer>> = safe_ptr;
-        Consume_1(_safe_ptr)
-    });
+    (unsafe { DoStuffWithSafePointer_0(&mut safe_ptr as *mut Option<Box<SafePointer>>) });
+    return (unsafe { Consume_1(safe_ptr) });
 }

--- a/tests/unit/out/unsafe/unique_ptr_const_deref.rs
+++ b/tests/unit/out/unsafe/unique_ptr_const_deref.rs
@@ -29,12 +29,6 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut h: Holder = <Holder>::default();
     h.val = Some(Box::new(10));
-    (unsafe {
-        let _h: *const Holder = (&mut h as *mut Holder).cast_const();
-        write_val_1(_h, 42)
-    });
-    return (unsafe {
-        let _h: *const Holder = (&mut h as *mut Holder).cast_const();
-        read_val_0(_h)
-    });
+    (unsafe { write_val_1((&mut h as *mut Holder).cast_const(), 42) });
+    return (unsafe { read_val_0((&mut h as *mut Holder).cast_const()) });
 }

--- a/tests/unit/out/unsafe/unique_ptr_small.rs
+++ b/tests/unit/out/unsafe/unique_ptr_small.rs
@@ -17,9 +17,6 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut n: Option<Box<i32>> = Some(Box::new(10));
-    (unsafe {
-        let _n: *mut Option<Box<i32>> = &mut n as *mut Option<Box<i32>>;
-        change_0(_n)
-    });
+    (unsafe { change_0(&mut n as *mut Option<Box<i32>>) });
     return (*n.as_deref_mut().unwrap());
 }

--- a/tests/unit/out/unsafe/unique_ptr_struct.rs
+++ b/tests/unit/out/unsafe/unique_ptr_struct.rs
@@ -25,9 +25,6 @@ unsafe fn main_0() -> i32 {
     (*p.as_deref_mut().unwrap()).x += 10;
     (*p.as_deref_mut().unwrap()).y =
         (((*p.as_deref_mut().unwrap()).x) + ((*p.as_deref_mut().unwrap()).y));
-    let mut s: i32 = (unsafe {
-        let _p: Point = (*p.as_deref_mut().unwrap()).clone();
-        sum_0(_p)
-    });
+    let mut s: i32 = (unsafe { sum_0((*p.as_deref_mut().unwrap()).clone()) });
     return s;
 }

--- a/tests/unit/out/unsafe/va_arg_chain.rs
+++ b/tests/unit/out/unsafe/va_arg_chain.rs
@@ -15,20 +15,12 @@ pub unsafe fn extract_nth_0(mut n: i32, mut ap: VaList) -> i32 {
     return ap.arg::<i32>();
 }
 pub unsafe fn middle_layer_1(mut n: i32, mut ap: VaList) -> i32 {
-    return (unsafe {
-        let _n: i32 = n;
-        let _ap: VaList = ap;
-        extract_nth_0(_n, _ap)
-    });
+    return (unsafe { extract_nth_0(n, ap) });
 }
 pub unsafe fn top_level_2(mut n: i32, __args: &[VaArg]) -> i32 {
     let mut ap: VaList = VaList::default();
     ap = VaList::new(__args);
-    let mut result: i32 = (unsafe {
-        let _n: i32 = n;
-        let _ap: VaList = ap;
-        middle_layer_1(_n, _ap)
-    });
+    let mut result: i32 = (unsafe { middle_layer_1(n, ap) });
     return result;
 }
 pub fn main() {

--- a/tests/unit/out/unsafe/va_arg_fn_ptr.rs
+++ b/tests/unit/out/unsafe/va_arg_fn_ptr.rs
@@ -22,10 +22,7 @@ pub unsafe fn apply_unary_3(mut x: i32, __args: &[VaArg]) -> i32 {
         *mut ::libc::c_void,
         Option<unsafe fn(i32) -> i32>,
     >(ap.arg::<*mut ::libc::c_void>());
-    let mut result: i32 = (unsafe {
-        let _arg0: i32 = x;
-        (fn_).unwrap()(_arg0)
-    });
+    let mut result: i32 = (unsafe { (fn_).unwrap()(x) });
     return result;
 }
 pub unsafe fn apply_binary_4(mut a: i32, mut b: i32, __args: &[VaArg]) -> i32 {
@@ -35,11 +32,7 @@ pub unsafe fn apply_binary_4(mut a: i32, mut b: i32, __args: &[VaArg]) -> i32 {
         *mut ::libc::c_void,
         Option<unsafe fn(i32, i32) -> i32>,
     >(ap.arg::<*mut ::libc::c_void>());
-    let mut result: i32 = (unsafe {
-        let _arg0: i32 = a;
-        let _arg1: i32 = b;
-        (fn_).unwrap()(_arg0, _arg1)
-    });
+    let mut result: i32 = (unsafe { (fn_).unwrap()(a, b) });
     return result;
 }
 pub fn main() {

--- a/tests/unit/out/unsafe/va_arg_forward.rs
+++ b/tests/unit/out/unsafe/va_arg_forward.rs
@@ -18,11 +18,7 @@ pub unsafe fn inner_0(mut count: i32, mut ap: VaList) -> i32 {
 pub unsafe fn outer_1(mut count: i32, __args: &[VaArg]) -> i32 {
     let mut ap: VaList = VaList::default();
     ap = VaList::new(__args);
-    let mut result: i32 = (unsafe {
-        let _count: i32 = count;
-        let _ap: VaList = ap;
-        inner_0(_count, _ap)
-    });
+    let mut result: i32 = (unsafe { inner_0(count, ap) });
     return result;
 }
 pub fn main() {

--- a/tests/unit/out/unsafe/va_arg_non_primitive_ptrs.rs
+++ b/tests/unit/out/unsafe/va_arg_non_primitive_ptrs.rs
@@ -75,24 +75,27 @@ unsafe fn main_0() -> i32 {
     let mut s: *const u8 = std::ptr::null();
     assert!(
         ((((unsafe {
-            let _option: i32 = (opt::OPT_STRING_OUT as i32);
-            dispatch_0(_option, &[(&mut s as *mut *const u8).into()])
+            dispatch_0(
+                (opt::OPT_STRING_OUT as i32),
+                &[(&mut s as *mut *const u8).into()],
+            )
         }) == (1)) as i32)
             != 0)
     );
     assert!((((!((s).is_null())) as i32) != 0));
     assert!(
         ((((unsafe {
-            let _option: i32 = (opt::OPT_FILE as i32);
-            dispatch_0(_option, &[(libcc2rs::stdout_unsafe()).into()])
+            dispatch_0(
+                (opt::OPT_FILE as i32),
+                &[(libcc2rs::stdout_unsafe()).into()],
+            )
         }) == (1)) as i32)
             != 0)
     );
     assert!(
         ((((unsafe {
-            let _option: i32 = (opt::OPT_FILE as i32);
             dispatch_0(
-                _option,
+                (opt::OPT_FILE as i32),
                 &[((0 as *mut ::libc::c_void) as *mut ::libc::FILE).into()],
             )
         }) == (0)) as i32)
@@ -103,17 +106,17 @@ unsafe fn main_0() -> i32 {
         next: std::ptr::null_mut(),
     };
     assert!(
-        ((((unsafe {
-            let _option: i32 = (opt::OPT_NODE as i32);
-            dispatch_0(_option, &[(&mut head as *mut node).into()])
-        }) == (42)) as i32)
+        ((((unsafe { dispatch_0((opt::OPT_NODE as i32), &[(&mut head as *mut node).into(),]) })
+            == (42)) as i32)
             != 0)
     );
     let mut outp: *mut node = (&mut head as *mut node);
     assert!(
         ((((unsafe {
-            let _option: i32 = (opt::OPT_NODE_OUT as i32);
-            dispatch_0(_option, &[(&mut outp as *mut *mut node).into()])
+            dispatch_0(
+                (opt::OPT_NODE_OUT as i32),
+                &[(&mut outp as *mut *mut node).into()],
+            )
         }) == (2)) as i32)
             != 0)
     );

--- a/tests/unit/out/unsafe/va_arg_printf.rs
+++ b/tests/unit/out/unsafe/va_arg_printf.rs
@@ -13,11 +13,7 @@ pub unsafe fn logf_impl_0(mut fmt: *const u8, mut ap: VaList) -> i32 {
 pub unsafe fn logf_1(mut fmt: *const u8, __args: &[VaArg]) -> i32 {
     let mut ap: VaList = VaList::default();
     ap = VaList::new(__args);
-    let mut result: i32 = (unsafe {
-        let _fmt: *const u8 = fmt;
-        let _ap: VaList = ap;
-        logf_impl_0(_fmt, _ap)
-    });
+    let mut result: i32 = (unsafe { logf_impl_0(fmt, ap) });
     return result;
 }
 pub fn main() {

--- a/tests/unit/out/unsafe/va_arg_snprintf.rs
+++ b/tests/unit/out/unsafe/va_arg_snprintf.rs
@@ -27,9 +27,8 @@ unsafe fn main_0() -> i32 {
     let mut buf: [u8; 64] = [0_u8; 64];
     assert!(
         ((((unsafe {
-            let _buf: *mut u8 = buf.as_mut_ptr();
             extract_first_0(
-                _buf,
+                buf.as_mut_ptr(),
                 1,
                 (b"%d\0".as_ptr().cast_mut()).cast_const(),
                 &[(42).into()],
@@ -40,9 +39,8 @@ unsafe fn main_0() -> i32 {
     assert!(((((buf[(0) as usize] as i32) == (42)) as i32) != 0));
     assert!(
         ((((unsafe {
-            let _buf: *mut u8 = buf.as_mut_ptr();
             extract_first_0(
-                _buf,
+                buf.as_mut_ptr(),
                 1,
                 (b"%d\0".as_ptr().cast_mut()).cast_const(),
                 &[(65).into()],

--- a/tests/unit/out/unsafe/va_arg_struct_ctx.rs
+++ b/tests/unit/out/unsafe/va_arg_struct_ctx.rs
@@ -29,9 +29,8 @@ unsafe fn main_0() -> i32 {
     ctx.verbose = 1;
     ctx.last_error = 0;
     (unsafe {
-        let _ctx: *mut context = (&mut ctx as *mut context);
         set_error_0(
-            _ctx,
+            (&mut ctx as *mut context),
             (b"error %d\0".as_ptr().cast_mut()).cast_const(),
             &[(42).into()],
         )
@@ -39,9 +38,8 @@ unsafe fn main_0() -> i32 {
     assert!(((((ctx.last_error) == (42)) as i32) != 0));
     ctx.verbose = 0;
     (unsafe {
-        let _ctx: *mut context = (&mut ctx as *mut context);
         set_error_0(
-            _ctx,
+            (&mut ctx as *mut context),
             (b"error %d\0".as_ptr().cast_mut()).cast_const(),
             &[(99).into()],
         )

--- a/tests/unit/out/unsafe/vector.rs
+++ b/tests/unit/out/unsafe/vector.rs
@@ -49,10 +49,7 @@ unsafe fn main_0() -> i32 {
         let pos = v2.as_mut_ptr().offset_from(v2.as_ptr()) as usize;
         v2.insert(pos, 100);
     };
-    (unsafe {
-        let _copy_vector: Vec<i32> = v2.clone();
-        copy_0(_copy_vector)
-    });
+    (unsafe { copy_0(v2.clone()) });
     assert!(((v2.len()) == (3_usize)));
     assert!(((v2[(0_usize)]) == (100)));
     assert!(((v2[(1_usize)]) == (2)));

--- a/tests/unit/out/unsafe/vector2.rs
+++ b/tests/unit/out/unsafe/vector2.rs
@@ -44,10 +44,6 @@ unsafe fn main_0() -> i32 {
     v.push(6);
     v2.push(8);
     v2.push(9);
-    (unsafe {
-        let _v: *mut Vec<i32> = &mut v as *mut Vec<i32>;
-        let _v3: Vec<i32> = v2.clone();
-        fn_0(_v, _v3)
-    });
+    (unsafe { fn_0(&mut v as *mut Vec<i32>, v2.clone()) });
     return 0;
 }

--- a/tests/unit/out/unsafe/void_cast.rs
+++ b/tests/unit/out/unsafe/void_cast.rs
@@ -93,13 +93,7 @@ unsafe fn main_0() -> i32 {
     let mut hp: *mut Holder = (&mut h as *mut Holder);
     &((*hp).field);
     let mut nt: NonTrivial = <NonTrivial>::default();
-    (unsafe {
-        let _x: *const NonTrivial = &nt as *const NonTrivial;
-        unused_ref_param_1(_x)
-    });
-    (unsafe {
-        let _p: *const NonTrivial = (&mut nt as *mut NonTrivial).cast_const();
-        unused_ptr_param_2(_p)
-    });
+    (unsafe { unused_ref_param_1(&nt as *const NonTrivial) });
+    (unsafe { unused_ptr_param_2((&mut nt as *mut NonTrivial).cast_const()) });
     return 0;
 }

--- a/tests/unit/out/unsafe/z_bit_cast.rs
+++ b/tests/unit/out/unsafe/z_bit_cast.rs
@@ -15,27 +15,14 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut a1: [u32; 3] = [1_u32, 2_u32, 3_u32];
+    (unsafe { decay_cast_0(a1.as_mut_ptr()) });
+    (unsafe { decay_cast_0((&mut a1[(0) as usize] as *mut u32)) });
+    (unsafe { bit_cast_1((a1.as_mut_ptr() as *const u32 as *const ::libc::c_void)) });
     (unsafe {
-        let _a1: *mut u32 = a1.as_mut_ptr();
-        decay_cast_0(_a1)
+        bit_cast_1(((&mut a1[(0) as usize] as *mut u32) as *const u32 as *const ::libc::c_void))
     });
     (unsafe {
-        let _a1: *mut u32 = (&mut a1[(0) as usize] as *mut u32);
-        decay_cast_0(_a1)
-    });
-    (unsafe {
-        let _p: *const ::libc::c_void = (a1.as_mut_ptr() as *const u32 as *const ::libc::c_void);
-        bit_cast_1(_p)
-    });
-    (unsafe {
-        let _p: *const ::libc::c_void =
-            ((&mut a1[(0) as usize] as *mut u32) as *const u32 as *const ::libc::c_void);
-        bit_cast_1(_p)
-    });
-    (unsafe {
-        let _p: *const ::libc::c_void =
-            ((&mut a1 as *mut [u32; 3]) as *const [u32; 3] as *const ::libc::c_void);
-        bit_cast_1(_p)
+        bit_cast_1(((&mut a1 as *mut [u32; 3]) as *const [u32; 3] as *const ::libc::c_void))
     });
     let mut ptr: *mut ::libc::c_void = (a1.as_mut_ptr() as *mut u32 as *mut ::libc::c_void);
     assert!(((ptr) == (a1.as_mut_ptr() as *mut u32 as *mut ::libc::c_void)));


### PR DESCRIPTION
In terms of converter, the PR is small. I moved GetAllVars and MayCauseBorrowMutError from converter to converter_lib because they are converter-agnostic. Then I added the aliasing logic in CollectCallInfo 2 functions in converter_lib: ReferencesThis and ArgsMayAlias.

The core idea is: if an argument of a function call does not alias with any other argument, then it can be inlined instead of hoisted. This includes aliases over this, for example `this.method(this.member)`