### PR TITLE
Handle explicit cast of union member

### DIFF
--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -1310,17 +1310,9 @@ bool ConverterRefCount::VisitExplicitCastExpr(clang::ExplicitCastExpr *expr) {
     } else if (expr->getSubExpr()->getType()->isPointerType() &&
                !expr->getSubExpr()->isNullPointerConstant(
                    ctx_, clang::Expr::NPC_ValueDependentIsNull)) {
-      auto src_pointee = expr->getSubExpr()->getType()->getPointeeType();
-      auto dst_pointee = expr->getType()->getPointeeType();
-      if (ctx_.hasSameUnqualifiedType(src_pointee, dst_pointee)) {
-        StrCat(std::format("({}.to_strong().as_pointer() as {})",
-                           ToString(expr->getSubExpr()),
-                           ToString(expr->getType())));
-      } else {
-        StrCat(std::format("{}.reinterpret_cast::<{}>()",
-                           ToString(expr->getSubExpr()),
-                           ConvertPointeeType(expr->getType())));
-      }
+      StrCat(std::format("{}.reinterpret_cast::<{}>()",
+                         ToString(expr->getSubExpr()),
+                         ConvertPointeeType(expr->getType())));
       return false;
     }
     return Converter::VisitExplicitCastExpr(expr);

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -1310,9 +1310,17 @@ bool ConverterRefCount::VisitExplicitCastExpr(clang::ExplicitCastExpr *expr) {
     } else if (expr->getSubExpr()->getType()->isPointerType() &&
                !expr->getSubExpr()->isNullPointerConstant(
                    ctx_, clang::Expr::NPC_ValueDependentIsNull)) {
-      StrCat(std::format("({}.to_strong().as_pointer() as {})",
-                         ToString(expr->getSubExpr()),
-                         ToString(expr->getType())));
+      auto src_pointee = expr->getSubExpr()->getType()->getPointeeType();
+      auto dst_pointee = expr->getType()->getPointeeType();
+      if (ctx_.hasSameUnqualifiedType(src_pointee, dst_pointee)) {
+        StrCat(std::format("({}.to_strong().as_pointer() as {})",
+                           ToString(expr->getSubExpr()),
+                           ToString(expr->getType())));
+      } else {
+        StrCat(std::format("{}.reinterpret_cast::<{}>()",
+                           ToString(expr->getSubExpr()),
+                           ConvertPointeeType(expr->getType())));
+      }
       return false;
     }
     return Converter::VisitExplicitCastExpr(expr);


### PR DESCRIPTION
Union members are translated using accessors:

```cpp
union u { int a; }
*(char *)&u.a = 0xFF;
```
becomes

```rs
struct u { __bytes: Value<Box<[u8]>> }
impl u { pub fn a() -> Ptr<i32> { ... } } // the accessor

u.a().reinterpret_cast<u8>().write(0xFF) // Before this PR it did not compile: (u.a() as Ptr<u8>).write(0xFF)
```

This PR replaces the wrong `(u.a() as Ptr<u8>)` pattern with `u.a().reinterpret_cast<u8>()`