### PR TITLE
Add panic'ing ByteRepr impl for Ptr and AnyPtr

### DIFF
--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -204,6 +204,9 @@ bool TypeImplementsByteRepr(clang::QualType qt) {
   if (qt->isIntegerType() || qt->isFloatingType() || qt->isEnumeralType()) {
     return true;
   }
+  if (qt->isPointerType()) {
+    return true;
+  }
   if (const auto *arr = qt->getAsArrayTypeUnsafe()) {
     return TypeImplementsByteRepr(arr->getElementType());
   }

--- a/libcc2rs/src/rc.rs
+++ b/libcc2rs/src/rc.rs
@@ -1256,6 +1256,7 @@ impl<T: ?Sized> AsPointerDyn<T> for Rc<RefCell<T>> {
 }
 
 impl<T: 'static> ByteRepr for Ptr<T> {}
+impl ByteRepr for AnyPtr {}
 
 #[cfg(test)]
 mod tests {

--- a/tests/multi-file/opaque_forward_decl/out/refcount/opaque_forward_decl.rs
+++ b/tests/multi-file/opaque_forward_decl/out/refcount/opaque_forward_decl.rs
@@ -11,7 +11,21 @@ pub struct container {
     pub p: Value<Ptr<opaque>>,
     pub x: Value<i32>,
 }
-impl ByteRepr for container {}
+impl ByteRepr for container {
+    fn byte_size() -> usize {
+        16
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.p.borrow()).to_bytes(&mut buf[0..8]);
+        (*self.x.borrow()).to_bytes(&mut buf[8..12]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            p: Rc::new(RefCell::new(<Ptr<opaque>>::from_bytes(&buf[0..8]))),
+            x: Rc::new(RefCell::new(<i32>::from_bytes(&buf[8..12]))),
+        }
+    }
+}
 pub fn main() {
     std::process::exit(main_0());
 }

--- a/tests/unit/out/refcount/10_struct.rs
+++ b/tests/unit/out/refcount/10_struct.rs
@@ -20,7 +20,21 @@ impl Clone for GraphNode {
         this
     }
 }
-impl ByteRepr for GraphNode {}
+impl ByteRepr for GraphNode {
+    fn byte_size() -> usize {
+        16
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.dst.borrow()).to_bytes(&mut buf[0..4]);
+        (*self.next.borrow()).to_bytes(&mut buf[8..16]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            dst: Rc::new(RefCell::new(<u32>::from_bytes(&buf[0..4]))),
+            next: Rc::new(RefCell::new(<Ptr<GraphNode>>::from_bytes(&buf[8..16]))),
+        }
+    }
+}
 #[derive(Default)]
 pub struct Graph {
     pub V: Value<u32>,
@@ -59,7 +73,21 @@ impl Clone for Graph {
         this
     }
 }
-impl ByteRepr for Graph {}
+impl ByteRepr for Graph {
+    fn byte_size() -> usize {
+        16
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.V.borrow()).to_bytes(&mut buf[0..4]);
+        (*self.adj.borrow()).to_bytes(&mut buf[8..16]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            V: Rc::new(RefCell::new(<u32>::from_bytes(&buf[0..4]))),
+            adj: Rc::new(RefCell::new(<Ptr<Ptr<GraphNode>>>::from_bytes(&buf[8..16]))),
+        }
+    }
+}
 pub fn main() {
     std::process::exit(main_0());
 }

--- a/tests/unit/out/refcount/addr_of_global.rs
+++ b/tests/unit/out/refcount/addr_of_global.rs
@@ -43,7 +43,19 @@ impl Clone for Outer {
         this
     }
 }
-impl ByteRepr for Outer {}
+impl ByteRepr for Outer {
+    fn byte_size() -> usize {
+        8
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.p.borrow()).to_bytes(&mut buf[0..8]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            p: Rc::new(RefCell::new(<Ptr<Inner>>::from_bytes(&buf[0..8]))),
+        }
+    }
+}
 thread_local!(
     pub static alpha_0: Value<Inner> = Rc::new(RefCell::new(Inner {
         value: Rc::new(RefCell::new(1)),

--- a/tests/unit/out/refcount/bst.rs
+++ b/tests/unit/out/refcount/bst.rs
@@ -22,7 +22,23 @@ impl Clone for node_t {
         this
     }
 }
-impl ByteRepr for node_t {}
+impl ByteRepr for node_t {
+    fn byte_size() -> usize {
+        24
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.left.borrow()).to_bytes(&mut buf[0..8]);
+        (*self.right.borrow()).to_bytes(&mut buf[8..16]);
+        (*self.value.borrow()).to_bytes(&mut buf[16..20]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            left: Rc::new(RefCell::new(<Ptr<node_t>>::from_bytes(&buf[0..8]))),
+            right: Rc::new(RefCell::new(<Ptr<node_t>>::from_bytes(&buf[8..16]))),
+            value: Rc::new(RefCell::new(<i32>::from_bytes(&buf[16..20]))),
+        }
+    }
+}
 pub fn find_0(node: Ptr<node_t>, value: i32) -> Ptr<node_t> {
     let node: Value<Ptr<node_t>> = Rc::new(RefCell::new(node));
     let value: Value<i32> = Rc::new(RefCell::new(value));

--- a/tests/unit/out/refcount/c_struct.rs
+++ b/tests/unit/out/refcount/c_struct.rs
@@ -51,7 +51,21 @@ pub struct Node {
     pub value: Value<i32>,
     pub next: Value<Ptr<Node>>,
 }
-impl ByteRepr for Node {}
+impl ByteRepr for Node {
+    fn byte_size() -> usize {
+        16
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.value.borrow()).to_bytes(&mut buf[0..4]);
+        (*self.next.borrow()).to_bytes(&mut buf[8..16]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            value: Rc::new(RefCell::new(<i32>::from_bytes(&buf[0..4]))),
+            next: Rc::new(RefCell::new(<Ptr<Node>>::from_bytes(&buf[8..16]))),
+        }
+    }
+}
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum Color {
     #[default]

--- a/tests/unit/out/refcount/complex_function.rs
+++ b/tests/unit/out/refcount/complex_function.rs
@@ -77,7 +77,19 @@ impl Clone for X3 {
         this
     }
 }
-impl ByteRepr for X3 {}
+impl ByteRepr for X3 {
+    fn byte_size() -> usize {
+        8
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.v.borrow()).to_bytes(&mut buf[0..8]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            v: Rc::new(RefCell::new(<Ptr<X2>>::from_bytes(&buf[0..8]))),
+        }
+    }
+}
 #[derive(Default)]
 pub struct X4 {
     pub v: Value<X3>,
@@ -95,7 +107,19 @@ impl Clone for X4 {
         this
     }
 }
-impl ByteRepr for X4 {}
+impl ByteRepr for X4 {
+    fn byte_size() -> usize {
+        8
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.v.borrow()).to_bytes(&mut buf[0..8]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            v: Rc::new(RefCell::new(<X3>::from_bytes(&buf[0..8]))),
+        }
+    }
+}
 pub fn main() {
     std::process::exit(main_0());
 }

--- a/tests/unit/out/refcount/default.rs
+++ b/tests/unit/out/refcount/default.rs
@@ -45,7 +45,27 @@ impl Default for Pointers {
         }
     }
 }
-impl ByteRepr for Pointers {}
+impl ByteRepr for Pointers {
+    fn byte_size() -> usize {
+        144
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.x1.borrow()).to_bytes(&mut buf[0..8]);
+        (*self.x2.borrow()).to_bytes(&mut buf[8..16]);
+        (*self.x3.borrow()).to_bytes(&mut buf[16..56]);
+        (*self.x4.borrow()).to_bytes(&mut buf[56..136]);
+        (*self.x5.borrow()).to_bytes(&mut buf[136..140]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            x1: Rc::new(RefCell::new(<Ptr<i32>>::from_bytes(&buf[0..8]))),
+            x2: Rc::new(RefCell::new(<Ptr<i32>>::from_bytes(&buf[8..16]))),
+            x3: Rc::new(RefCell::new(<Box<[Ptr<i32>]>>::from_bytes(&buf[16..56]))),
+            x4: Rc::new(RefCell::new(<Box<[Ptr<i32>]>>::from_bytes(&buf[56..136]))),
+            x5: Rc::new(RefCell::new(<i32>::from_bytes(&buf[136..140]))),
+        }
+    }
+}
 pub fn main() {
     std::process::exit(main_0());
 }

--- a/tests/unit/out/refcount/default_in_statics.rs
+++ b/tests/unit/out/refcount/default_in_statics.rs
@@ -20,7 +20,21 @@ impl Clone for Inner {
         this
     }
 }
-impl ByteRepr for Inner {}
+impl ByteRepr for Inner {
+    fn byte_size() -> usize {
+        16
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.v.borrow()).to_bytes(&mut buf[0..4]);
+        (*self.name.borrow()).to_bytes(&mut buf[8..16]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            v: Rc::new(RefCell::new(<i32>::from_bytes(&buf[0..4]))),
+            name: Rc::new(RefCell::new(<Ptr<u8>>::from_bytes(&buf[8..16]))),
+        }
+    }
+}
 #[derive()]
 pub struct Outer {
     pub p1: Value<Ptr<i32>>,
@@ -65,7 +79,35 @@ impl Default for Outer {
         }
     }
 }
-impl ByteRepr for Outer {}
+impl ByteRepr for Outer {
+    fn byte_size() -> usize {
+        88
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.p1.borrow()).to_bytes(&mut buf[0..8]);
+        (*self.p2.borrow()).to_bytes(&mut buf[8..16]);
+        (*self.arr.borrow()).to_bytes(&mut buf[16..40]);
+        (*self.cp.borrow()).to_bytes(&mut buf[40..48]);
+        (*self.pp.borrow()).to_bytes(&mut buf[48..56]);
+        (*self.inner.borrow()).to_bytes(&mut buf[56..72]);
+        (*self.x.borrow()).to_bytes(&mut buf[72..76]);
+        (*self.fn_.borrow()).to_bytes(&mut buf[80..88]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            p1: Rc::new(RefCell::new(<Ptr<i32>>::from_bytes(&buf[0..8]))),
+            p2: Rc::new(RefCell::new(<Ptr<i32>>::from_bytes(&buf[8..16]))),
+            arr: Rc::new(RefCell::new(<Box<[Ptr<i32>]>>::from_bytes(&buf[16..40]))),
+            cp: Rc::new(RefCell::new(<Ptr<u8>>::from_bytes(&buf[40..48]))),
+            pp: Rc::new(RefCell::new(<Ptr<Ptr<i32>>>::from_bytes(&buf[48..56]))),
+            inner: Rc::new(RefCell::new(<Inner>::from_bytes(&buf[56..72]))),
+            x: Rc::new(RefCell::new(<i32>::from_bytes(&buf[72..76]))),
+            fn_: Rc::new(RefCell::new(<FnPtr<fn(i32) -> i32>>::from_bytes(
+                &buf[80..88],
+            ))),
+        }
+    }
+}
 #[derive()]
 pub struct Foo {
     pub s1: Value<Ptr<u8>>,
@@ -97,7 +139,31 @@ impl Default for Foo {
         }
     }
 }
-impl ByteRepr for Foo {}
+impl ByteRepr for Foo {
+    fn byte_size() -> usize {
+        40
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.s1.borrow()).to_bytes(&mut buf[0..8]);
+        (*self.s2.borrow()).to_bytes(&mut buf[8..16]);
+        (*self.fn1.borrow()).to_bytes(&mut buf[16..24]);
+        (*self.fn2.borrow()).to_bytes(&mut buf[24..32]);
+        (*self.n.borrow()).to_bytes(&mut buf[32..36]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            s1: Rc::new(RefCell::new(<Ptr<u8>>::from_bytes(&buf[0..8]))),
+            s2: Rc::new(RefCell::new(<Ptr<u8>>::from_bytes(&buf[8..16]))),
+            fn1: Rc::new(RefCell::new(<FnPtr<fn(i32) -> i32>>::from_bytes(
+                &buf[16..24],
+            ))),
+            fn2: Rc::new(RefCell::new(<FnPtr<fn(i32) -> i32>>::from_bytes(
+                &buf[24..32],
+            ))),
+            n: Rc::new(RefCell::new(<i32>::from_bytes(&buf[32..36]))),
+        }
+    }
+}
 thread_local!(
     pub static static_fn_0: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::null()));
 );

--- a/tests/unit/out/refcount/doubly_linked_list.rs
+++ b/tests/unit/out/refcount/doubly_linked_list.rs
@@ -32,7 +32,23 @@ impl Clone for Node {
         this
     }
 }
-impl ByteRepr for Node {}
+impl ByteRepr for Node {
+    fn byte_size() -> usize {
+        24
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.val.borrow()).to_bytes(&mut buf[0..4]);
+        (*self.next.borrow()).to_bytes(&mut buf[8..16]);
+        (*self.prev.borrow()).to_bytes(&mut buf[16..24]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            val: Rc::new(RefCell::new(<i32>::from_bytes(&buf[0..4]))),
+            next: Rc::new(RefCell::new(<Ptr<Node>>::from_bytes(&buf[8..16]))),
+            prev: Rc::new(RefCell::new(<Ptr<Node>>::from_bytes(&buf[16..24]))),
+        }
+    }
+}
 pub fn Find_0(head: Ptr<Node>, idx: i32) -> Ptr<Node> {
     let head: Value<Ptr<Node>> = Rc::new(RefCell::new(head));
     let idx: Value<i32> = Rc::new(RefCell::new(idx));

--- a/tests/unit/out/refcount/enum_int_interop.rs
+++ b/tests/unit/out/refcount/enum_int_interop.rs
@@ -102,7 +102,23 @@ impl Clone for Entry {
         this
     }
 }
-impl ByteRepr for Entry {}
+impl ByteRepr for Entry {
+    fn byte_size() -> usize {
+        16
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.name.borrow()).to_bytes(&mut buf[0..8]);
+        (*self.color.borrow()).to_bytes(&mut buf[8..12]);
+        (*self.opt.borrow()).to_bytes(&mut buf[12..16]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            name: Rc::new(RefCell::new(<Ptr<u8>>::from_bytes(&buf[0..8]))),
+            color: Rc::new(RefCell::new(<Color>::from_bytes(&buf[8..12]))),
+            opt: Rc::new(RefCell::new(<Option>::from_bytes(&buf[12..16]))),
+        }
+    }
+}
 thread_local!(
     pub static global_color_0: Value<Color> = Rc::new(RefCell::new(Color::GREEN));
 );

--- a/tests/unit/out/refcount/enum_int_interop_c.rs
+++ b/tests/unit/out/refcount/enum_int_interop_c.rs
@@ -92,7 +92,23 @@ pub struct Entry {
     pub color: Value<Color>,
     pub opt: Value<Option>,
 }
-impl ByteRepr for Entry {}
+impl ByteRepr for Entry {
+    fn byte_size() -> usize {
+        16
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.name.borrow()).to_bytes(&mut buf[0..8]);
+        (*self.color.borrow()).to_bytes(&mut buf[8..12]);
+        (*self.opt.borrow()).to_bytes(&mut buf[12..16]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            name: Rc::new(RefCell::new(<Ptr<u8>>::from_bytes(&buf[0..8]))),
+            color: Rc::new(RefCell::new(<Color>::from_bytes(&buf[8..12]))),
+            opt: Rc::new(RefCell::new(<Option>::from_bytes(&buf[12..16]))),
+        }
+    }
+}
 thread_local!(
     pub static global_color_0: Value<Color> = Rc::new(RefCell::new(Color::GREEN));
 );

--- a/tests/unit/out/refcount/exprs.rs
+++ b/tests/unit/out/refcount/exprs.rs
@@ -53,7 +53,21 @@ impl Clone for Y {
         this
     }
 }
-impl ByteRepr for Y {}
+impl ByteRepr for Y {
+    fn byte_size() -> usize {
+        16
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.x.borrow()).to_bytes(&mut buf[0..4]);
+        (*self.p.borrow()).to_bytes(&mut buf[8..16]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            x: Rc::new(RefCell::new(<X>::from_bytes(&buf[0..4]))),
+            p: Rc::new(RefCell::new(<Ptr<X>>::from_bytes(&buf[8..16]))),
+        }
+    }
+}
 pub fn main() {
     std::process::exit(main_0());
 }

--- a/tests/unit/out/refcount/fn_ptr_cast.rs
+++ b/tests/unit/out/refcount/fn_ptr_cast.rs
@@ -53,7 +53,19 @@ impl Clone for Command {
         this
     }
 }
-impl ByteRepr for Command {}
+impl ByteRepr for Command {
+    fn byte_size() -> usize {
+        8
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.data.borrow()).to_bytes(&mut buf[0..8]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            data: Rc::new(RefCell::new(<AnyPtr>::from_bytes(&buf[0..8]))),
+        }
+    }
+}
 pub fn test_void_ptr_to_fn_3() {
     let cmd: Value<Command> = Rc::new(RefCell::new(<Command>::default()));
     (*(*cmd.borrow()).data.borrow_mut()) = FnPtr::<fn(i32) -> i32>::new(double_it_0).to_any();

--- a/tests/unit/out/refcount/fn_ptr_struct.rs
+++ b/tests/unit/out/refcount/fn_ptr_struct.rs
@@ -28,7 +28,23 @@ impl Default for Handler {
         }
     }
 }
-impl ByteRepr for Handler {}
+impl ByteRepr for Handler {
+    fn byte_size() -> usize {
+        16
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.tag.borrow()).to_bytes(&mut buf[0..4]);
+        (*self.cb.borrow()).to_bytes(&mut buf[8..16]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            tag: Rc::new(RefCell::new(<i32>::from_bytes(&buf[0..4]))),
+            cb: Rc::new(RefCell::new(<FnPtr<fn(i32) -> i32>>::from_bytes(
+                &buf[8..16],
+            ))),
+        }
+    }
+}
 pub fn double_it_0(x: i32) -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(x));
     return ((*x.borrow()) * 2);

--- a/tests/unit/out/refcount/fn_ptr_vtable.rs
+++ b/tests/unit/out/refcount/fn_ptr_vtable.rs
@@ -31,7 +31,27 @@ impl Default for Vtable {
         }
     }
 }
-impl ByteRepr for Vtable {}
+impl ByteRepr for Vtable {
+    fn byte_size() -> usize {
+        24
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.create.borrow()).to_bytes(&mut buf[0..8]);
+        (*self.get.borrow()).to_bytes(&mut buf[8..16]);
+        (*self.destroy.borrow()).to_bytes(&mut buf[16..24]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            create: Rc::new(RefCell::new(<FnPtr<fn(i32) -> AnyPtr>>::from_bytes(
+                &buf[0..8],
+            ))),
+            get: Rc::new(RefCell::new(<FnPtr<fn(AnyPtr) -> i32>>::from_bytes(
+                &buf[8..16],
+            ))),
+            destroy: Rc::new(RefCell::new(<FnPtr<fn(AnyPtr)>>::from_bytes(&buf[16..24]))),
+        }
+    }
+}
 thread_local!(
     pub static storage_0: Value<i32> = <Value<i32>>::default();
 );

--- a/tests/unit/out/refcount/global_pointers.rs
+++ b/tests/unit/out/refcount/global_pointers.rs
@@ -20,7 +20,21 @@ impl Clone for Entry {
         this
     }
 }
-impl ByteRepr for Entry {}
+impl ByteRepr for Entry {
+    fn byte_size() -> usize {
+        16
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.name.borrow()).to_bytes(&mut buf[0..8]);
+        (*self.p.borrow()).to_bytes(&mut buf[8..16]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            name: Rc::new(RefCell::new(<Ptr<u8>>::from_bytes(&buf[0..8]))),
+            p: Rc::new(RefCell::new(<Ptr<i32>>::from_bytes(&buf[8..16]))),
+        }
+    }
+}
 thread_local!(
     pub static single_entry_0: Value<Entry> = Rc::new(RefCell::new(Entry {
         name: Rc::new(RefCell::new(Ptr::from_string_literal(b"alone"))),

--- a/tests/unit/out/refcount/huffman.rs
+++ b/tests/unit/out/refcount/huffman.rs
@@ -29,7 +29,25 @@ impl Clone for MinHeapNode {
         this
     }
 }
-impl ByteRepr for MinHeapNode {}
+impl ByteRepr for MinHeapNode {
+    fn byte_size() -> usize {
+        24
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.data.borrow()).to_bytes(&mut buf[0..1]);
+        (*self.freq.borrow()).to_bytes(&mut buf[4..8]);
+        (*self.left.borrow()).to_bytes(&mut buf[8..16]);
+        (*self.right.borrow()).to_bytes(&mut buf[16..24]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            data: Rc::new(RefCell::new(<u8>::from_bytes(&buf[0..1]))),
+            freq: Rc::new(RefCell::new(<i32>::from_bytes(&buf[4..8]))),
+            left: Rc::new(RefCell::new(<Ptr<MinHeapNode>>::from_bytes(&buf[8..16]))),
+            right: Rc::new(RefCell::new(<Ptr<MinHeapNode>>::from_bytes(&buf[16..24]))),
+        }
+    }
+}
 pub fn Swap_0(a: Ptr<MinHeapNode>, b: Ptr<MinHeapNode>) {
     let t: Value<MinHeapNode> = Rc::new(RefCell::new(MinHeapNode {
         data: Rc::new(RefCell::new((*(*a.upgrade().deref()).data.borrow()))),

--- a/tests/unit/out/refcount/linked_list.rs
+++ b/tests/unit/out/refcount/linked_list.rs
@@ -26,7 +26,21 @@ impl Clone for Node {
         this
     }
 }
-impl ByteRepr for Node {}
+impl ByteRepr for Node {
+    fn byte_size() -> usize {
+        16
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.val.borrow()).to_bytes(&mut buf[0..4]);
+        (*self.next.borrow()).to_bytes(&mut buf[8..16]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            val: Rc::new(RefCell::new(<i32>::from_bytes(&buf[0..4]))),
+            next: Rc::new(RefCell::new(<Ptr<Node>>::from_bytes(&buf[8..16]))),
+        }
+    }
+}
 pub fn Find_0(head: Ptr<Node>, idx: i32) -> Ptr<Node> {
     let head: Value<Ptr<Node>> = Rc::new(RefCell::new(head));
     let idx: Value<i32> = Rc::new(RefCell::new(idx));

--- a/tests/unit/out/refcount/new_bst.rs
+++ b/tests/unit/out/refcount/new_bst.rs
@@ -22,7 +22,23 @@ impl Clone for node_t {
         this
     }
 }
-impl ByteRepr for node_t {}
+impl ByteRepr for node_t {
+    fn byte_size() -> usize {
+        24
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.left.borrow()).to_bytes(&mut buf[0..8]);
+        (*self.right.borrow()).to_bytes(&mut buf[8..16]);
+        (*self.value.borrow()).to_bytes(&mut buf[16..20]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            left: Rc::new(RefCell::new(<Ptr<node_t>>::from_bytes(&buf[0..8]))),
+            right: Rc::new(RefCell::new(<Ptr<node_t>>::from_bytes(&buf[8..16]))),
+            value: Rc::new(RefCell::new(<i32>::from_bytes(&buf[16..20]))),
+        }
+    }
+}
 pub fn find_0(node: Ptr<node_t>, value: i32) -> Ptr<node_t> {
     let node: Value<Ptr<node_t>> = Rc::new(RefCell::new(node));
     let value: Value<i32> = Rc::new(RefCell::new(value));

--- a/tests/unit/out/refcount/opaque_forward_decl.rs
+++ b/tests/unit/out/refcount/opaque_forward_decl.rs
@@ -11,7 +11,21 @@ pub struct container {
     pub p: Value<Ptr<opaque>>,
     pub x: Value<i32>,
 }
-impl ByteRepr for container {}
+impl ByteRepr for container {
+    fn byte_size() -> usize {
+        16
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.p.borrow()).to_bytes(&mut buf[0..8]);
+        (*self.x.borrow()).to_bytes(&mut buf[8..12]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            p: Rc::new(RefCell::new(<Ptr<opaque>>::from_bytes(&buf[0..8]))),
+            x: Rc::new(RefCell::new(<i32>::from_bytes(&buf[8..12]))),
+        }
+    }
+}
 pub fn main() {
     std::process::exit(main_0());
 }

--- a/tests/unit/out/refcount/opaque_then_defined.rs
+++ b/tests/unit/out/refcount/opaque_then_defined.rs
@@ -11,13 +11,41 @@ pub struct list {
     pub head: Value<Ptr<node>>,
     pub size: Value<i32>,
 }
-impl ByteRepr for list {}
+impl ByteRepr for list {
+    fn byte_size() -> usize {
+        16
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.head.borrow()).to_bytes(&mut buf[0..8]);
+        (*self.size.borrow()).to_bytes(&mut buf[8..12]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            head: Rc::new(RefCell::new(<Ptr<node>>::from_bytes(&buf[0..8]))),
+            size: Rc::new(RefCell::new(<i32>::from_bytes(&buf[8..12]))),
+        }
+    }
+}
 #[derive(Default)]
 pub struct node {
     pub value: Value<i32>,
     pub next: Value<Ptr<node>>,
 }
-impl ByteRepr for node {}
+impl ByteRepr for node {
+    fn byte_size() -> usize {
+        16
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.value.borrow()).to_bytes(&mut buf[0..4]);
+        (*self.next.borrow()).to_bytes(&mut buf[8..16]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            value: Rc::new(RefCell::new(<i32>::from_bytes(&buf[0..4]))),
+            next: Rc::new(RefCell::new(<Ptr<node>>::from_bytes(&buf[8..16]))),
+        }
+    }
+}
 pub fn main() {
     std::process::exit(main_0());
 }

--- a/tests/unit/out/refcount/pointer_array.rs
+++ b/tests/unit/out/refcount/pointer_array.rs
@@ -29,7 +29,19 @@ impl Default for StackArray {
         }
     }
 }
-impl ByteRepr for StackArray {}
+impl ByteRepr for StackArray {
+    fn byte_size() -> usize {
+        24
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.arr.borrow()).to_bytes(&mut buf[0..24]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            arr: Rc::new(RefCell::new(<Box<[Ptr<i32>]>>::from_bytes(&buf[0..24]))),
+        }
+    }
+}
 pub fn IncrementAll_0(s: Ptr<StackArray>) {
     let i: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while ((*i.borrow()) < 3) {

--- a/tests/unit/out/refcount/push_emplace_back.rs
+++ b/tests/unit/out/refcount/push_emplace_back.rs
@@ -45,7 +45,21 @@ impl Clone for Writer {
         this
     }
 }
-impl ByteRepr for Writer {}
+impl ByteRepr for Writer {
+    fn byte_size() -> usize {
+        16
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.output.borrow()).to_bytes(&mut buf[0..8]);
+        (*self.chunk.borrow()).to_bytes(&mut buf[8..12]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            output: Rc::new(RefCell::new(<Ptr<Vec<Chunk>>>::from_bytes(&buf[0..8]))),
+            chunk: Rc::new(RefCell::new(<Chunk>::from_bytes(&buf[8..12]))),
+        }
+    }
+}
 #[derive(Default)]
 pub struct JPEGData {
     pub com_data: Value<Vec<Value<Vec<u8>>>>,

--- a/tests/unit/out/refcount/union_tagged_many_arms.rs
+++ b/tests/unit/out/refcount/union_tagged_many_arms.rs
@@ -1,0 +1,156 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+enum Tag_enum {
+    #[default]
+    T_NUM_S = 0,
+    T_NUM_U = 1,
+    T_TEXT = 2,
+    T_FLOAT = 3,
+    T_REF = 4,
+}
+impl From<i32> for Tag_enum {
+    fn from(n: i32) -> Tag_enum {
+        match n {
+            0 => Tag_enum::T_NUM_S,
+            1 => Tag_enum::T_NUM_U,
+            2 => Tag_enum::T_TEXT,
+            3 => Tag_enum::T_FLOAT,
+            4 => Tag_enum::T_REF,
+            _ => panic!("invalid Tag_enum value: {}", n),
+        }
+    }
+}
+libcc2rs::impl_enum_inc_dec!(Tag_enum);
+impl ByteRepr for Tag_enum {
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self as i32).to_bytes(buf);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        <Tag_enum>::from(i32::from_bytes(buf))
+    }
+}
+pub struct anon_0 {
+    __bytes: Value<Box<[u8]>>,
+}
+impl anon_0 {
+    pub fn text(&self) -> Ptr<Ptr<u8>> {
+        (self.__bytes.as_pointer() as Ptr<u8>).reinterpret_cast()
+    }
+    pub fn handle(&self) -> Ptr<AnyPtr> {
+        (self.__bytes.as_pointer() as Ptr<u8>).reinterpret_cast()
+    }
+    pub fn signed_n(&self) -> Ptr<i64> {
+        (self.__bytes.as_pointer() as Ptr<u8>).reinterpret_cast()
+    }
+    pub fn unsigned_n(&self) -> Ptr<u64> {
+        (self.__bytes.as_pointer() as Ptr<u8>).reinterpret_cast()
+    }
+    pub fn f(&self) -> Ptr<f64> {
+        (self.__bytes.as_pointer() as Ptr<u8>).reinterpret_cast()
+    }
+}
+impl Clone for anon_0 {
+    fn clone(&self) -> Self {
+        anon_0 {
+            __bytes: Rc::new(RefCell::new(self.__bytes.borrow().clone())),
+        }
+    }
+}
+impl Default for anon_0 {
+    fn default() -> Self {
+        anon_0 {
+            __bytes: Rc::new(RefCell::new(Box::from([0u8; 8]))),
+        }
+    }
+}
+impl ByteRepr for anon_0 {
+    fn byte_size() -> usize {
+        8
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        buf.copy_from_slice(&self.__bytes.borrow());
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        anon_0 {
+            __bytes: Rc::new(RefCell::new(Box::from(buf))),
+        }
+    }
+}
+#[derive(Default)]
+pub struct Slot {
+    pub tag: Value<Tag_enum>,
+    pub payload: Value<anon_0>,
+}
+impl ByteRepr for Slot {
+    fn byte_size() -> usize {
+        16
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.tag.borrow()).to_bytes(&mut buf[0..4]);
+        (*self.payload.borrow()).to_bytes(&mut buf[8..16]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            tag: Rc::new(RefCell::new(<Tag_enum>::from_bytes(&buf[0..4]))),
+            payload: Rc::new(RefCell::new(<anon_0>::from_bytes(&buf[8..16]))),
+        }
+    }
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let a: Value<Slot> = <Value<Slot>>::default();
+    (*(*a.borrow()).tag.borrow_mut()) = Tag_enum::T_NUM_S;
+    (*(*a.borrow()).payload.borrow_mut())
+        .signed_n()
+        .write((-7_i32 as i64));
+    assert!(
+        (((((*(*a.borrow()).payload.borrow()).signed_n().read()) == (-7_i32 as i64)) as i32) != 0)
+    );
+    let b: Value<Slot> = <Value<Slot>>::default();
+    (*(*b.borrow()).tag.borrow_mut()) = Tag_enum::T_NUM_U;
+    (*(*b.borrow()).payload.borrow_mut())
+        .unsigned_n()
+        .write(3735928559_u64);
+    assert!(
+        (((((*(*b.borrow()).payload.borrow()).unsigned_n().read()) == 3735928559_u64) as i32) != 0)
+    );
+    let c: Value<Slot> = <Value<Slot>>::default();
+    (*(*c.borrow()).tag.borrow_mut()) = Tag_enum::T_TEXT;
+    (*(*c.borrow()).payload.borrow_mut())
+        .text()
+        .write((Ptr::from_string_literal(b"hello")).clone());
+    assert!(
+        (((((((*(*c.borrow()).payload.borrow()).text().read())
+            .offset((0) as isize)
+            .read()) as i32)
+            == ('h' as i32)) as i32)
+            != 0)
+    );
+    let d: Value<Slot> = <Value<Slot>>::default();
+    (*(*d.borrow()).tag.borrow_mut()) = Tag_enum::T_FLOAT;
+    (*(*d.borrow()).payload.borrow_mut()).f().write(1.5E+0);
+    assert!((((((*(*d.borrow()).payload.borrow()).f().read()) == 1.5E+0) as i32) != 0));
+    let x: Value<i32> = Rc::new(RefCell::new(0));
+    let e: Value<Slot> = <Value<Slot>>::default();
+    (*(*e.borrow()).tag.borrow_mut()) = Tag_enum::T_REF;
+    (*(*e.borrow()).payload.borrow_mut())
+        .handle()
+        .write(((x.as_pointer()) as Ptr<i32>).to_any());
+    assert!(
+        ((({
+            let _lhs = ((*(*e.borrow()).payload.borrow()).handle().read()).clone();
+            _lhs == ((x.as_pointer()) as Ptr<i32>).to_any()
+        }) as i32)
+            != 0)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/union_tagged_simple.rs
+++ b/tests/unit/out/refcount/union_tagged_simple.rs
@@ -1,0 +1,123 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+enum Kind_enum {
+    #[default]
+    KIND_NONE = 0,
+    KIND_DONE = 1,
+}
+impl From<i32> for Kind_enum {
+    fn from(n: i32) -> Kind_enum {
+        match n {
+            0 => Kind_enum::KIND_NONE,
+            1 => Kind_enum::KIND_DONE,
+            _ => panic!("invalid Kind_enum value: {}", n),
+        }
+    }
+}
+libcc2rs::impl_enum_inc_dec!(Kind_enum);
+impl ByteRepr for Kind_enum {
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self as i32).to_bytes(buf);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        <Kind_enum>::from(i32::from_bytes(buf))
+    }
+}
+pub struct anon_0 {
+    __bytes: Value<Box<[u8]>>,
+}
+impl anon_0 {
+    pub fn obj(&self) -> Ptr<AnyPtr> {
+        (self.__bytes.as_pointer() as Ptr<u8>).reinterpret_cast()
+    }
+    pub fn code(&self) -> Ptr<i32> {
+        (self.__bytes.as_pointer() as Ptr<u8>).reinterpret_cast()
+    }
+}
+impl Clone for anon_0 {
+    fn clone(&self) -> Self {
+        anon_0 {
+            __bytes: Rc::new(RefCell::new(self.__bytes.borrow().clone())),
+        }
+    }
+}
+impl Default for anon_0 {
+    fn default() -> Self {
+        anon_0 {
+            __bytes: Rc::new(RefCell::new(Box::from([0u8; 8]))),
+        }
+    }
+}
+impl ByteRepr for anon_0 {
+    fn byte_size() -> usize {
+        8
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        buf.copy_from_slice(&self.__bytes.borrow());
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        anon_0 {
+            __bytes: Rc::new(RefCell::new(Box::from(buf))),
+        }
+    }
+}
+#[derive(Default)]
+pub struct Event {
+    pub kind: Value<Kind_enum>,
+    pub handle: Value<AnyPtr>,
+    pub payload: Value<anon_0>,
+}
+impl ByteRepr for Event {
+    fn byte_size() -> usize {
+        24
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.kind.borrow()).to_bytes(&mut buf[0..4]);
+        (*self.handle.borrow()).to_bytes(&mut buf[8..16]);
+        (*self.payload.borrow()).to_bytes(&mut buf[16..24]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            kind: Rc::new(RefCell::new(<Kind_enum>::from_bytes(&buf[0..4]))),
+            handle: Rc::new(RefCell::new(<AnyPtr>::from_bytes(&buf[8..16]))),
+            payload: Rc::new(RefCell::new(<anon_0>::from_bytes(&buf[16..24]))),
+        }
+    }
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let dummy: Value<i32> = Rc::new(RefCell::new(0));
+    let m1: Value<Event> = <Value<Event>>::default();
+    (*(*m1.borrow()).kind.borrow_mut()) = Kind_enum::KIND_DONE;
+    (*(*m1.borrow()).handle.borrow_mut()) = ((dummy.as_pointer()) as Ptr<i32>).to_any();
+    (*(*m1.borrow()).payload.borrow_mut()).code().write(42);
+    assert!(
+        (((((*(*m1.borrow()).kind.borrow()) as u32) == ((Kind_enum::KIND_DONE as i32) as u32))
+            as i32)
+            != 0)
+    );
+    assert!((((((*(*m1.borrow()).payload.borrow()).code().read()) == 42) as i32) != 0));
+    let m2: Value<Event> = <Value<Event>>::default();
+    (*(*m2.borrow()).kind.borrow_mut()) = Kind_enum::KIND_NONE;
+    (*(*m2.borrow()).handle.borrow_mut()) = ((dummy.as_pointer()) as Ptr<i32>).to_any();
+    (*(*m2.borrow()).payload.borrow_mut())
+        .obj()
+        .write(((dummy.as_pointer()) as Ptr<i32>).to_any());
+    assert!(
+        ((({
+            let _lhs = ((*(*m2.borrow()).payload.borrow()).obj().read()).clone();
+            _lhs == ((dummy.as_pointer()) as Ptr<i32>).to_any()
+        }) as i32)
+            != 0)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/union_tagged_struct_arms.rs
+++ b/tests/unit/out/refcount/union_tagged_struct_arms.rs
@@ -38,7 +38,23 @@ pub struct anon_1 {
     pub count: Value<i64>,
     pub cursor: Value<i64>,
 }
-impl ByteRepr for anon_1 {}
+impl ByteRepr for anon_1 {
+    fn byte_size() -> usize {
+        24
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.items.borrow()).to_bytes(&mut buf[0..8]);
+        (*self.count.borrow()).to_bytes(&mut buf[8..16]);
+        (*self.cursor.borrow()).to_bytes(&mut buf[16..24]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            items: Rc::new(RefCell::new(<Ptr<Ptr<u8>>>::from_bytes(&buf[0..8]))),
+            count: Rc::new(RefCell::new(<i64>::from_bytes(&buf[8..16]))),
+            cursor: Rc::new(RefCell::new(<i64>::from_bytes(&buf[16..24]))),
+        }
+    }
+}
 #[derive(Default)]
 pub struct anon_2 {
     pub lo: Value<i32>,

--- a/tests/unit/out/refcount/union_void_ptr_sized_deref.rs
+++ b/tests/unit/out/refcount/union_void_ptr_sized_deref.rs
@@ -1,0 +1,163 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+enum Width_enum {
+    #[default]
+    W_64 = 0,
+    W_32 = 1,
+    W_16 = 2,
+}
+impl From<i32> for Width_enum {
+    fn from(n: i32) -> Width_enum {
+        match n {
+            0 => Width_enum::W_64,
+            1 => Width_enum::W_32,
+            2 => Width_enum::W_16,
+            _ => panic!("invalid Width_enum value: {}", n),
+        }
+    }
+}
+libcc2rs::impl_enum_inc_dec!(Width_enum);
+impl ByteRepr for Width_enum {
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self as i32).to_bytes(buf);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        <Width_enum>::from(i32::from_bytes(buf))
+    }
+}
+pub struct anon_0 {
+    __bytes: Value<Box<[u8]>>,
+}
+impl anon_0 {
+    pub fn text(&self) -> Ptr<Ptr<u8>> {
+        (self.__bytes.as_pointer() as Ptr<u8>).reinterpret_cast()
+    }
+    pub fn handle(&self) -> Ptr<AnyPtr> {
+        (self.__bytes.as_pointer() as Ptr<u8>).reinterpret_cast()
+    }
+    pub fn signed_n(&self) -> Ptr<i64> {
+        (self.__bytes.as_pointer() as Ptr<u8>).reinterpret_cast()
+    }
+    pub fn f(&self) -> Ptr<f64> {
+        (self.__bytes.as_pointer() as Ptr<u8>).reinterpret_cast()
+    }
+}
+impl Clone for anon_0 {
+    fn clone(&self) -> Self {
+        anon_0 {
+            __bytes: Rc::new(RefCell::new(self.__bytes.borrow().clone())),
+        }
+    }
+}
+impl Default for anon_0 {
+    fn default() -> Self {
+        anon_0 {
+            __bytes: Rc::new(RefCell::new(Box::from([0u8; 8]))),
+        }
+    }
+}
+impl ByteRepr for anon_0 {
+    fn byte_size() -> usize {
+        8
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        buf.copy_from_slice(&self.__bytes.borrow());
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        anon_0 {
+            __bytes: Rc::new(RefCell::new(Box::from(buf))),
+        }
+    }
+}
+#[derive(Default)]
+pub struct Sink {
+    pub width: Value<Width_enum>,
+    pub out: Value<anon_0>,
+}
+impl ByteRepr for Sink {
+    fn byte_size() -> usize {
+        16
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.width.borrow()).to_bytes(&mut buf[0..4]);
+        (*self.out.borrow()).to_bytes(&mut buf[8..16]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            width: Rc::new(RefCell::new(<Width_enum>::from_bytes(&buf[0..4]))),
+            out: Rc::new(RefCell::new(<anon_0>::from_bytes(&buf[8..16]))),
+        }
+    }
+}
+pub fn write_count_1(s: Ptr<Sink>, count: i64) {
+    let s: Value<Ptr<Sink>> = Rc::new(RefCell::new(s));
+    let count: Value<i64> = Rc::new(RefCell::new(count));
+    'switch: {
+        let __match_cond = ((*(*(*s.borrow()).upgrade().deref()).width.borrow()) as u32);
+        match __match_cond {
+            __v if __v == ((Width_enum::W_64 as i32) as u32) => {
+                ((*(*(*s.borrow()).upgrade().deref()).out.borrow())
+                    .handle()
+                    .read())
+                .cast::<i64>()
+                .expect("ub:wrong type")
+                .write((*count.borrow()));
+                break 'switch;
+            }
+            __v if __v == ((Width_enum::W_32 as i32) as u32) => {
+                ((*(*(*s.borrow()).upgrade().deref()).out.borrow())
+                    .handle()
+                    .read())
+                .cast::<i32>()
+                .expect("ub:wrong type")
+                .write(((*count.borrow()) as i32));
+                break 'switch;
+            }
+            __v if __v == ((Width_enum::W_16 as i32) as u32) => {
+                ((*(*(*s.borrow()).upgrade().deref()).out.borrow())
+                    .handle()
+                    .read())
+                .cast::<i16>()
+                .expect("ub:wrong type")
+                .write(((*count.borrow()) as i16));
+                break 'switch;
+            }
+            _ => {}
+        }
+    };
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let buf64: Value<i64> = Rc::new(RefCell::new(0_i64));
+    let buf32: Value<i32> = Rc::new(RefCell::new(0));
+    let buf16: Value<i16> = Rc::new(RefCell::new(0_i16));
+    let s: Value<Sink> = <Value<Sink>>::default();
+    (*(*s.borrow()).width.borrow_mut()) = Width_enum::W_64;
+    (*(*s.borrow()).out.borrow_mut())
+        .handle()
+        .write(((buf64.as_pointer()) as Ptr<i64>).to_any());
+    ({ write_count_1((s.as_pointer()), 1234605616436508552_i64) });
+    assert!(((((*buf64.borrow()) == 1234605616436508552_i64) as i32) != 0));
+    (*(*s.borrow()).width.borrow_mut()) = Width_enum::W_32;
+    (*(*s.borrow()).out.borrow_mut())
+        .handle()
+        .write(((buf32.as_pointer()) as Ptr<i32>).to_any());
+    ({ write_count_1((s.as_pointer()), 305419896_i64) });
+    assert!(((((*buf32.borrow()) == 305419896) as i32) != 0));
+    (*(*s.borrow()).width.borrow_mut()) = Width_enum::W_16;
+    (*(*s.borrow()).out.borrow_mut())
+        .handle()
+        .write(((buf16.as_pointer()) as Ptr<i16>).to_any());
+    ({ write_count_1((s.as_pointer()), 4660_i64) });
+    assert!((((((*buf16.borrow()) as i32) == 4660) as i32) != 0));
+    return 0;
+}

--- a/tests/unit/out/refcount/va_arg_non_primitive_ptrs.rs
+++ b/tests/unit/out/refcount/va_arg_non_primitive_ptrs.rs
@@ -11,7 +11,21 @@ pub struct node {
     pub data: Value<i32>,
     pub next: Value<Ptr<node>>,
 }
-impl ByteRepr for node {}
+impl ByteRepr for node {
+    fn byte_size() -> usize {
+        16
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.data.borrow()).to_bytes(&mut buf[0..4]);
+        (*self.next.borrow()).to_bytes(&mut buf[8..16]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            data: Rc::new(RefCell::new(<i32>::from_bytes(&buf[0..4]))),
+            next: Rc::new(RefCell::new(<Ptr<node>>::from_bytes(&buf[8..16]))),
+        }
+    }
+}
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 enum opt {
     #[default]

--- a/tests/unit/union_tagged_many_arms.c
+++ b/tests/unit/union_tagged_many_arms.c
@@ -1,4 +1,4 @@
-// no-compile: refcount
+// panic: refcount
 #include <assert.h>
 #include <stdint.h>
 

--- a/tests/unit/union_tagged_simple.c
+++ b/tests/unit/union_tagged_simple.c
@@ -1,4 +1,4 @@
-// no-compile: refcount
+// panic: refcount
 #include <assert.h>
 
 typedef enum {

--- a/tests/unit/union_void_ptr_sized_deref.c
+++ b/tests/unit/union_void_ptr_sized_deref.c
@@ -1,4 +1,4 @@
-// no-compile: refcount
+// panic: refcount
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>


### PR DESCRIPTION
This just adds panic'ing implementations for Ptr and AnyPtr so that some tests move from no-compile to panic and adds the ByteRepr boilerplate where needed.

It will make the PR with the real ByteRepr implementatoin for Ptr and AnyPtr smaller.