### PR TITLE
Allow `Ptr::offset()` to receive any value that can cast to `isize`

### DIFF
--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -2060,7 +2060,7 @@ bool ConverterRefCount::ConvertCXXOperatorCallExpr(
       StrCat(
           std::format("{}.as_ref().unwrap()", ConvertRValue(expr->getArg(0))));
       if (isAddrOf()) {
-        StrCat(std::format(".as_pointer().offset(({}) as isize)",
+        StrCat(std::format(".as_pointer().offset(({}))",
                            ConvertRValue(expr->getArg(1))));
       } else {
         if (isRValue()) {
@@ -2080,7 +2080,7 @@ bool ConverterRefCount::ConvertCXXOperatorCallExpr(
 
     if (isLValue()) {
       PushConversionKind push_ck(*this, ConversionKind::Unboxed);
-      pending_deref_.set(std::format("({} as {}).offset({} as isize)",
+      pending_deref_.set(std::format("({} as {}).offset({})",
                                      ConvertObject(expr->getArg(0)),
                                      ConvertPtrType(expr->getArg(0)->getType()),
                                      ConvertRValue(expr->getArg(1))),
@@ -2100,7 +2100,7 @@ bool ConverterRefCount::ConvertCXXOperatorCallExpr(
       }
 
       PushConversionKind push(*this, ConversionKind::Unboxed);
-      StrCat(std::format("({} as {}).offset({} as isize)",
+      StrCat(std::format("({} as {}).offset({})",
                          ConvertObject(expr->getArg(0)),
                          ConvertPtrType(expr->getArg(0)->getType()),
                          ConvertRValue(expr->getArg(1))));
@@ -2151,7 +2151,7 @@ void ConverterRefCount::ConvertArraySubscript(clang::Expr *base,
 
     {
       PushParen paren(*this, is_inner_boxed);
-      StrCat(std::format("({} as {}).offset({} as isize)",
+      StrCat(std::format("({} as {}).offset({})",
                          ToString(base->IgnoreImplicit()),
                          ConvertPtrType(base->IgnoreImplicit()->getType()),
                          ConvertRValue(idx)));

--- a/libcc2rs/src/rc.rs
+++ b/libcc2rs/src/rc.rs
@@ -296,7 +296,11 @@ impl<T> Ptr<T> {
     }
 
     #[inline]
-    pub fn offset(&self, offset: isize) -> Self {
+    pub fn offset(&self, offset: impl TryInto<isize>) -> Self {
+        let offset = offset
+            .try_into()
+            .ok()
+            .expect("the offset must fit in a isize");
         let step = self.elem_step();
         Self {
             kind: self.kind.clone(),

--- a/tests/ub/out/refcount/ub7.rs
+++ b/tests/ub/out/refcount/ub7.rs
@@ -26,5 +26,5 @@ fn main_0() -> i32 {
         ('n' as u8),
         ('g' as u8),
     ])));
-    return (({ strlen_0(((s.as_pointer() as Ptr<u8>).offset(0 as isize))) }) as i32);
+    return (({ strlen_0(((s.as_pointer() as Ptr<u8>).offset(0))) }) as i32);
 }

--- a/tests/unit/out/refcount/04_address_taken_array.rs
+++ b/tests/unit/out/refcount/04_address_taken_array.rs
@@ -16,7 +16,7 @@ fn main_0() -> i32 {
     let arr2_ptr: Value<Ptr<i32>> = Rc::new(RefCell::new((arr2.as_pointer() as Ptr<i32>)));
     (*arr2_ptr.borrow()).offset((0) as isize).write(5);
     (*arr2_ptr.borrow()).offset((1) as isize).write(6);
-    let arr2_ref1: Ptr<i32> = (arr2.as_pointer() as Ptr<i32>).offset(1 as isize);
+    let arr2_ref1: Ptr<i32> = (arr2.as_pointer() as Ptr<i32>).offset(1);
     arr2_ref1.write(7);
     return ((*arr2.borrow())[(0) as usize] + (*arr2.borrow())[(1) as usize]);
 }

--- a/tests/unit/out/refcount/array_of_noncopy_struct.rs
+++ b/tests/unit/out/refcount/array_of_noncopy_struct.rs
@@ -36,7 +36,7 @@ fn main_0() -> i32 {
     assert!(((*(*arr.borrow())[(1) as usize].data.borrow()).len() == 1_usize));
     assert!(
         ((((*arr.borrow())[(1) as usize].data.as_pointer() as Ptr<i32>)
-            .offset(0_usize as isize)
+            .offset(0_usize)
             .read())
             == 42)
     );

--- a/tests/unit/out/refcount/borrow_mut_opt.rs
+++ b/tests/unit/out/refcount/borrow_mut_opt.rs
@@ -63,7 +63,7 @@ pub fn convert_with_rhs_1() {
     (*x.borrow_mut()) += __rhs;
     let __rhs = ((*p.borrow()).read());
     (*y.borrow_mut()) += __rhs;
-    (*p.borrow_mut()) = ((arr.as_pointer() as Ptr<i32>).offset(0 as isize));
+    (*p.borrow_mut()) = ((arr.as_pointer() as Ptr<i32>).offset(0));
     let __rhs = ((*p.borrow()).read());
     (*arr.borrow_mut())[(0) as usize] = __rhs;
     let __rhs = (*x.borrow());

--- a/tests/unit/out/refcount/bounded_struct_ptr.rs
+++ b/tests/unit/out/refcount/bounded_struct_ptr.rs
@@ -53,9 +53,7 @@ fn main_0() -> i32 {
         ((*arr.borrow())[(1) as usize].x1.as_pointer()),
     ));
     let a: Value<i32> = Rc::new(RefCell::new(((*p1.borrow()).read())));
-    let p2: Value<Ptr<Foo>> = Rc::new(RefCell::new(
-        ((arr.as_pointer() as Ptr<Foo>).offset(0 as isize)),
-    ));
+    let p2: Value<Ptr<Foo>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<Foo>).offset(0))));
     return {
         let _lhs = (*a.borrow());
         _lhs + (*(*(*p2.borrow()).upgrade().deref()).x2.borrow())

--- a/tests/unit/out/refcount/char_printing.rs
+++ b/tests/unit/out/refcount/char_printing.rs
@@ -21,12 +21,8 @@ fn main_0() -> i32 {
     write!(libcc2rs::cout(), "{:} a", (*i.borrow()),);
     libcc2rs::cout().write_all(
         &([
-            (&[((vec_.as_pointer() as Ptr<u8>)
-                .offset(0_usize as isize)
-                .read())] as &[u8]),
-            (&[((vec_.as_pointer() as Ptr<u8>)
-                .offset(1_usize as isize)
-                .read())] as &[u8]),
+            (&[((vec_.as_pointer() as Ptr<u8>).offset(0_usize).read())] as &[u8]),
+            (&[((vec_.as_pointer() as Ptr<u8>).offset(1_usize).read())] as &[u8]),
             (&[('o' as u8)] as &[u8]),
             (&(*str.borrow())[..(*str.borrow()).len() - 1] as &[u8]),
             (&[b'\n'] as &[u8]),
@@ -46,13 +42,9 @@ fn main_0() -> i32 {
     write!(libcc2rs::cout(), "Hello, World!\n",);
     libcc2rs::cout().write_all(
         &([
-            (&[((vec_.as_pointer() as Ptr<u8>)
-                .offset(0_usize as isize)
-                .read())] as &[u8]),
+            (&[((vec_.as_pointer() as Ptr<u8>).offset(0_usize).read())] as &[u8]),
             (&[('\n' as u8)] as &[u8]),
-            (&[((vec_.as_pointer() as Ptr<u8>)
-                .offset(1_usize as isize)
-                .read())] as &[u8]),
+            (&[((vec_.as_pointer() as Ptr<u8>).offset(1_usize).read())] as &[u8]),
             (&[('\n' as u8)] as &[u8]),
         ]
         .concat()),

--- a/tests/unit/out/refcount/char_printing_cerr.rs
+++ b/tests/unit/out/refcount/char_printing_cerr.rs
@@ -21,12 +21,8 @@ fn main_0() -> i32 {
     write!(libcc2rs::cerr(), "{:} a", (*i.borrow()),);
     libcc2rs::cerr().write_all(
         &([
-            (&[((vec_.as_pointer() as Ptr<u8>)
-                .offset(0_usize as isize)
-                .read())] as &[u8]),
-            (&[((vec_.as_pointer() as Ptr<u8>)
-                .offset(1_usize as isize)
-                .read())] as &[u8]),
+            (&[((vec_.as_pointer() as Ptr<u8>).offset(0_usize).read())] as &[u8]),
+            (&[((vec_.as_pointer() as Ptr<u8>).offset(1_usize).read())] as &[u8]),
             (&[('o' as u8)] as &[u8]),
             (&(*str.borrow())[..(*str.borrow()).len() - 1] as &[u8]),
             (&[b'\n'] as &[u8]),
@@ -46,13 +42,9 @@ fn main_0() -> i32 {
     write!(libcc2rs::cerr(), "Hello, World!\n",);
     libcc2rs::cerr().write_all(
         &([
-            (&[((vec_.as_pointer() as Ptr<u8>)
-                .offset(0_usize as isize)
-                .read())] as &[u8]),
+            (&[((vec_.as_pointer() as Ptr<u8>).offset(0_usize).read())] as &[u8]),
             (&[('\n' as u8)] as &[u8]),
-            (&[((vec_.as_pointer() as Ptr<u8>)
-                .offset(1_usize as isize)
-                .read())] as &[u8]),
+            (&[((vec_.as_pointer() as Ptr<u8>).offset(1_usize).read())] as &[u8]),
             (&[('\n' as u8)] as &[u8]),
         ]
         .concat()),

--- a/tests/unit/out/refcount/clone_vs_move.rs
+++ b/tests/unit/out/refcount/clone_vs_move.rs
@@ -162,7 +162,7 @@ fn main_0() -> i32 {
     'loop_: while ((*i.borrow()) < (*N.borrow())) {
         assert!(
             (((v2.as_pointer() as Ptr<i32>)
-                .offset(((*i.borrow()) as usize) as isize)
+                .offset(((*i.borrow()) as usize))
                 .read())
                 == (*i.borrow()))
         );
@@ -171,7 +171,7 @@ fn main_0() -> i32 {
     let i: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while ((*i.borrow()) < (*N.borrow())) {
         (v2.as_pointer() as Ptr<i32>)
-            .offset(((*i.borrow()) as usize) as isize)
+            .offset(((*i.borrow()) as usize))
             .with_mut(|__v| __v.prefix_inc());
         (*i.borrow_mut()).prefix_inc();
     }
@@ -179,13 +179,13 @@ fn main_0() -> i32 {
     'loop_: while ((*i.borrow()) < (*N.borrow())) {
         assert!(
             (((v2.as_pointer() as Ptr<i32>)
-                .offset(((*i.borrow()) as usize) as isize)
+                .offset(((*i.borrow()) as usize))
                 .read())
                 == ((*i.borrow()) + 1))
         );
         assert!(
             (((v1.as_pointer() as Ptr<i32>)
-                .offset(((*i.borrow()) as usize) as isize)
+                .offset(((*i.borrow()) as usize))
                 .read())
                 == (*i.borrow()))
         );
@@ -216,7 +216,7 @@ fn main_0() -> i32 {
     'loop_: while ((*i.borrow()) < (*N.borrow())) {
         assert!(
             ((*((m1.as_pointer() as Ptr<Value<Vec<i32>>>)
-                .offset(((*i.borrow()) as usize) as isize)
+                .offset(((*i.borrow()) as usize))
                 .upgrade()
                 .deref()
                 .as_pointer() as Ptr<Vec<i32>>)
@@ -227,7 +227,7 @@ fn main_0() -> i32 {
         );
         assert!(
             ((*((m2.as_pointer() as Ptr<Value<Vec<i32>>>)
-                .offset(((*i.borrow()) as usize) as isize)
+                .offset(((*i.borrow()) as usize))
                 .upgrade()
                 .deref()
                 .as_pointer() as Ptr<Vec<i32>>)
@@ -240,21 +240,21 @@ fn main_0() -> i32 {
         'loop_: while ((*j.borrow()) < 10) {
             assert!(
                 ((((m1.as_pointer() as Ptr<Value<Vec<i32>>>)
-                    .offset(((*i.borrow()) as usize) as isize)
+                    .offset(((*i.borrow()) as usize))
                     .upgrade()
                     .deref()
                     .as_pointer() as Ptr<i32>)
-                    .offset(((*j.borrow()) as usize) as isize)
+                    .offset(((*j.borrow()) as usize))
                     .read())
                     == 0)
             );
             assert!(
                 ((((m2.as_pointer() as Ptr<Value<Vec<i32>>>)
-                    .offset(((*i.borrow()) as usize) as isize)
+                    .offset(((*i.borrow()) as usize))
                     .upgrade()
                     .deref()
                     .as_pointer() as Ptr<i32>)
-                    .offset(((*j.borrow()) as usize) as isize)
+                    .offset(((*j.borrow()) as usize))
                     .read())
                     == 0)
             );
@@ -267,11 +267,11 @@ fn main_0() -> i32 {
         let j: Value<i32> = Rc::new(RefCell::new(0));
         'loop_: while ((*j.borrow()) < 10) {
             ((m2.as_pointer() as Ptr<Value<Vec<i32>>>)
-                .offset(((*i.borrow()) as usize) as isize)
+                .offset(((*i.borrow()) as usize))
                 .upgrade()
                 .deref()
                 .as_pointer() as Ptr<i32>)
-                .offset(((*j.borrow()) as usize) as isize)
+                .offset(((*j.borrow()) as usize))
                 .with_mut(|__v| __v.postfix_inc());
             (*j.borrow_mut()).prefix_inc();
         }
@@ -281,7 +281,7 @@ fn main_0() -> i32 {
     'loop_: while ((*i.borrow()) < (*N.borrow())) {
         assert!(
             ((*((m1.as_pointer() as Ptr<Value<Vec<i32>>>)
-                .offset(((*i.borrow()) as usize) as isize)
+                .offset(((*i.borrow()) as usize))
                 .upgrade()
                 .deref()
                 .as_pointer() as Ptr<Vec<i32>>)
@@ -292,7 +292,7 @@ fn main_0() -> i32 {
         );
         assert!(
             ((*((m2.as_pointer() as Ptr<Value<Vec<i32>>>)
-                .offset(((*i.borrow()) as usize) as isize)
+                .offset(((*i.borrow()) as usize))
                 .upgrade()
                 .deref()
                 .as_pointer() as Ptr<Vec<i32>>)
@@ -305,21 +305,21 @@ fn main_0() -> i32 {
         'loop_: while ((*j.borrow()) < 10) {
             assert!(
                 ((((m1.as_pointer() as Ptr<Value<Vec<i32>>>)
-                    .offset(((*i.borrow()) as usize) as isize)
+                    .offset(((*i.borrow()) as usize))
                     .upgrade()
                     .deref()
                     .as_pointer() as Ptr<i32>)
-                    .offset(((*j.borrow()) as usize) as isize)
+                    .offset(((*j.borrow()) as usize))
                     .read())
                     == 0)
             );
             assert!(
                 ((((m2.as_pointer() as Ptr<Value<Vec<i32>>>)
-                    .offset(((*i.borrow()) as usize) as isize)
+                    .offset(((*i.borrow()) as usize))
                     .upgrade()
                     .deref()
                     .as_pointer() as Ptr<i32>)
-                    .offset(((*j.borrow()) as usize) as isize)
+                    .offset(((*j.borrow()) as usize))
                     .read())
                     == 1)
             );
@@ -436,37 +436,31 @@ fn main_0() -> i32 {
     ));
     let s2: Value<Vec<u8>> = Rc::new(RefCell::new((*s1.borrow()).clone()));
     (s2.as_pointer() as Ptr<u8>)
-        .offset(0_usize as isize)
+        .offset(0_usize)
         .write(('b' as u8));
     (s2.as_pointer() as Ptr<u8>)
-        .offset(1_usize as isize)
+        .offset(1_usize)
         .write(('b' as u8));
     (s2.as_pointer() as Ptr<u8>)
-        .offset(2_usize as isize)
+        .offset(2_usize)
         .write(('b' as u8));
     assert!(
-        ((((s2.as_pointer() as Ptr<u8>).offset(0_usize as isize).read()) as i32)
-            == (('b' as u8) as i32))
+        ((((s2.as_pointer() as Ptr<u8>).offset(0_usize).read()) as i32) == (('b' as u8) as i32))
     );
     assert!(
-        ((((s2.as_pointer() as Ptr<u8>).offset(1_usize as isize).read()) as i32)
-            == (('b' as u8) as i32))
+        ((((s2.as_pointer() as Ptr<u8>).offset(1_usize).read()) as i32) == (('b' as u8) as i32))
     );
     assert!(
-        ((((s2.as_pointer() as Ptr<u8>).offset(2_usize as isize).read()) as i32)
-            == (('b' as u8) as i32))
+        ((((s2.as_pointer() as Ptr<u8>).offset(2_usize).read()) as i32) == (('b' as u8) as i32))
     );
     assert!(
-        ((((s1.as_pointer() as Ptr<u8>).offset(0_usize as isize).read()) as i32)
-            == (('a' as u8) as i32))
+        ((((s1.as_pointer() as Ptr<u8>).offset(0_usize).read()) as i32) == (('a' as u8) as i32))
     );
     assert!(
-        ((((s1.as_pointer() as Ptr<u8>).offset(1_usize as isize).read()) as i32)
-            == (('a' as u8) as i32))
+        ((((s1.as_pointer() as Ptr<u8>).offset(1_usize).read()) as i32) == (('a' as u8) as i32))
     );
     assert!(
-        ((((s1.as_pointer() as Ptr<u8>).offset(2_usize as isize).read()) as i32)
-            == (('a' as u8) as i32))
+        ((((s1.as_pointer() as Ptr<u8>).offset(2_usize).read()) as i32) == (('a' as u8) as i32))
     );
     let b1: Value<Bar> = Rc::new(RefCell::new(Bar {
         w: Rc::new(RefCell::new(1)),
@@ -484,12 +478,12 @@ fn main_0() -> i32 {
     'loop_: while ((*i.borrow()) < (*N.borrow())) {
         assert!(
             (((v4.as_pointer() as Ptr<i32>)
-                .offset(((*i.borrow()) as usize) as isize)
+                .offset(((*i.borrow()) as usize))
                 .read())
                 == ((*i.borrow()) + 1))
         );
         (v4.as_pointer() as Ptr<i32>)
-            .offset(((*i.borrow()) as usize) as isize)
+            .offset(((*i.borrow()) as usize))
             .with_mut(|__v| __v.prefix_inc());
         (*i.borrow_mut()).prefix_inc();
     }
@@ -497,13 +491,13 @@ fn main_0() -> i32 {
     'loop_: while ((*i.borrow()) < (*N.borrow())) {
         assert!(
             (((v4.as_pointer() as Ptr<i32>)
-                .offset(((*i.borrow()) as usize) as isize)
+                .offset(((*i.borrow()) as usize))
                 .read())
                 == ((*i.borrow()) + 2))
         );
         assert!(
             (((v2.as_pointer() as Ptr<i32>)
-                .offset(((*i.borrow()) as usize) as isize)
+                .offset(((*i.borrow()) as usize))
                 .read())
                 == ((*i.borrow()) + 1))
         );

--- a/tests/unit/out/refcount/fn_ptr_stable_sort.rs
+++ b/tests/unit/out/refcount/fn_ptr_stable_sort.rs
@@ -64,7 +64,7 @@ fn main_0() -> i32 {
     );
     assert!(
         ((*(*(v.as_pointer() as Ptr<Item>)
-            .offset(0_usize as isize)
+            .offset(0_usize)
             .upgrade()
             .deref())
         .key
@@ -73,7 +73,7 @@ fn main_0() -> i32 {
     );
     assert!(
         ((*(*(v.as_pointer() as Ptr<Item>)
-            .offset(1_usize as isize)
+            .offset(1_usize)
             .upgrade()
             .deref())
         .key
@@ -82,7 +82,7 @@ fn main_0() -> i32 {
     );
     assert!(
         ((*(*(v.as_pointer() as Ptr<Item>)
-            .offset(2_usize as isize)
+            .offset(2_usize)
             .upgrade()
             .deref())
         .key

--- a/tests/unit/out/refcount/foreach_mut.rs
+++ b/tests/unit/out/refcount/foreach_mut.rs
@@ -32,9 +32,9 @@ fn main_0() -> i32 {
         (*sum.borrow_mut()) += __rhs;
     }
     let v2: Value<Vec<Ptr<i32>>> = Rc::new(RefCell::new(Vec::new()));
-    (*v2.borrow_mut()).push(((v1.as_pointer() as Ptr<i32>).offset(0_usize as isize)));
-    (*v2.borrow_mut()).push(((v1.as_pointer() as Ptr<i32>).offset(1_usize as isize)));
-    (*v2.borrow_mut()).push(((v1.as_pointer() as Ptr<i32>).offset(2_usize as isize)));
+    (*v2.borrow_mut()).push(((v1.as_pointer() as Ptr<i32>).offset(0_usize)));
+    (*v2.borrow_mut()).push(((v1.as_pointer() as Ptr<i32>).offset(1_usize)));
+    (*v2.borrow_mut()).push(((v1.as_pointer() as Ptr<i32>).offset(2_usize)));
     'loop_: for mut p in v2.as_pointer() as Ptr<Ptr<i32>> {
         let p: Value<Ptr<i32>> = Rc::new(RefCell::new(p.read().clone()));
         {

--- a/tests/unit/out/refcount/huffman.rs
+++ b/tests/unit/out/refcount/huffman.rs
@@ -83,7 +83,7 @@ impl MinHeap {
             .as_ref()
             .unwrap()
             .as_pointer()
-            .offset(((*self.next.borrow_mut()).postfix_inc() as usize) as isize))
+            .offset(((*self.next.borrow_mut()).postfix_inc() as usize)))
         .clone();
     }
     pub fn Heapify(&self, idx: i32) {

--- a/tests/unit/out/refcount/implicit_autoref.rs
+++ b/tests/unit/out/refcount/implicit_autoref.rs
@@ -33,11 +33,11 @@ fn main_0() -> i32 {
     let p: Value<Ptr<Vec<i32>>> = Rc::new(RefCell::new((v.as_pointer())));
     let a: Value<i32> = Rc::new(RefCell::new(
         ((((*p.borrow()).to_strong().as_pointer()) as Ptr<i32>)
-            .offset(0_usize as isize)
+            .offset(0_usize)
             .read()),
     ));
     (((*p.borrow()).to_strong().as_pointer()) as Ptr<i32>)
-        .offset(1_usize as isize)
+        .offset(1_usize)
         .write(30);
     let h: Value<Holder> = Rc::new(RefCell::new(<Holder>::default()));
     (*(*h.borrow()).v.borrow_mut()).push(40);
@@ -45,23 +45,23 @@ fn main_0() -> i32 {
     let hp: Value<Ptr<Holder>> = Rc::new(RefCell::new((h.as_pointer())));
     let b: Value<i32> = Rc::new(RefCell::new(
         (((*(*hp.borrow()).upgrade().deref()).v.as_pointer() as Ptr<i32>)
-            .offset(0_usize as isize)
+            .offset(0_usize)
             .read()),
     ));
     ((*(*hp.borrow()).upgrade().deref()).v.as_pointer() as Ptr<i32>)
-        .offset(1_usize as isize)
+        .offset(1_usize)
         .write(60);
     assert!(((*a.borrow()) == 10));
     assert!(
         (((((*p.borrow()).to_strong().as_pointer()) as Ptr<i32>)
-            .offset(1_usize as isize)
+            .offset(1_usize)
             .read())
             == 30)
     );
     assert!(((*b.borrow()) == 40));
     assert!(
         ((((*(*hp.borrow()).upgrade().deref()).v.as_pointer() as Ptr<i32>)
-            .offset(1_usize as isize)
+            .offset(1_usize)
             .read())
             == 60)
     );
@@ -72,7 +72,7 @@ fn main_0() -> i32 {
     });
     assert!(
         (((((*p.borrow()).to_strong().as_pointer()) as Ptr<i32>)
-            .offset(0_usize as isize)
+            .offset(0_usize)
             .read())
             == 42)
     );

--- a/tests/unit/out/refcount/kruskal.rs
+++ b/tests/unit/out/refcount/kruskal.rs
@@ -46,7 +46,7 @@ pub fn partition_0(arr: Ptr<Option<Value<Box<[Edge]>>>>, start: i32, end: i32) -
         .as_ref()
         .unwrap()
         .as_pointer()
-        .offset(((*start.borrow()) as usize) as isize))
+        .offset(((*start.borrow()) as usize)))
     .clone();
     let count: Value<i32> = Rc::new(RefCell::new(0));
     let i: Value<i32> = Rc::new(RefCell::new(((*start.borrow()) + 1)));

--- a/tests/unit/out/refcount/map.rs
+++ b/tests/unit/out/refcount/map.rs
@@ -371,7 +371,7 @@ fn main_0() -> i32 {
             .with_mut(|__v: &mut BTreeMap<i32, Value<bool>>| {
                 __v.entry(
                     ((indexes.as_pointer() as Ptr<i32>)
-                        .offset(((*i.borrow()) as usize) as isize)
+                        .offset(((*i.borrow()) as usize))
                         .read())
                     .clone(),
                 )

--- a/tests/unit/out/refcount/memcpy_struct_struct.rs
+++ b/tests/unit/out/refcount/memcpy_struct_struct.rs
@@ -75,14 +75,13 @@ fn main_0() -> i32 {
     ])));
     let table_size: Value<usize> = Rc::new(RefCell::new(4_usize));
     {
-        (((table.as_pointer() as Ptr<Entry>).offset((*table_size.borrow()) as isize))
-            as Ptr<Entry>)
+        (((table.as_pointer() as Ptr<Entry>).offset((*table_size.borrow()))) as Ptr<Entry>)
             .to_any()
             .memcpy(
-                &(((table.as_pointer() as Ptr<Entry>).offset(0 as isize)) as Ptr<Entry>).to_any(),
+                &(((table.as_pointer() as Ptr<Entry>).offset(0)) as Ptr<Entry>).to_any(),
                 (((*table_size.borrow()) as u64).wrapping_mul((4usize as u64)) as usize) as usize,
             );
-        (((table.as_pointer() as Ptr<Entry>).offset((*table_size.borrow()) as isize)) as Ptr<Entry>)
+        (((table.as_pointer() as Ptr<Entry>).offset((*table_size.borrow()))) as Ptr<Entry>)
             .to_any()
             .clone()
     };

--- a/tests/unit/out/refcount/pointer_arithmetic.rs
+++ b/tests/unit/out/refcount/pointer_arithmetic.rs
@@ -18,7 +18,7 @@ fn main_0() -> i32 {
     };
     if ((*x.borrow()) == 2) {
         let a: Value<Box<[i32]>> = Rc::new(RefCell::new(Box::new([1, 2])));
-        (*p.borrow_mut()) = ((a.as_pointer() as Ptr<i32>).offset(1 as isize));
+        (*p.borrow_mut()) = ((a.as_pointer() as Ptr<i32>).offset(1));
         {
             let _ptr = (*p.borrow()).clone();
             _ptr.write(_ptr.read() + 1)

--- a/tests/unit/out/refcount/pointer_diff.rs
+++ b/tests/unit/out/refcount/pointer_diff.rs
@@ -11,11 +11,7 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let a: Value<Box<[i32]>> = Rc::new(RefCell::new(Box::new([1, 2, 3, 4, 5])));
-    let p0: Value<Ptr<i32>> = Rc::new(RefCell::new(
-        ((a.as_pointer() as Ptr<i32>).offset(0 as isize)),
-    ));
-    let p1: Value<Ptr<i32>> = Rc::new(RefCell::new(
-        ((a.as_pointer() as Ptr<i32>).offset(4 as isize)),
-    ));
+    let p0: Value<Ptr<i32>> = Rc::new(RefCell::new(((a.as_pointer() as Ptr<i32>).offset(0))));
+    let p1: Value<Ptr<i32>> = Rc::new(RefCell::new(((a.as_pointer() as Ptr<i32>).offset(4))));
     return ((((*p1.borrow()).clone() - (*p0.borrow()).clone()) as i64) as i32);
 }

--- a/tests/unit/out/refcount/pointer_eq.rs
+++ b/tests/unit/out/refcount/pointer_eq.rs
@@ -31,11 +31,11 @@ fn main_0() -> i32 {
     });
     assert!({
         let _lhs = (*p.borrow()).offset((1) as isize);
-        _lhs == ((arr.as_pointer() as Ptr<i32>).offset(1 as isize))
+        _lhs == ((arr.as_pointer() as Ptr<i32>).offset(1))
     });
     assert!({
         let _lhs = (*p.borrow()).offset((2) as isize);
-        _lhs == ((arr.as_pointer() as Ptr<i32>).offset(2 as isize))
+        _lhs == ((arr.as_pointer() as Ptr<i32>).offset(2))
     });
     let val: Value<i32> = Rc::new(RefCell::new(42));
     let orig: Value<Ptr<i32>> = Rc::new(RefCell::new((val.as_pointer())));
@@ -61,7 +61,7 @@ fn main_0() -> i32 {
     });
     assert!({
         let _lhs = (*arr_back.borrow()).offset((1) as isize);
-        _lhs == ((arr.as_pointer() as Ptr<i32>).offset(1 as isize))
+        _lhs == ((arr.as_pointer() as Ptr<i32>).offset(1))
     });
     return 0;
 }

--- a/tests/unit/out/refcount/pointer_offset.rs
+++ b/tests/unit/out/refcount/pointer_offset.rs
@@ -12,50 +12,38 @@ pub fn main() {
 fn main_0() -> i32 {
     let out: Value<i32> = Rc::new(RefCell::new(0));
     let arr: Value<Box<[i32]>> = Rc::new(RefCell::new(Box::new([1, 2, 3, 4, 0])));
-    let ptr: Value<Ptr<i32>> = Rc::new(RefCell::new(
-        ((arr.as_pointer() as Ptr<i32>).offset(0 as isize)),
-    ));
+    let ptr: Value<Ptr<i32>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<i32>).offset(0))));
     'loop_: while (((*ptr.borrow()).read()) != 0) {
         let __rhs = ((*ptr.borrow()).read());
         (*out.borrow_mut()) += __rhs;
         (*ptr.borrow_mut()).prefix_inc();
     }
-    let ptr: Value<Ptr<i32>> = Rc::new(RefCell::new(
-        ((arr.as_pointer() as Ptr<i32>).offset(1 as isize)),
-    ));
+    let ptr: Value<Ptr<i32>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<i32>).offset(1))));
     'loop_: while (((*ptr.borrow()).read()) != 4) {
         let __rhs = ((*ptr.borrow()).read());
         (*out.borrow_mut()) += __rhs;
         (*ptr.borrow_mut()).postfix_inc();
     }
-    let ptr: Value<Ptr<i32>> = Rc::new(RefCell::new(
-        ((arr.as_pointer() as Ptr<i32>).offset(4 as isize)),
-    ));
+    let ptr: Value<Ptr<i32>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<i32>).offset(4))));
     'loop_: while (((*ptr.borrow()).read()) != 1) {
         let __rhs = ((*ptr.borrow()).read());
         (*out.borrow_mut()) += __rhs;
         (*ptr.borrow_mut()).postfix_dec();
     }
-    let ptr: Value<Ptr<i32>> = Rc::new(RefCell::new(
-        ((arr.as_pointer() as Ptr<i32>).offset(3 as isize)),
-    ));
+    let ptr: Value<Ptr<i32>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<i32>).offset(3))));
     'loop_: while (((*ptr.borrow()).read()) != 2) {
         let __rhs = ((*ptr.borrow()).read());
         (*out.borrow_mut()) += __rhs;
         (*ptr.borrow_mut()).prefix_dec();
     }
-    let ptr: Value<Ptr<i32>> = Rc::new(RefCell::new(
-        ((arr.as_pointer() as Ptr<i32>).offset(0 as isize)),
-    ));
+    let ptr: Value<Ptr<i32>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<i32>).offset(0))));
     'loop_: while (((*ptr.borrow()).read()) != 0) {
         let __rhs = ((*ptr.borrow()).read());
         (*out.borrow_mut()) += __rhs;
         let __rhs = (*ptr.borrow()).offset((1) as isize);
         (*ptr.borrow_mut()) = __rhs;
     }
-    let ptr: Value<Ptr<i32>> = Rc::new(RefCell::new(
-        ((arr.as_pointer() as Ptr<i32>).offset(0 as isize)),
-    ));
+    let ptr: Value<Ptr<i32>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<i32>).offset(0))));
     let i: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while ((*i.borrow()) < 5) {
         let __rhs = ((*ptr.borrow()).offset((*i.borrow()) as isize).read());

--- a/tests/unit/out/refcount/pointer_usize_arith.rs
+++ b/tests/unit/out/refcount/pointer_usize_arith.rs
@@ -91,7 +91,7 @@ fn main_0() -> i32 {
     ));
     assert!((((*q5.borrow()).read()) == 13));
     let q6: Value<Ptr<i32>> = Rc::new(RefCell::new(
-        ((arr.as_pointer() as Ptr<i32>).offset((*n.borrow()) as isize)),
+        ((arr.as_pointer() as Ptr<i32>).offset((*n.borrow()))),
     ));
     assert!({
         let _lhs = (*q6.borrow()).clone();
@@ -104,10 +104,10 @@ fn main_0() -> i32 {
     ])));
     let row1: Value<Ptr<i32>> = Rc::new(RefCell::new(
         ((((matrix.as_pointer() as Ptr<Value<Box<[i32]>>>)
-            .offset(1 as isize)
+            .offset(1)
             .read()
             .as_pointer()) as Ptr<i32>)
-            .offset(0 as isize)),
+            .offset(0)),
     ));
     assert!((((*row1.borrow()).offset((2) as isize).read()) == 6));
     let back: Value<Ptr<i32>> = Rc::new(RefCell::new((*end.borrow()).offset(-((1) as isize))));

--- a/tests/unit/out/refcount/push_emplace_back.rs
+++ b/tests/unit/out/refcount/push_emplace_back.rs
@@ -172,7 +172,7 @@ fn main_0() -> i32 {
     ({ push_param_0((vecs.as_pointer())) });
     assert!(((*vecs.borrow()).len() == 1_usize));
     assert!((*((vecs.as_pointer() as Ptr<Value<Vec<u8>>>)
-        .offset(0_usize as isize)
+        .offset(0_usize)
         .upgrade()
         .deref()
         .as_pointer() as Ptr<Vec<u8>>)
@@ -184,7 +184,7 @@ fn main_0() -> i32 {
     assert!(((*(*jpg.borrow()).com_data.borrow()).len() == 1_usize));
     assert!(
         ((*(((*jpg.borrow()).com_data.as_pointer() as Ptr<Value<Vec<u8>>>)
-            .offset(0_usize as isize)
+            .offset(0_usize)
             .upgrade()
             .deref()
             .as_pointer() as Ptr<Vec<u8>>)
@@ -195,31 +195,31 @@ fn main_0() -> i32 {
     );
     assert!(
         ((((((*jpg.borrow()).com_data.as_pointer() as Ptr<Value<Vec<u8>>>)
-            .offset(0_usize as isize)
+            .offset(0_usize)
             .upgrade()
             .deref()
             .as_pointer() as Ptr<u8>)
-            .offset(0_usize as isize)
+            .offset(0_usize)
             .read()) as i32)
             == 1)
     );
     assert!(
         ((((((*jpg.borrow()).com_data.as_pointer() as Ptr<Value<Vec<u8>>>)
-            .offset(0_usize as isize)
+            .offset(0_usize)
             .upgrade()
             .deref()
             .as_pointer() as Ptr<u8>)
-            .offset(1_usize as isize)
+            .offset(1_usize)
             .read()) as i32)
             == 2)
     );
     assert!(
         ((((((*jpg.borrow()).com_data.as_pointer() as Ptr<Value<Vec<u8>>>)
-            .offset(0_usize as isize)
+            .offset(0_usize)
             .upgrade()
             .deref()
             .as_pointer() as Ptr<u8>)
-            .offset(2_usize as isize)
+            .offset(2_usize)
             .read()) as i32)
             == 3)
     );
@@ -234,7 +234,7 @@ fn main_0() -> i32 {
     assert!(((*chunks.borrow()).len() == 1_usize));
     assert!(
         ((*(*(chunks.as_pointer() as Ptr<Chunk>)
-            .offset(0_usize as isize)
+            .offset(0_usize)
             .upgrade()
             .deref())
         .data
@@ -245,7 +245,7 @@ fn main_0() -> i32 {
     assert!(((*(*jpg.borrow()).app_data.borrow()).len() == 1_usize));
     assert!(
         ((*(((*jpg.borrow()).app_data.as_pointer() as Ptr<Value<Vec<u8>>>)
-            .offset(0_usize as isize)
+            .offset(0_usize)
             .upgrade()
             .deref()
             .as_pointer() as Ptr<Vec<u8>>)
@@ -256,21 +256,21 @@ fn main_0() -> i32 {
     );
     assert!(
         ((((((*jpg.borrow()).app_data.as_pointer() as Ptr<Value<Vec<u8>>>)
-            .offset(0_usize as isize)
+            .offset(0_usize)
             .upgrade()
             .deref()
             .as_pointer() as Ptr<u8>)
-            .offset(0_usize as isize)
+            .offset(0_usize)
             .read()) as i32)
             == 1)
     );
     assert!(
         ((((((*jpg.borrow()).app_data.as_pointer() as Ptr<Value<Vec<u8>>>)
-            .offset(0_usize as isize)
+            .offset(0_usize)
             .upgrade()
             .deref()
             .as_pointer() as Ptr<u8>)
-            .offset(2_usize as isize)
+            .offset(2_usize)
             .read()) as i32)
             == 3)
     );
@@ -281,7 +281,7 @@ fn main_0() -> i32 {
     assert!(((*chunks.borrow()).len() == 2_usize));
     assert!(
         ((*(*(chunks.as_pointer() as Ptr<Chunk>)
-            .offset(1_usize as isize)
+            .offset(1_usize)
             .upgrade()
             .deref())
         .data
@@ -292,7 +292,7 @@ fn main_0() -> i32 {
     assert!(((*chunks.borrow()).len() == 3_usize));
     assert!(
         ((*(*(chunks.as_pointer() as Ptr<Chunk>)
-            .offset(2_usize as isize)
+            .offset(2_usize)
             .upgrade()
             .deref())
         .data

--- a/tests/unit/out/refcount/reinterpret_cast_vec_write.rs
+++ b/tests/unit/out/refcount/reinterpret_cast_vec_write.rs
@@ -23,11 +23,6 @@ fn main_0() -> i32 {
     assert!(((((*bytes.borrow()).offset((4) as isize).read()) as i32) == 5));
     assert!(((((*bytes.borrow()).offset((7) as isize).read()) as i32) == 8));
     (*bytes.borrow()).offset((4) as isize).write(255_u8);
-    assert!(
-        (((vec_.as_pointer() as Ptr<u32>)
-            .offset(1_usize as isize)
-            .read())
-            == 134678271_u32)
-    );
+    assert!((((vec_.as_pointer() as Ptr<u32>).offset(1_usize).read()) == 134678271_u32));
     return 0;
 }

--- a/tests/unit/out/refcount/simple_index.rs
+++ b/tests/unit/out/refcount/simple_index.rs
@@ -12,7 +12,7 @@ pub fn main() {
 fn main_0() -> i32 {
     let v: Value<Vec<bool>> = Rc::new(RefCell::new(vec![true]));
     return (((*(v.as_pointer() as Ptr<bool>)
-        .offset(0_usize as isize)
+        .offset(0_usize)
         .upgrade()
         .deref()) as bool) as i32);
 }

--- a/tests/unit/out/refcount/sort.rs
+++ b/tests/unit/out/refcount/sort.rs
@@ -26,10 +26,10 @@ fn main_0() -> i32 {
     'loop_: while (((*i.borrow()) as usize) < ((*v.borrow()).len()).wrapping_sub(1_usize)) {
         assert!(
             (((v.as_pointer() as Ptr<i32>)
-                .offset(((*i.borrow()) as usize) as isize)
+                .offset(((*i.borrow()) as usize))
                 .read())
                 < ((v.as_pointer() as Ptr<i32>)
-                    .offset((((*i.borrow()).wrapping_add(1_u32)) as usize) as isize)
+                    .offset((((*i.borrow()).wrapping_add(1_u32)) as usize))
                     .read()))
         );
         (*i.borrow_mut()).prefix_inc();

--- a/tests/unit/out/refcount/split_binop_aliased_borrows.rs
+++ b/tests/unit/out/refcount/split_binop_aliased_borrows.rs
@@ -12,8 +12,8 @@ pub fn main() {
 fn main_0() -> i32 {
     let v: Value<Vec<i32>> = Rc::new(RefCell::new(vec![1, 2]));
     let p: Value<Ptr<i32>> = Rc::new(RefCell::new((v.as_pointer() as Ptr<i32>)));
-    let r: Ptr<i32> = (v.as_pointer() as Ptr<i32>).offset(1_usize as isize);
+    let r: Ptr<i32> = (v.as_pointer() as Ptr<i32>).offset(1_usize);
     let __rhs = (r.read());
     (*p.borrow()).write(__rhs);
-    return ((v.as_pointer() as Ptr<i32>).offset(0_usize as isize).read());
+    return ((v.as_pointer() as Ptr<i32>).offset(0_usize).read());
 }

--- a/tests/unit/out/refcount/string.rs
+++ b/tests/unit/out/refcount/string.rs
@@ -19,24 +19,19 @@ fn main_0() -> i32 {
     assert!((((*s1.borrow()).len() - 1) == 5_usize));
     assert!((((*s1.borrow()).len() - 1) == ((*s1.borrow()).len() - 1)));
     assert!(
-        ((((s1.as_pointer() as Ptr<u8>).offset(0_usize as isize).read()) as i32)
-            == (('h' as u8) as i32))
+        ((((s1.as_pointer() as Ptr<u8>).offset(0_usize).read()) as i32) == (('h' as u8) as i32))
     );
     assert!(
-        ((((s1.as_pointer() as Ptr<u8>).offset(1_usize as isize).read()) as i32)
-            == (('e' as u8) as i32))
+        ((((s1.as_pointer() as Ptr<u8>).offset(1_usize).read()) as i32) == (('e' as u8) as i32))
     );
     assert!(
-        ((((s1.as_pointer() as Ptr<u8>).offset(2_usize as isize).read()) as i32)
-            == (('l' as u8) as i32))
+        ((((s1.as_pointer() as Ptr<u8>).offset(2_usize).read()) as i32) == (('l' as u8) as i32))
     );
     assert!(
-        ((((s1.as_pointer() as Ptr<u8>).offset(3_usize as isize).read()) as i32)
-            == (('l' as u8) as i32))
+        ((((s1.as_pointer() as Ptr<u8>).offset(3_usize).read()) as i32) == (('l' as u8) as i32))
     );
     assert!(
-        ((((s1.as_pointer() as Ptr<u8>).offset(4_usize as isize).read()) as i32)
-            == (('o' as u8) as i32))
+        ((((s1.as_pointer() as Ptr<u8>).offset(4_usize).read()) as i32) == (('o' as u8) as i32))
     );
     assert!((*s1.borrow())
         .iter()
@@ -63,7 +58,7 @@ fn main_0() -> i32 {
             ((((*p2.borrow()).offset((*i.borrow()) as isize).read()) as i32)
                 == (('a' as u8) as i32))
                 && ((((s2.as_pointer() as Ptr<u8>)
-                    .offset(((*i.borrow()) as usize) as isize)
+                    .offset(((*i.borrow()) as usize))
                     .read()) as i32)
                     == (('a' as u8) as i32))
         );
@@ -72,18 +67,16 @@ fn main_0() -> i32 {
     assert!((((*s2.borrow()).len() - 1) == 10_usize));
     assert!((((*s2.borrow()).len() - 1) == ((*s2.borrow()).len() - 1)));
     (s2.as_pointer() as Ptr<u8>)
-        .offset(0_usize as isize)
+        .offset(0_usize)
         .write(('b' as u8));
     (s2.as_pointer() as Ptr<u8>)
-        .offset(1_usize as isize)
+        .offset(1_usize)
         .write(('c' as u8));
     assert!(
-        ((((s2.as_pointer() as Ptr<u8>).offset(0_usize as isize).read()) as i32)
-            == (('b' as u8) as i32))
+        ((((s2.as_pointer() as Ptr<u8>).offset(0_usize).read()) as i32) == (('b' as u8) as i32))
     );
     assert!(
-        ((((s2.as_pointer() as Ptr<u8>).offset(1_usize as isize).read()) as i32)
-            == (('c' as u8) as i32))
+        ((((s2.as_pointer() as Ptr<u8>).offset(1_usize).read()) as i32) == (('c' as u8) as i32))
     );
     let i: Value<u32> = Rc::new(RefCell::new(2_u32));
     'loop_: while (((*i.borrow()) as usize) < ((*s2.borrow()).len() - 1)) {
@@ -91,7 +84,7 @@ fn main_0() -> i32 {
             ((((*p2.borrow()).offset((*i.borrow()) as isize).read()) as i32)
                 == (('a' as u8) as i32))
                 && ((((s2.as_pointer() as Ptr<u8>)
-                    .offset(((*i.borrow()) as usize) as isize)
+                    .offset(((*i.borrow()) as usize))
                     .read()) as i32)
                     == (('a' as u8) as i32))
         );
@@ -115,7 +108,7 @@ fn main_0() -> i32 {
         assert!({
             let _lhs = (((*p3.borrow()).offset((*i.borrow()) as isize).read()) as i32);
             _lhs == (((s3.as_pointer() as Ptr<u8>)
-                .offset(((*i.borrow()) as usize) as isize)
+                .offset(((*i.borrow()) as usize))
                 .read()) as i32)
         });
         (*i.borrow_mut()).prefix_inc();
@@ -147,7 +140,7 @@ fn main_0() -> i32 {
         assert!({
             let _lhs = (((*p4.borrow()).offset((*i.borrow()) as isize).read()) as i32);
             _lhs == (((s4.as_pointer() as Ptr<u8>)
-                .offset(((*i.borrow()) as usize) as isize)
+                .offset(((*i.borrow()) as usize))
                 .read()) as i32)
         });
         (*i.borrow_mut()).prefix_inc();
@@ -167,7 +160,7 @@ fn main_0() -> i32 {
         assert!({
             let _lhs = (((*p5.borrow()).offset((*i.borrow()) as isize).read()) as i32);
             _lhs == (((s5.as_pointer() as Ptr<u8>)
-                .offset(((*i.borrow()) as usize) as isize)
+                .offset(((*i.borrow()) as usize))
                 .read()) as i32)
         });
         (*i.borrow_mut()).prefix_inc();
@@ -190,21 +183,15 @@ fn main_0() -> i32 {
     ));
     assert!((((*string.borrow()).len() - 1) == 3_usize));
     assert!(
-        ((((string.as_pointer() as Ptr<u8>)
-            .offset(0_usize as isize)
-            .read()) as i32)
+        ((((string.as_pointer() as Ptr<u8>).offset(0_usize).read()) as i32)
             == (('b' as u8) as i32))
     );
     assert!(
-        ((((string.as_pointer() as Ptr<u8>)
-            .offset(1_usize as isize)
-            .read()) as i32)
+        ((((string.as_pointer() as Ptr<u8>).offset(1_usize).read()) as i32)
             == (('a' as u8) as i32))
     );
     assert!(
-        ((((string.as_pointer() as Ptr<u8>)
-            .offset(2_usize as isize)
-            .read()) as i32)
+        ((((string.as_pointer() as Ptr<u8>).offset(2_usize).read()) as i32)
             == (('r' as u8) as i32))
     );
     assert!((*string.borrow())
@@ -219,21 +206,15 @@ fn main_0() -> i32 {
     };
     assert!((((*string.borrow()).len() - 1) == 3_usize));
     assert!(
-        ((((string.as_pointer() as Ptr<u8>)
-            .offset(0_usize as isize)
-            .read()) as i32)
+        ((((string.as_pointer() as Ptr<u8>).offset(0_usize).read()) as i32)
             == (('b' as u8) as i32))
     );
     assert!(
-        ((((string.as_pointer() as Ptr<u8>)
-            .offset(1_usize as isize)
-            .read()) as i32)
+        ((((string.as_pointer() as Ptr<u8>).offset(1_usize).read()) as i32)
             == (('a' as u8) as i32))
     );
     assert!(
-        ((((string.as_pointer() as Ptr<u8>)
-            .offset(2_usize as isize)
-            .read()) as i32)
+        ((((string.as_pointer() as Ptr<u8>).offset(2_usize).read()) as i32)
             == (('r' as u8) as i32))
     );
     assert!((*string.borrow())
@@ -248,59 +229,35 @@ fn main_0() -> i32 {
     };
     assert!((((*string.borrow()).len() - 1) == 5_usize));
     assert!(
-        ((((string.as_pointer() as Ptr<u8>)
-            .offset(0_usize as isize)
-            .read()) as i32)
+        ((((string.as_pointer() as Ptr<u8>).offset(0_usize).read()) as i32)
             == (('b' as u8) as i32))
     );
     assert!(
-        ((((string.as_pointer() as Ptr<u8>)
-            .offset(1_usize as isize)
-            .read()) as i32)
+        ((((string.as_pointer() as Ptr<u8>).offset(1_usize).read()) as i32)
             == (('a' as u8) as i32))
     );
     assert!(
-        ((((string.as_pointer() as Ptr<u8>)
-            .offset(2_usize as isize)
-            .read()) as i32)
+        ((((string.as_pointer() as Ptr<u8>).offset(2_usize).read()) as i32)
             == (('r' as u8) as i32))
     );
-    assert!(
-        ((((string.as_pointer() as Ptr<u8>)
-            .offset(3_usize as isize)
-            .read()) as i32)
-            == 0)
-    );
-    assert!(
-        ((((string.as_pointer() as Ptr<u8>)
-            .offset(4_usize as isize)
-            .read()) as i32)
-            == 0)
-    );
+    assert!(((((string.as_pointer() as Ptr<u8>).offset(3_usize).read()) as i32) == 0));
+    assert!(((((string.as_pointer() as Ptr<u8>).offset(4_usize).read()) as i32) == 0));
     (string.as_pointer() as Ptr<u8>)
-        .offset(3_usize as isize)
+        .offset(3_usize)
         .write(('a' as u8));
     (string.as_pointer() as Ptr<u8>)
-        .offset(4_usize as isize)
+        .offset(4_usize)
         .write(('b' as u8));
     assert!(
-        ((((string.as_pointer() as Ptr<u8>)
-            .offset(3_usize as isize)
-            .read()) as i32)
+        ((((string.as_pointer() as Ptr<u8>).offset(3_usize).read()) as i32)
             == (('a' as u8) as i32))
     );
     assert!(
-        ((((string.as_pointer() as Ptr<u8>)
-            .offset(4_usize as isize)
-            .read()) as i32)
+        ((((string.as_pointer() as Ptr<u8>).offset(4_usize).read()) as i32)
             == (('b' as u8) as i32))
     );
-    (string.as_pointer() as Ptr<u8>)
-        .offset(3_usize as isize)
-        .write(0_u8);
-    (string.as_pointer() as Ptr<u8>)
-        .offset(4_usize as isize)
-        .write(0_u8);
+    (string.as_pointer() as Ptr<u8>).offset(3_usize).write(0_u8);
+    (string.as_pointer() as Ptr<u8>).offset(4_usize).write(0_u8);
     {
         (*string.borrow_mut()).pop();
         (*string.borrow_mut()).resize((4_usize) as usize, 0);
@@ -308,29 +265,18 @@ fn main_0() -> i32 {
     };
     assert!((((*string.borrow()).len() - 1) == 4_usize));
     assert!(
-        ((((string.as_pointer() as Ptr<u8>)
-            .offset(0_usize as isize)
-            .read()) as i32)
+        ((((string.as_pointer() as Ptr<u8>).offset(0_usize).read()) as i32)
             == (('b' as u8) as i32))
     );
     assert!(
-        ((((string.as_pointer() as Ptr<u8>)
-            .offset(1_usize as isize)
-            .read()) as i32)
+        ((((string.as_pointer() as Ptr<u8>).offset(1_usize).read()) as i32)
             == (('a' as u8) as i32))
     );
     assert!(
-        ((((string.as_pointer() as Ptr<u8>)
-            .offset(2_usize as isize)
-            .read()) as i32)
+        ((((string.as_pointer() as Ptr<u8>).offset(2_usize).read()) as i32)
             == (('r' as u8) as i32))
     );
-    assert!(
-        ((((string.as_pointer() as Ptr<u8>)
-            .offset(3_usize as isize)
-            .read()) as i32)
-            == 0)
-    );
+    assert!(((((string.as_pointer() as Ptr<u8>).offset(3_usize).read()) as i32) == 0));
     let result: Value<Vec<u8>> = Rc::new(RefCell::new({
         let mut r = (*string.borrow()).clone();
         r.pop();
@@ -340,51 +286,32 @@ fn main_0() -> i32 {
     }));
     assert!((((*result.borrow()).len() - 1) == 8_usize));
     assert!(
-        ((((result.as_pointer() as Ptr<u8>)
-            .offset(0_usize as isize)
-            .read()) as i32)
+        ((((result.as_pointer() as Ptr<u8>).offset(0_usize).read()) as i32)
             == (('b' as u8) as i32))
     );
     assert!(
-        ((((result.as_pointer() as Ptr<u8>)
-            .offset(1_usize as isize)
-            .read()) as i32)
+        ((((result.as_pointer() as Ptr<u8>).offset(1_usize).read()) as i32)
             == (('a' as u8) as i32))
     );
     assert!(
-        ((((result.as_pointer() as Ptr<u8>)
-            .offset(2_usize as isize)
-            .read()) as i32)
+        ((((result.as_pointer() as Ptr<u8>).offset(2_usize).read()) as i32)
             == (('r' as u8) as i32))
     );
+    assert!(((((result.as_pointer() as Ptr<u8>).offset(3_usize).read()) as i32) == 0));
     assert!(
-        ((((result.as_pointer() as Ptr<u8>)
-            .offset(3_usize as isize)
-            .read()) as i32)
-            == 0)
-    );
-    assert!(
-        ((((result.as_pointer() as Ptr<u8>)
-            .offset(4_usize as isize)
-            .read()) as i32)
+        ((((result.as_pointer() as Ptr<u8>).offset(4_usize).read()) as i32)
             == ((' ' as u8) as i32))
     );
     assert!(
-        ((((result.as_pointer() as Ptr<u8>)
-            .offset(5_usize as isize)
-            .read()) as i32)
+        ((((result.as_pointer() as Ptr<u8>).offset(5_usize).read()) as i32)
             == (('f' as u8) as i32))
     );
     assert!(
-        ((((result.as_pointer() as Ptr<u8>)
-            .offset(6_usize as isize)
-            .read()) as i32)
+        ((((result.as_pointer() as Ptr<u8>).offset(6_usize).read()) as i32)
             == (('o' as u8) as i32))
     );
     assert!(
-        ((((result.as_pointer() as Ptr<u8>)
-            .offset(7_usize as isize)
-            .read()) as i32)
+        ((((result.as_pointer() as Ptr<u8>).offset(7_usize).read()) as i32)
             == (('o' as u8) as i32))
     );
     let substr_0: Value<Vec<u8>> = Rc::new(RefCell::new({
@@ -399,21 +326,15 @@ fn main_0() -> i32 {
     }));
     assert!((((*substr_0.borrow()).len() - 1) == 3_usize));
     assert!(
-        ((((substr_0.as_pointer() as Ptr<u8>)
-            .offset(0_usize as isize)
-            .read()) as i32)
+        ((((substr_0.as_pointer() as Ptr<u8>).offset(0_usize).read()) as i32)
             == (('f' as u8) as i32))
     );
     assert!(
-        ((((substr_0.as_pointer() as Ptr<u8>)
-            .offset(1_usize as isize)
-            .read()) as i32)
+        ((((substr_0.as_pointer() as Ptr<u8>).offset(1_usize).read()) as i32)
             == (('o' as u8) as i32))
     );
     assert!(
-        ((((substr_0.as_pointer() as Ptr<u8>)
-            .offset(2_usize as isize)
-            .read()) as i32)
+        ((((substr_0.as_pointer() as Ptr<u8>).offset(2_usize).read()) as i32)
             == (('o' as u8) as i32))
     );
     let substr_1: Value<Vec<u8>> = Rc::new(RefCell::new({
@@ -428,33 +349,20 @@ fn main_0() -> i32 {
     }));
     assert!((((*substr_1.borrow()).len() - 1) == 5_usize));
     assert!(
-        ((((substr_1.as_pointer() as Ptr<u8>)
-            .offset(0_usize as isize)
-            .read()) as i32)
+        ((((substr_1.as_pointer() as Ptr<u8>).offset(0_usize).read()) as i32)
             == (('b' as u8) as i32))
     );
     assert!(
-        ((((substr_1.as_pointer() as Ptr<u8>)
-            .offset(1_usize as isize)
-            .read()) as i32)
+        ((((substr_1.as_pointer() as Ptr<u8>).offset(1_usize).read()) as i32)
             == (('a' as u8) as i32))
     );
     assert!(
-        ((((substr_1.as_pointer() as Ptr<u8>)
-            .offset(2_usize as isize)
-            .read()) as i32)
+        ((((substr_1.as_pointer() as Ptr<u8>).offset(2_usize).read()) as i32)
             == (('r' as u8) as i32))
     );
+    assert!(((((substr_1.as_pointer() as Ptr<u8>).offset(3_usize).read()) as i32) == 0));
     assert!(
-        ((((substr_1.as_pointer() as Ptr<u8>)
-            .offset(3_usize as isize)
-            .read()) as i32)
-            == 0)
-    );
-    assert!(
-        ((((substr_1.as_pointer() as Ptr<u8>)
-            .offset(4_usize as isize)
-            .read()) as i32)
+        ((((substr_1.as_pointer() as Ptr<u8>).offset(4_usize).read()) as i32)
             == ((' ' as u8) as i32))
     );
     let substr_2: Value<Vec<u8>> = Rc::new(RefCell::new({
@@ -469,51 +377,32 @@ fn main_0() -> i32 {
     }));
     assert!((((*substr_2.borrow()).len() - 1) == 8_usize));
     assert!(
-        ((((substr_2.as_pointer() as Ptr<u8>)
-            .offset(0_usize as isize)
-            .read()) as i32)
+        ((((substr_2.as_pointer() as Ptr<u8>).offset(0_usize).read()) as i32)
             == (('b' as u8) as i32))
     );
     assert!(
-        ((((substr_2.as_pointer() as Ptr<u8>)
-            .offset(1_usize as isize)
-            .read()) as i32)
+        ((((substr_2.as_pointer() as Ptr<u8>).offset(1_usize).read()) as i32)
             == (('a' as u8) as i32))
     );
     assert!(
-        ((((substr_2.as_pointer() as Ptr<u8>)
-            .offset(2_usize as isize)
-            .read()) as i32)
+        ((((substr_2.as_pointer() as Ptr<u8>).offset(2_usize).read()) as i32)
             == (('r' as u8) as i32))
     );
+    assert!(((((substr_2.as_pointer() as Ptr<u8>).offset(3_usize).read()) as i32) == 0));
     assert!(
-        ((((substr_2.as_pointer() as Ptr<u8>)
-            .offset(3_usize as isize)
-            .read()) as i32)
-            == 0)
-    );
-    assert!(
-        ((((substr_2.as_pointer() as Ptr<u8>)
-            .offset(4_usize as isize)
-            .read()) as i32)
+        ((((substr_2.as_pointer() as Ptr<u8>).offset(4_usize).read()) as i32)
             == ((' ' as u8) as i32))
     );
     assert!(
-        ((((substr_2.as_pointer() as Ptr<u8>)
-            .offset(5_usize as isize)
-            .read()) as i32)
+        ((((substr_2.as_pointer() as Ptr<u8>).offset(5_usize).read()) as i32)
             == (('f' as u8) as i32))
     );
     assert!(
-        ((((substr_2.as_pointer() as Ptr<u8>)
-            .offset(6_usize as isize)
-            .read()) as i32)
+        ((((substr_2.as_pointer() as Ptr<u8>).offset(6_usize).read()) as i32)
             == (('o' as u8) as i32))
     );
     assert!(
-        ((((substr_2.as_pointer() as Ptr<u8>)
-            .offset(7_usize as isize)
-            .read()) as i32)
+        ((((substr_2.as_pointer() as Ptr<u8>).offset(7_usize).read()) as i32)
             == (('o' as u8) as i32))
     );
     let pos: Value<usize> = Rc::new(RefCell::new({
@@ -567,8 +456,7 @@ fn main_0() -> i32 {
             .collect::<Vec<u8>>(),
     ));
     let output_data: Value<Ptr<u8>> = Rc::new(RefCell::new(
-        ((string_to_cast.as_pointer() as Ptr<u8>).offset(0_usize as isize))
-            .reinterpret_cast::<u8>(),
+        ((string_to_cast.as_pointer() as Ptr<u8>).offset(0_usize)).reinterpret_cast::<u8>(),
     ));
     assert!(((((*output_data.borrow()).read()) as i32) == (('c' as u8) as i32)));
     assert!(

--- a/tests/unit/out/refcount/string2.rs
+++ b/tests/unit/out/refcount/string2.rs
@@ -17,7 +17,7 @@ fn main_0() -> i32 {
             .collect::<Vec<u8>>(),
     ));
     (arr.as_pointer() as Ptr<u8>)
-        .offset(1_usize as isize)
+        .offset(1_usize)
         .write(('b' as u8));
     let p: Value<Ptr<u8>> = Rc::new(RefCell::new(
         (arr.as_pointer() as Ptr<u8>).offset((1) as isize),

--- a/tests/unit/out/refcount/strlen.rs
+++ b/tests/unit/out/refcount/strlen.rs
@@ -26,5 +26,5 @@ fn main_0() -> i32 {
         ('o' as u8),
         ('\0' as u8),
     ])));
-    return (({ strlen_0(((string.as_pointer() as Ptr<u8>).offset(0 as isize))) }) as i32);
+    return (({ strlen_0(((string.as_pointer() as Ptr<u8>).offset(0))) }) as i32);
 }

--- a/tests/unit/out/refcount/strlen_diff.rs
+++ b/tests/unit/out/refcount/strlen_diff.rs
@@ -27,5 +27,5 @@ fn main_0() -> i32 {
         ('g' as u8),
         ('\0' as u8),
     ])));
-    return (({ strlen_0(((s.as_pointer() as Ptr<u8>).offset(0 as isize))) }) as i32);
+    return (({ strlen_0(((s.as_pointer() as Ptr<u8>).offset(0))) }) as i32);
 }

--- a/tests/unit/out/refcount/strlen_rec.rs
+++ b/tests/unit/out/refcount/strlen_rec.rs
@@ -25,5 +25,5 @@ fn main_0() -> i32 {
         ('r' as u8),
         ('\0' as u8),
     ])));
-    return ({ strlen_0(((s.as_pointer() as Ptr<u8>).offset(0 as isize)), 0) });
+    return ({ strlen_0(((s.as_pointer() as Ptr<u8>).offset(0)), 0) });
 }

--- a/tests/unit/out/refcount/typedef-anon-struct.rs
+++ b/tests/unit/out/refcount/typedef-anon-struct.rs
@@ -63,7 +63,7 @@ fn main_0() -> i32 {
     assert!(((*(*o.borrow()).runs.borrow()).len() == 1_usize));
     assert!(
         ((*(*((*o.borrow()).runs.as_pointer() as Ptr<Outer_RunInfo>)
-            .offset(0_usize as isize)
+            .offset(0_usize)
             .upgrade()
             .deref())
         .block_idx
@@ -72,7 +72,7 @@ fn main_0() -> i32 {
     );
     assert!(
         ((*(*((*o.borrow()).runs.as_pointer() as Ptr<Outer_RunInfo>)
-            .offset(0_usize as isize)
+            .offset(0_usize)
             .upgrade()
             .deref())
         .num_extra_zero_runs

--- a/tests/unit/out/refcount/vector.rs
+++ b/tests/unit/out/refcount/vector.rs
@@ -26,30 +26,11 @@ fn main_0() -> i32 {
         (*v1.borrow_mut()).resize_with(__a0, || <i32>::default())
     };
     assert!(((*v1.borrow()).len() == 100_usize));
-    assert!(
-        (((v1.as_pointer() as Ptr<i32>)
-            .offset(99_usize as isize)
-            .read())
-            == 0)
-    );
-    (v1.as_pointer() as Ptr<i32>)
-        .offset(0_usize as isize)
-        .write(40);
-    (v1.as_pointer() as Ptr<i32>)
-        .offset(99_usize as isize)
-        .write(50);
-    assert!(
-        (((v1.as_pointer() as Ptr<i32>)
-            .offset(0_usize as isize)
-            .read())
-            == 40)
-    );
-    assert!(
-        (((v1.as_pointer() as Ptr<i32>)
-            .offset(99_usize as isize)
-            .read())
-            == 50)
-    );
+    assert!((((v1.as_pointer() as Ptr<i32>).offset(99_usize).read()) == 0));
+    (v1.as_pointer() as Ptr<i32>).offset(0_usize).write(40);
+    (v1.as_pointer() as Ptr<i32>).offset(99_usize).write(50);
+    assert!((((v1.as_pointer() as Ptr<i32>).offset(0_usize).read()) == 40));
+    assert!((((v1.as_pointer() as Ptr<i32>).offset(99_usize).read()) == 50));
     let v2: Value<Vec<i32>> = Rc::new(RefCell::new(Vec::new()));
     assert!(((*v2.borrow()).len() == 0_usize));
     (*v2.borrow_mut()).push(1);
@@ -62,18 +43,8 @@ fn main_0() -> i32 {
         (v2.as_pointer() as Ptr<Vec<i32>>).to_strong().as_pointer() as Ptr<i32>
     };
     assert!(((*v2.borrow()).len() == 2_usize));
-    assert!(
-        (((v2.as_pointer() as Ptr<i32>)
-            .offset(0_usize as isize)
-            .read())
-            == 2)
-    );
-    assert!(
-        (((v2.as_pointer() as Ptr<i32>)
-            .offset(1_usize as isize)
-            .read())
-            == 3)
-    );
+    assert!((((v2.as_pointer() as Ptr<i32>).offset(0_usize).read()) == 2));
+    assert!((((v2.as_pointer() as Ptr<i32>).offset(1_usize).read()) == 3));
     {
         let __off = (v2.as_pointer() as Ptr<i32>).clone().get_offset();
         (*v2.borrow_mut()).insert(__off, 100);
@@ -81,24 +52,9 @@ fn main_0() -> i32 {
     };
     ({ copy_0((*v2.borrow()).clone()) });
     assert!(((*v2.borrow()).len() == 3_usize));
-    assert!(
-        (((v2.as_pointer() as Ptr<i32>)
-            .offset(0_usize as isize)
-            .read())
-            == 100)
-    );
-    assert!(
-        (((v2.as_pointer() as Ptr<i32>)
-            .offset(1_usize as isize)
-            .read())
-            == 2)
-    );
-    assert!(
-        (((v2.as_pointer() as Ptr<i32>)
-            .offset(2_usize as isize)
-            .read())
-            == 3)
-    );
+    assert!((((v2.as_pointer() as Ptr<i32>).offset(0_usize).read()) == 100));
+    assert!((((v2.as_pointer() as Ptr<i32>).offset(1_usize).read()) == 2));
+    assert!((((v2.as_pointer() as Ptr<i32>).offset(2_usize).read()) == 3));
     let s2: Value<usize> = Rc::new(RefCell::new((*v2.borrow()).len()));
     let v3: Value<Vec<i32>> = Rc::new(RefCell::new(vec![1; 100_usize as usize]));
     assert!(((*v3.borrow()).len() == 100_usize));
@@ -106,7 +62,7 @@ fn main_0() -> i32 {
     'loop_: while ((*i.borrow()) < 100) {
         assert!(
             (((v3.as_pointer() as Ptr<i32>)
-                .offset(((*i.borrow()) as usize) as isize)
+                .offset(((*i.borrow()) as usize))
                 .read())
                 == 1)
         );
@@ -121,7 +77,7 @@ fn main_0() -> i32 {
     let i: Value<u32> = Rc::new(RefCell::new(0_u32));
     'loop_: while (((*i.borrow()) as usize) < (*v4.borrow()).len()) {
         assert!(((v4.as_pointer() as Ptr<Ptr::<i32>>)
-            .offset(((*i.borrow()) as usize) as isize)
+            .offset(((*i.borrow()) as usize))
             .read())
         .is_null());
         (*i.borrow_mut()).prefix_inc();
@@ -135,7 +91,7 @@ fn main_0() -> i32 {
     let i: Value<u32> = Rc::new(RefCell::new(0_u32));
     'loop_: while (((*i.borrow()) as usize) < (*v5.borrow()).len()) {
         assert!(((v5.as_pointer() as Ptr<Ptr::<i32>>)
-            .offset(((*i.borrow()) as usize) as isize)
+            .offset(((*i.borrow()) as usize))
             .read())
         .is_null());
         (*i.borrow_mut()).prefix_inc();
@@ -146,7 +102,7 @@ fn main_0() -> i32 {
     'loop_: while (((*i.borrow()) as usize) < (*s2.borrow())) {
         assert!(
             (((v6.as_pointer() as Ptr<f64>)
-                .offset(((*i.borrow()) as usize) as isize)
+                .offset(((*i.borrow()) as usize))
                 .read())
                 == 2.0E+0)
         );
@@ -162,14 +118,14 @@ fn main_0() -> i32 {
     'loop_: while ((*i.borrow()) < 200_u32) {
         assert!(
             ((*(*(v7.as_pointer() as Ptr<(Value<Ptr::<i32>>, Value<i32>)>)
-                .offset(((*i.borrow()) as usize) as isize)
+                .offset(((*i.borrow()) as usize))
                 .upgrade()
                 .deref())
             .0
             .borrow())
             .is_null())
                 && ((*(*(v7.as_pointer() as Ptr<(Value<Ptr::<i32>>, Value<i32>)>)
-                    .offset(((*i.borrow()) as usize) as isize)
+                    .offset(((*i.borrow()) as usize))
                     .upgrade()
                     .deref())
                 .1
@@ -182,46 +138,16 @@ fn main_0() -> i32 {
     assert!((((*p1.borrow()).read()) == 2.0E+0));
     let p2: Value<Ptr<i32>> = Rc::new(RefCell::new((v3.as_pointer() as Ptr<i32>)));
     assert!((((*p2.borrow()).read()) == 1));
-    assert!(
-        (((v3.as_pointer() as Ptr<i32>)
-            .offset(0_usize as isize)
-            .read())
-            == 1)
-    );
-    assert!(
-        (((v3.as_pointer() as Ptr<i32>)
-            .offset(1_usize as isize)
-            .read())
-            == 1)
-    );
+    assert!((((v3.as_pointer() as Ptr<i32>).offset(0_usize).read()) == 1));
+    assert!((((v3.as_pointer() as Ptr<i32>).offset(1_usize).read()) == 1));
     (*p2.borrow()).write((9.9E+1 as i32));
     assert!((((*p2.borrow()).read()) == 99));
-    assert!(
-        (((v3.as_pointer() as Ptr<i32>)
-            .offset(0_usize as isize)
-            .read())
-            == 99)
-    );
-    assert!(
-        (((v3.as_pointer() as Ptr<i32>)
-            .offset(1_usize as isize)
-            .read())
-            == 1)
-    );
+    assert!((((v3.as_pointer() as Ptr<i32>).offset(0_usize).read()) == 99));
+    assert!((((v3.as_pointer() as Ptr<i32>).offset(1_usize).read()) == 1));
     (*p2.borrow_mut()).prefix_inc();
     (*p2.borrow()).write(98);
-    assert!(
-        (((v3.as_pointer() as Ptr<i32>)
-            .offset(0_usize as isize)
-            .read())
-            == 99)
-    );
-    assert!(
-        (((v3.as_pointer() as Ptr<i32>)
-            .offset(1_usize as isize)
-            .read())
-            == 98)
-    );
+    assert!((((v3.as_pointer() as Ptr<i32>).offset(0_usize).read()) == 99));
+    assert!((((v3.as_pointer() as Ptr<i32>).offset(1_usize).read()) == 98));
     assert!(((*v3.borrow()).capacity() == 100_usize));
     assert!(((*v3.borrow()).len() == 100_usize));
     if 200_usize as usize > (*v3.borrow()).capacity() as usize {

--- a/tests/unit/out/refcount/vector2.rs
+++ b/tests/unit/out/refcount/vector2.rs
@@ -16,67 +16,40 @@ pub fn fn_0(v: Ptr<Vec<i32>>, v3: Vec<i32>) {
     (*v2.borrow_mut()).push(1);
     (*v2.borrow_mut()).push(3);
     (*x.borrow_mut()) = ((v.to_strong().as_pointer() as Ptr<i32>)
-        .offset(2_usize as isize)
+        .offset(2_usize)
         .read());
-    (v2.as_pointer() as Ptr<i32>)
-        .offset(0_usize as isize)
-        .write(1);
+    (v2.as_pointer() as Ptr<i32>).offset(0_usize).write(1);
     ((if true {
         v3.as_pointer()
     } else {
         v.to_strong().as_pointer()
     }) as Ptr<i32>)
-        .offset(0_usize as isize)
+        .offset(0_usize)
         .write(7);
     (v2.as_pointer() as Ptr<Vec<i32>>).write((*v.upgrade().deref()).clone());
     (((*v4.borrow()).to_strong().as_pointer()) as Ptr<i32>)
-        .offset(1_usize as isize)
+        .offset(1_usize)
         .write(13);
     assert!(((*x.borrow()) == 6));
     assert!((((v.to_strong().as_pointer() as Ptr<i32>).read()) == 4));
     assert!(
         (((v.to_strong().as_pointer() as Ptr<i32>)
-            .offset(1_usize as isize)
+            .offset(1_usize)
             .read())
             == 5)
     );
     assert!(
         (((v.to_strong().as_pointer() as Ptr<i32>)
-            .offset(2_usize as isize)
+            .offset(2_usize)
             .read())
             == 6)
     );
     assert!((((v.to_strong().as_pointer() as Ptr<i32>).to_last().read()) == 20));
-    assert!(
-        (((v2.as_pointer() as Ptr<i32>)
-            .offset(0_usize as isize)
-            .read())
-            == 4)
-    );
-    assert!(
-        (((v2.as_pointer() as Ptr<i32>)
-            .offset(1_usize as isize)
-            .read())
-            == 5)
-    );
-    assert!(
-        (((v2.as_pointer() as Ptr<i32>)
-            .offset(2_usize as isize)
-            .read())
-            == 6)
-    );
-    assert!(
-        (((v3.as_pointer() as Ptr<i32>)
-            .offset(0_usize as isize)
-            .read())
-            == 7)
-    );
-    assert!(
-        (((v3.as_pointer() as Ptr<i32>)
-            .offset(1_usize as isize)
-            .read())
-            == 13)
-    );
+    assert!((((v2.as_pointer() as Ptr<i32>).offset(0_usize).read()) == 4));
+    assert!((((v2.as_pointer() as Ptr<i32>).offset(1_usize).read()) == 5));
+    assert!((((v2.as_pointer() as Ptr<i32>).offset(2_usize).read()) == 6));
+    assert!((((v3.as_pointer() as Ptr<i32>).offset(0_usize).read()) == 7));
+    assert!((((v3.as_pointer() as Ptr<i32>).offset(1_usize).read()) == 13));
     v.with_mut(|__v: &mut Vec<i32>| __v.push(20));
 }
 pub fn main() {

--- a/tests/unit/out/refcount/vector3.rs
+++ b/tests/unit/out/refcount/vector3.rs
@@ -20,7 +20,7 @@ fn main_0() -> i32 {
     {
         let __a0 = 2_usize as usize;
         (v.as_pointer() as Ptr<Value<Vec<i32>>>)
-            .offset(0_usize as isize)
+            .offset(0_usize)
             .with_mut(|__v: &mut Value<Vec<i32>>| {
                 (*__v.borrow_mut()).resize_with(__a0, || <i32>::default())
             })
@@ -28,31 +28,31 @@ fn main_0() -> i32 {
     {
         let __a0 = 1_usize as usize;
         (v.as_pointer() as Ptr<Value<Vec<i32>>>)
-            .offset(1_usize as isize)
+            .offset(1_usize)
             .with_mut(|__v: &mut Value<Vec<i32>>| {
                 (*__v.borrow_mut()).resize_with(__a0, || <i32>::default())
             })
     };
     ((v.as_pointer() as Ptr<Value<Vec<i32>>>)
-        .offset(0_usize as isize)
+        .offset(0_usize)
         .upgrade()
         .deref()
         .as_pointer() as Ptr<i32>)
-        .offset(0_usize as isize)
+        .offset(0_usize)
         .write(1);
     ((v.as_pointer() as Ptr<Value<Vec<i32>>>)
-        .offset(0_usize as isize)
+        .offset(0_usize)
         .upgrade()
         .deref()
         .as_pointer() as Ptr<i32>)
-        .offset(1_usize as isize)
+        .offset(1_usize)
         .write(5);
     ((v.as_pointer() as Ptr<Value<Vec<i32>>>)
-        .offset(1_usize as isize)
+        .offset(1_usize)
         .upgrade()
         .deref()
         .as_pointer() as Ptr<i32>)
-        .offset(0_usize as isize)
+        .offset(0_usize)
         .write(6);
     'loop_: for mut v2 in v.as_pointer() as Ptr<Value<Vec<i32>>> {
         let v2: Ptr<Vec<i32>> = v2.upgrade().deref().as_pointer();

--- a/tests/unit/out/refcount/vector_iter_range_ctor.rs
+++ b/tests/unit/out/refcount/vector_iter_range_ctor.rs
@@ -22,18 +22,9 @@ fn main_0() -> i32 {
     }));
     assert!(((*v1.borrow()).len() == 3_usize));
     assert!(
-        ((((v1.as_pointer() as Ptr<u32>)
-            .offset(0_usize as isize)
-            .read())
-            == 1_u32)
-            && (((v1.as_pointer() as Ptr<u32>)
-                .offset(1_usize as isize)
-                .read())
-                == 2_u32))
-            && (((v1.as_pointer() as Ptr<u32>)
-                .offset(2_usize as isize)
-                .read())
-                == 3_u32)
+        ((((v1.as_pointer() as Ptr<u32>).offset(0_usize).read()) == 1_u32)
+            && (((v1.as_pointer() as Ptr<u32>).offset(1_usize).read()) == 2_u32))
+            && (((v1.as_pointer() as Ptr<u32>).offset(2_usize).read()) == 3_u32)
     );
     let v2: Value<Vec<u64>> = Rc::new(RefCell::new({
         let __count = (src.as_pointer() as Ptr<u32>)
@@ -46,18 +37,9 @@ fn main_0() -> i32 {
     }));
     assert!(((*v2.borrow()).len() == 3_usize));
     assert!(
-        ((((v2.as_pointer() as Ptr<u64>)
-            .offset(0_usize as isize)
-            .read())
-            == 1_u64)
-            && (((v2.as_pointer() as Ptr<u64>)
-                .offset(1_usize as isize)
-                .read())
-                == 2_u64))
-            && (((v2.as_pointer() as Ptr<u64>)
-                .offset(2_usize as isize)
-                .read())
-                == 3_u64)
+        ((((v2.as_pointer() as Ptr<u64>).offset(0_usize).read()) == 1_u64)
+            && (((v2.as_pointer() as Ptr<u64>).offset(1_usize).read()) == 2_u64))
+            && (((v2.as_pointer() as Ptr<u64>).offset(2_usize).read()) == 3_u64)
     );
     let v3: Value<Vec<i32>> = Rc::new(RefCell::new({
         let __count = (src.as_pointer() as Ptr<u32>)
@@ -70,18 +52,9 @@ fn main_0() -> i32 {
     }));
     assert!(((*v3.borrow()).len() == 3_usize));
     assert!(
-        ((((v3.as_pointer() as Ptr<i32>)
-            .offset(0_usize as isize)
-            .read())
-            == 1)
-            && (((v3.as_pointer() as Ptr<i32>)
-                .offset(1_usize as isize)
-                .read())
-                == 2))
-            && (((v3.as_pointer() as Ptr<i32>)
-                .offset(2_usize as isize)
-                .read())
-                == 3)
+        ((((v3.as_pointer() as Ptr<i32>).offset(0_usize).read()) == 1)
+            && (((v3.as_pointer() as Ptr<i32>).offset(1_usize).read()) == 2))
+            && (((v3.as_pointer() as Ptr<i32>).offset(2_usize).read()) == 3)
     );
     let src1: Value<Box<[u32]>> = Rc::new(RefCell::new(Box::new([1_u32, 2_u32, 3_u32])));
     let v4: Value<Vec<u32>> = Rc::new(RefCell::new({
@@ -91,18 +64,9 @@ fn main_0() -> i32 {
     }));
     assert!(((*v4.borrow()).len() == 3_usize));
     assert!(
-        ((((v4.as_pointer() as Ptr<u32>)
-            .offset(0_usize as isize)
-            .read())
-            == 1_u32)
-            && (((v4.as_pointer() as Ptr<u32>)
-                .offset(1_usize as isize)
-                .read())
-                == 2_u32))
-            && (((v4.as_pointer() as Ptr<u32>)
-                .offset(2_usize as isize)
-                .read())
-                == 3_u32)
+        ((((v4.as_pointer() as Ptr<u32>).offset(0_usize).read()) == 1_u32)
+            && (((v4.as_pointer() as Ptr<u32>).offset(1_usize).read()) == 2_u32))
+            && (((v4.as_pointer() as Ptr<u32>).offset(2_usize).read()) == 3_u32)
     );
     let buf: Value<Box<[u8]>> =
         Rc::new(RefCell::new(Box::new([10_u8, 20_u8, 30_u8, 40_u8, 50_u8])));
@@ -117,8 +81,8 @@ fn main_0() -> i32 {
     }));
     assert!(((*v5.borrow()).len() == 5_usize));
     assert!(
-        ((((v5.as_pointer() as Ptr<u8>).offset(0_usize as isize).read()) as i32) == 10)
-            && ((((v5.as_pointer() as Ptr<u8>).offset(4_usize as isize).read()) as i32) == 50)
+        ((((v5.as_pointer() as Ptr<u8>).offset(0_usize).read()) as i32) == 10)
+            && ((((v5.as_pointer() as Ptr<u8>).offset(4_usize).read()) as i32) == 50)
     );
     return 0;
 }

--- a/tests/unit/out/refcount/z_bit_cast.rs
+++ b/tests/unit/out/refcount/z_bit_cast.rs
@@ -18,9 +18,9 @@ pub fn main() {
 fn main_0() -> i32 {
     let a1: Value<Box<[u32]>> = Rc::new(RefCell::new(Box::new([1_u32, 2_u32, 3_u32])));
     ({ decay_cast_0((a1.as_pointer() as Ptr<u32>)) });
-    ({ decay_cast_0(((a1.as_pointer() as Ptr<u32>).offset(0 as isize))) });
+    ({ decay_cast_0(((a1.as_pointer() as Ptr<u32>).offset(0))) });
     ({ bit_cast_1(((a1.as_pointer() as Ptr<u32>) as Ptr<u32>).to_any()) });
-    ({ bit_cast_1((((a1.as_pointer() as Ptr<u32>).offset(0 as isize)) as Ptr<u32>).to_any()) });
+    ({ bit_cast_1((((a1.as_pointer() as Ptr<u32>).offset(0)) as Ptr<u32>).to_any()) });
     ({ bit_cast_1(((a1.as_pointer()) as Ptr<u32>).to_any()) });
     let ptr: Value<AnyPtr> = Rc::new(RefCell::new(
         ((a1.as_pointer() as Ptr<u32>) as Ptr<u32>).to_any(),


### PR DESCRIPTION
The rationale behind this change is to avoid unnecessary casts that may hurt readability, such as: `0_usize as isize`.
With this change, we are allowed to omit the cast, as it will be performed inside the `offset` function.

This also has the advantage of panicking whenever we try to cast a usize larger than `isize::MAX`.