### PR TITLE
Add panic-ub test mode

### DIFF
--- a/tests/lit/lit/formats/Cpp2RustTest.py
+++ b/tests/lit/lit/formats/Cpp2RustTest.py
@@ -18,6 +18,7 @@ MODELS = ("refcount", "unsafe")
 PTR_RE = re.compile(r"0x[0-9a-fA-F]+")
 
 RE_XFAIL = re.compile(r"//\s*XFAIL:\s*(.*)")
+RE_PANIC_UB = re.compile(r"//\s*panic-ub\s*(?::\s*(.*))?$", re.MULTILINE)
 RE_PANIC = re.compile(r"//\s*panic\s*(?::\s*(.*))?$", re.MULTILINE)
 RE_NOCOMPILE = re.compile(r"//\s*no-compile\s*(?::\s*(.*))?$", re.MULTILINE)
 RE_TRANS_FAIL = re.compile(r"//\s*translation-fail\s*(?::\s*(.*))?$", re.MULTILINE)
@@ -27,6 +28,7 @@ RE_NONDET = re.compile(r"//\s*nondet-result\s*(?::\s*(.*))?$", re.MULTILINE)
 @dataclass
 class TestExpectations:
     should_panic: bool = False
+    should_panic_ub: bool = False
     should_not_compile: bool = False
     should_not_translate: bool = False
     is_nondet_result: bool = False
@@ -47,6 +49,7 @@ class TestExpectations:
         xfail = xfail_m is not None and model in re.split(r"\s*,\s*", xfail_m.group(1))
         return cls(
             should_panic=matches(RE_PANIC.search(text)),
+            should_panic_ub=matches(RE_PANIC_UB.search(text)),
             should_not_compile=matches(RE_NOCOMPILE.search(text)),
             should_not_translate=matches(RE_TRANS_FAIL.search(text)),
             is_nondet_result=matches(RE_NONDET.search(text)),
@@ -254,13 +257,21 @@ class TestContext:
             return None
         self.rust_result = RunResult(*lit.util.executeCommand(str(self.rust_bin)))
 
-        if exp.should_panic:
+        if exp.should_panic_ub:
             err = str(self.rust_result.stderr)
             if not re.search(
                 r"thread 'main' \(\d+\) panicked at", err
             ) or self.rust_result.returncode not in [-6, 101]:
                 return (exp.fail_code, "expected panic\n" + err)
             return self.success_result()
+
+        if exp.should_panic:
+            err = str(self.rust_result.stderr)
+            if not re.search(
+                r"thread 'main' \(\d+\) panicked at", err
+            ) or self.rust_result.returncode not in [-6, 101]:
+                return (exp.fail_code, "expected panic\n" + err)
+            return (lit.Test.XFAIL, "")
 
         if exp.is_nondet_result:
             return self.success_result()

--- a/tests/ub/dangling-prvalue-as-lvalue.cpp
+++ b/tests/ub/dangling-prvalue-as-lvalue.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 
 #include <vector>
 

--- a/tests/ub/enum_out_of_range_cast.cpp
+++ b/tests/ub/enum_out_of_range_cast.cpp
@@ -1,4 +1,4 @@
-// panic
+// panic-ub
 
 enum Color { RED, GREEN, BLUE };
 

--- a/tests/ub/enum_out_of_range_increment.c
+++ b/tests/ub/enum_out_of_range_increment.c
@@ -1,4 +1,4 @@
-// panic
+// panic-ub
 
 enum color { RED, GREEN, BLUE };
 

--- a/tests/ub/max.cpp
+++ b/tests/ub/max.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT license that can be found in the LICENSE file.
 
 // ub: unsafe
-// panic: refcount
+// panic-ub: refcount
 
 #include <algorithm>
 

--- a/tests/ub/ub1.cpp
+++ b/tests/ub/ub1.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 // nondet-result: unsafe
 int &dangling() {
   int x = 1;

--- a/tests/ub/ub10.cpp
+++ b/tests/ub/ub10.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 // nondet-result: unsafe
 int main() {
   int *arr = new int[10];

--- a/tests/ub/ub11.cpp
+++ b/tests/ub/ub11.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 // nondet-result: unsafe
 int main() {
   int *element = new int(10);

--- a/tests/ub/ub12.cpp
+++ b/tests/ub/ub12.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 // nondet-result: unsafe
 void escape(int *ptr) { delete ptr; }
 

--- a/tests/ub/ub13.cpp
+++ b/tests/ub/ub13.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 // nondet-result: unsafe
 void escape(int *p) { delete p; }
 

--- a/tests/ub/ub14.cpp
+++ b/tests/ub/ub14.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 // nondet-result: unsafe
 int main() {
   int *arr1 = new int[100];

--- a/tests/ub/ub15.cpp
+++ b/tests/ub/ub15.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 // nondet-result: unsafe
 int main() {
   int *arr = new int[15];

--- a/tests/ub/ub16.cpp
+++ b/tests/ub/ub16.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 // nondet-result: unsafe
 int *foo(int *a) { return &a[5]; }
 int main() {

--- a/tests/ub/ub17.cpp
+++ b/tests/ub/ub17.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 // nondet-result: unsafe
 int main() {
   int x = 1;

--- a/tests/ub/ub18.cpp
+++ b/tests/ub/ub18.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 // nondet-result: unsafe
 int main() {
   int arr[3] = {1, 2, 3};

--- a/tests/ub/ub19.cpp
+++ b/tests/ub/ub19.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 // nondet-result: unsafe
 void foo(int *array) { delete[] array; }
 int main() {

--- a/tests/ub/ub2.cpp
+++ b/tests/ub/ub2.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 // nondet-result: unsafe
 int *null() {
   int *p = nullptr;

--- a/tests/ub/ub20.cpp
+++ b/tests/ub/ub20.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 // nondet-result: unsafe
 void foo(int *single) { delete single; }
 int main() {

--- a/tests/ub/ub21.cpp
+++ b/tests/ub/ub21.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 // nondet-result: unsafe
 #include <cstddef>
 size_t strlen(const char *s) {

--- a/tests/ub/ub3.cpp
+++ b/tests/ub/ub3.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 // nondet-result: unsafe
 int *dangling() {
   int x = 1;

--- a/tests/ub/ub4.cpp
+++ b/tests/ub/ub4.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 // nondet-result: unsafe
 int *smaller(int &x1, int &x2) { return (x1 < x2) ? &x1 : &x2; }
 int main() {

--- a/tests/ub/ub5.cpp
+++ b/tests/ub/ub5.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 // nondet-result: unsafe
 void null(int **p) { *p = nullptr; }
 int main() {

--- a/tests/ub/ub6.cpp
+++ b/tests/ub/ub6.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 // nondet-result: unsafe
 #include <memory>
 

--- a/tests/ub/ub7.cpp
+++ b/tests/ub/ub7.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 // nondet-result: unsafe
 #include <cstddef>
 

--- a/tests/ub/ub8.cpp
+++ b/tests/ub/ub8.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 // nondet-result: unsafe
 int main() {
   int x = 5;

--- a/tests/ub/ub9.cpp
+++ b/tests/ub/ub9.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-// panic: refcount
+// panic-ub: refcount
 // nondet-result: unsafe
 int main() {
   int *arr = new int[10];


### PR DESCRIPTION
The `panic` mode is currently used for both describing UB tests (e.g. translate null ptr deref as panic) and for describing translation gaps (panic in libcc2rs for types that don't implement ByteRepr).

I renamed the first type as `panic-ub` and the second type as `panic`. So that the `Expectedly Failed Tests` in lit includes the second type, i.e. translation gaps.