### PR TITLE
Add safe fdset macros rules

### DIFF
--- a/libcc2rs/src/libc_shims/fdset.rs
+++ b/libcc2rs/src/libc_shims/fdset.rs
@@ -1,0 +1,26 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+use std::collections::BTreeSet;
+
+#[derive(Clone, Default)]
+pub struct CFdSet {
+    fds: BTreeSet<i32>,
+}
+
+impl crate::ByteRepr for CFdSet {}
+
+impl CFdSet {
+    pub fn zero(&mut self) {
+        self.fds.clear();
+    }
+    pub fn set(&mut self, fd: i32) {
+        self.fds.insert(fd);
+    }
+    pub fn clr(&mut self, fd: i32) {
+        self.fds.remove(&fd);
+    }
+    pub fn isset(&self, fd: i32) -> bool {
+        self.fds.contains(&fd)
+    }
+}

--- a/libcc2rs/src/libc_shims/mod.rs
+++ b/libcc2rs/src/libc_shims/mod.rs
@@ -2,6 +2,7 @@
 // Distributed under the MIT license that can be found in the LICENSE file.
 
 mod dirent;
+mod fdset;
 mod ifaddrs;
 mod ip;
 mod netdb;
@@ -13,6 +14,7 @@ mod termios;
 mod time;
 
 pub use dirent::*;
+pub use fdset::*;
 pub use ifaddrs::*;
 pub use ip::*;
 pub use netdb::*;

--- a/rules/select/tgt_refcount.rs
+++ b/rules/select/tgt_refcount.rs
@@ -1,0 +1,24 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+use libcc2rs::*;
+
+fn t1() -> CFdSet {
+    Default::default()
+}
+
+fn f2(a0: i32, a1: Ptr<CFdSet>) {
+    a1.with_mut(|__s| __s.set(a0));
+}
+
+fn f3(a0: i32, a1: Ptr<CFdSet>) {
+    a1.with_mut(|__s| __s.clr(a0));
+}
+
+fn f4(a0: i32, a1: Ptr<CFdSet>) -> i32 {
+    if a1.with(|__s| __s.isset(a0)) { 1 } else { 0 }
+}
+
+fn f5(a0: Ptr<CFdSet>) {
+    a0.with_mut(|__s| __s.zero());
+}

--- a/rules/src/modules.rs
+++ b/rules/src/modules.rs
@@ -112,6 +112,8 @@ pub mod pwd_tgt_refcount;
 pub mod pwd_tgt_unsafe;
 #[path = r#"../rustls/tgt_unsafe.rs"#]
 pub mod rustls_tgt_unsafe;
+#[path = r#"../select/tgt_refcount.rs"#]
+pub mod select_tgt_refcount;
 #[path = r#"../select/tgt_unsafe.rs"#]
 pub mod select_tgt_unsafe;
 #[path = r#"../signal/tgt_unsafe.rs"#]

--- a/tests/unit/fd_set_macros.c
+++ b/tests/unit/fd_set_macros.c
@@ -1,4 +1,3 @@
-// no-compile: refcount
 #include <assert.h>
 #include <sys/select.h>
 

--- a/tests/unit/out/refcount/fd_set_macros.rs
+++ b/tests/unit/out/refcount/fd_set_macros.rs
@@ -1,0 +1,41 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let set: Value<CFdSet> = Rc::new(RefCell::new(Default::default()));
+    (set.as_pointer()).with_mut(|__s| __s.zero());
+    assert!(
+        ((!(if (set.as_pointer()).with(|__s| __s.isset(3)) {
+            1
+        } else {
+            0
+        } != 0) as i32)
+            != 0)
+    );
+    (set.as_pointer()).with_mut(|__s| __s.set(3));
+    assert!(
+        (if (set.as_pointer()).with(|__s| __s.isset(3)) {
+            1
+        } else {
+            0
+        } != 0)
+    );
+    (set.as_pointer()).with_mut(|__s| __s.clr(3));
+    assert!(
+        ((!(if (set.as_pointer()).with(|__s| __s.isset(3)) {
+            1
+        } else {
+            0
+        } != 0) as i32)
+            != 0)
+    );
+    return 0;
+}


### PR DESCRIPTION
Nix also contains a FdSet, but its semantics are too strict for mechanical translation: https://docs.rs/nix/latest/nix/sys/select/struct.FdSet.html

nix::FdSet has lifetime attached and the methods insert/remove/etc take a BorrowedFd, not a raw integer. This is too strict for the C semantics.

Instead, in C, you can modify the fd set in whichever way you want, and only a later call to select will validate if the fd set is in a valid state or not.

To fix this limitation I added CFdSet which behaves like the C version of fd set.