### PR TITLE
Add safe translation for open/read/write/close

### DIFF
--- a/libcc2rs/src/fd.rs
+++ b/libcc2rs/src/fd.rs
@@ -1,0 +1,52 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+use std::cell::RefCell;
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
+
+pub struct FdRegistry {
+    fds: Vec<Option<OwnedFd>>,
+}
+
+thread_local! {
+    static FD_REGISTRY: RefCell<FdRegistry> = const { RefCell::new(FdRegistry { fds: Vec::new() }) };
+}
+
+impl FdRegistry {
+    pub fn register(fd: OwnedFd) -> i32 {
+        let raw = fd.as_raw_fd();
+        FD_REGISTRY.with(|r| {
+            let fds = &mut r.borrow_mut().fds;
+            let idx = raw as usize;
+            if fds.len() <= idx {
+                fds.resize_with(idx + 1, || None);
+            }
+            assert!(fds[idx].is_none(), "ub: fd registry collision on fd {raw}");
+            fds[idx] = Some(fd);
+        });
+        raw
+    }
+
+    pub fn with_fd<R>(fd: i32, f: impl FnOnce(BorrowedFd<'_>) -> R) -> R {
+        FD_REGISTRY.with(|r| {
+            let reg = r.borrow();
+            let owned = reg
+                .fds
+                .get(fd as usize)
+                .and_then(|slot| slot.as_ref())
+                .unwrap_or_else(|| panic!("ub: bad fd {fd}"));
+            f(owned.as_fd())
+        })
+    }
+
+    pub fn close(fd: i32) -> i32 {
+        FD_REGISTRY.with(|r| {
+            r.borrow_mut()
+                .fds
+                .get_mut(fd as usize)
+                .and_then(|slot| slot.take())
+                .unwrap_or_else(|| panic!("ub: bad fd {fd}"))
+        });
+        0
+    }
+}

--- a/libcc2rs/src/lib.rs
+++ b/libcc2rs/src/lib.rs
@@ -37,4 +37,7 @@ pub use compat::*;
 mod va_args;
 pub use va_args::*;
 
+mod fd;
+pub use fd::*;
+
 pub use libcc2rs_macros::{goto, goto_block, switch};

--- a/rules/fcntl/src.cpp
+++ b/rules/fcntl/src.cpp
@@ -12,3 +12,13 @@ template <typename... Args>
 int f2(const char *a0, int a1, Args... args) {
   return open(a0, a1, args...);
 }
+
+int f3(void) { return O_CREAT; }
+int f4(void) { return O_TRUNC; }
+int f5(void) { return O_APPEND; }
+int f6(void) { return O_EXCL; }
+int f7(void) { return O_NONBLOCK; }
+int f8(void) { return O_CLOEXEC; }
+int f9(void) { return O_RDONLY; }
+int f10(void) { return O_WRONLY; }
+int f11(void) { return O_RDWR; }

--- a/rules/fcntl/tgt_refcount.rs
+++ b/rules/fcntl/tgt_refcount.rs
@@ -13,10 +13,19 @@ fn f1(a0: i32, a1: i32, va: &[VaArg]) -> i32 {
 }
 
 fn f2(a0: Ptr<u8>, a1: i32, va: &[VaArg]) -> i32 {
-    panic!(
-        "open is not supported in the refcount model (path={:?}, flags={}, varargs={})",
-        a0.to_rust_string(),
-        a1,
-        va.len()
-    )
+    let __mode = match va.first() {
+        Some(__m) => nix::sys::stat::Mode::from_bits_truncate(i32::get(__m) as ::libc::mode_t),
+        None => nix::sys::stat::Mode::empty(),
+    };
+    match nix::fcntl::open(
+        a0.to_rust_string().as_str(),
+        nix::fcntl::OFlag::from_bits_retain(a1),
+        __mode,
+    ) {
+        Ok(__ofd) => FdRegistry::register(__ofd),
+        Err(__e) => {
+            libcc2rs::cpp2rust_errno().write(__e as i32);
+            -1
+        }
+    }
 }

--- a/rules/fcntl/tgt_refcount.rs
+++ b/rules/fcntl/tgt_refcount.rs
@@ -29,3 +29,39 @@ fn f2(a0: Ptr<u8>, a1: i32, va: &[VaArg]) -> i32 {
         }
     }
 }
+
+fn f3() -> i32 {
+    ::libc::O_CREAT
+}
+
+fn f4() -> i32 {
+    ::libc::O_TRUNC
+}
+
+fn f5() -> i32 {
+    ::libc::O_APPEND
+}
+
+fn f6() -> i32 {
+    ::libc::O_EXCL
+}
+
+fn f7() -> i32 {
+    ::libc::O_NONBLOCK
+}
+
+fn f8() -> i32 {
+    ::libc::O_CLOEXEC
+}
+
+fn f9() -> i32 {
+    ::libc::O_RDONLY
+}
+
+fn f10() -> i32 {
+    ::libc::O_WRONLY
+}
+
+fn f11() -> i32 {
+    ::libc::O_RDWR
+}

--- a/rules/fcntl/tgt_unsafe.rs
+++ b/rules/fcntl/tgt_unsafe.rs
@@ -5,3 +5,39 @@ unsafe extern "C" {
     fn f1(a0: i32, a1: i32, ...) -> i32;
     fn f2(a0: *const i8, a1: i32, ...) -> i32;
 }
+
+unsafe fn f3() -> i32 {
+    ::libc::O_CREAT
+}
+
+unsafe fn f4() -> i32 {
+    ::libc::O_TRUNC
+}
+
+unsafe fn f5() -> i32 {
+    ::libc::O_APPEND
+}
+
+unsafe fn f6() -> i32 {
+    ::libc::O_EXCL
+}
+
+unsafe fn f7() -> i32 {
+    ::libc::O_NONBLOCK
+}
+
+unsafe fn f8() -> i32 {
+    ::libc::O_CLOEXEC
+}
+
+unsafe fn f9() -> i32 {
+    ::libc::O_RDONLY
+}
+
+unsafe fn f10() -> i32 {
+    ::libc::O_WRONLY
+}
+
+unsafe fn f11() -> i32 {
+    ::libc::O_RDWR
+}

--- a/rules/unistd/tgt_refcount.rs
+++ b/rules/unistd/tgt_refcount.rs
@@ -3,6 +3,23 @@
 
 use libcc2rs::*;
 
+fn f1(a0: i32) -> i32 {
+    FdRegistry::close(a0)
+}
+
+fn f3(a0: i32, a1: AnyPtr, a2: usize) -> isize {
+    match FdRegistry::with_fd(a0, |__fd| {
+        a1.reinterpret_cast::<u8>()
+            .with_slice_mut(a2, |__buf| nix::unistd::read(__fd, __buf))
+    }) {
+        Ok(__n) => __n as isize,
+        Err(__e) => {
+            libcc2rs::cpp2rust_errno().write(__e as i32);
+            -1
+        }
+    }
+}
+
 fn f4(a0: Ptr<u8>) -> i32 {
     match nix::unistd::unlink(a0.to_rust_string().as_str()) {
         Ok(()) => 0,
@@ -30,6 +47,19 @@ fn f9(a0: Ptr<u8>, a1: usize) -> i32 {
             }
             0
         }
+        Err(__e) => {
+            libcc2rs::cpp2rust_errno().write(__e as i32);
+            -1
+        }
+    }
+}
+
+fn f10(a0: i32, a1: AnyPtr, a2: usize) -> isize {
+    match FdRegistry::with_fd(a0, |__fd| {
+        a1.reinterpret_cast::<u8>()
+            .with_slice(a2, |__buf| nix::unistd::write(__fd, __buf))
+    }) {
+        Ok(__n) => __n as isize,
         Err(__e) => {
             libcc2rs::cpp2rust_errno().write(__e as i32);
             -1

--- a/tests/ub/fd_close_invalid.c
+++ b/tests/ub/fd_close_invalid.c
@@ -1,0 +1,4 @@
+// panic-ub: refcount
+#include <unistd.h>
+
+int main(void) { return close(1234) == -1 ? 0 : 1; }

--- a/tests/ub/fd_double_close.c
+++ b/tests/ub/fd_double_close.c
@@ -1,0 +1,9 @@
+// panic-ub: refcount
+#include <fcntl.h>
+#include <unistd.h>
+
+int main(void) {
+  int fd = open("/dev/null", O_RDONLY);
+  close(fd);
+  return close(fd) == -1 ? 0 : 1;
+}

--- a/tests/ub/fd_use_after_close.c
+++ b/tests/ub/fd_use_after_close.c
@@ -1,0 +1,11 @@
+// panic-ub: refcount
+#include <fcntl.h>
+#include <unistd.h>
+
+int main(void) {
+  int fd = open("/dev/null", O_RDONLY);
+  close(fd);
+  char buf[4];
+  ssize_t n = read(fd, buf, sizeof(buf));
+  return n == -1 ? 0 : 1;
+}

--- a/tests/ub/out/refcount/fd_close_invalid.rs
+++ b/tests/ub/out/refcount/fd_close_invalid.rs
@@ -1,0 +1,18 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    return if (((FdRegistry::close(1234) == -1_i32) as i32) != 0) {
+        0
+    } else {
+        1
+    };
+}

--- a/tests/ub/out/refcount/fd_double_close.rs
+++ b/tests/ub/out/refcount/fd_double_close.rs
@@ -1,0 +1,38 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let fd: Value<i32> = Rc::new(RefCell::new({
+        let __mode = match &[].first() {
+            Some(__m) => nix::sys::stat::Mode::from_bits_truncate(i32::get(__m) as ::libc::mode_t),
+            None => nix::sys::stat::Mode::empty(),
+        };
+        match nix::fcntl::open(
+            Ptr::from_string_literal(b"/dev/null")
+                .to_rust_string()
+                .as_str(),
+            nix::fcntl::OFlag::from_bits_retain(0),
+            __mode,
+        ) {
+            Ok(__ofd) => FdRegistry::register(__ofd),
+            Err(__e) => {
+                libcc2rs::cpp2rust_errno().write(__e as i32);
+                -1
+            }
+        }
+    }));
+    FdRegistry::close((*fd.borrow()));
+    return if (((FdRegistry::close((*fd.borrow())) == -1_i32) as i32) != 0) {
+        0
+    } else {
+        1
+    };
+}

--- a/tests/ub/out/refcount/fd_double_close.rs
+++ b/tests/ub/out/refcount/fd_double_close.rs
@@ -19,7 +19,7 @@ fn main_0() -> i32 {
             Ptr::from_string_literal(b"/dev/null")
                 .to_rust_string()
                 .as_str(),
-            nix::fcntl::OFlag::from_bits_retain(0),
+            nix::fcntl::OFlag::from_bits_retain(::libc::O_RDONLY),
             __mode,
         ) {
             Ok(__ofd) => FdRegistry::register(__ofd),

--- a/tests/ub/out/refcount/fd_use_after_close.rs
+++ b/tests/ub/out/refcount/fd_use_after_close.rs
@@ -1,0 +1,57 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let fd: Value<i32> = Rc::new(RefCell::new({
+        let __mode = match &[].first() {
+            Some(__m) => nix::sys::stat::Mode::from_bits_truncate(i32::get(__m) as ::libc::mode_t),
+            None => nix::sys::stat::Mode::empty(),
+        };
+        match nix::fcntl::open(
+            Ptr::from_string_literal(b"/dev/null")
+                .to_rust_string()
+                .as_str(),
+            nix::fcntl::OFlag::from_bits_retain(0),
+            __mode,
+        ) {
+            Ok(__ofd) => FdRegistry::register(__ofd),
+            Err(__e) => {
+                libcc2rs::cpp2rust_errno().write(__e as i32);
+                -1
+            }
+        }
+    }));
+    FdRegistry::close((*fd.borrow()));
+    let buf: Value<Box<[u8]>> = Rc::new(RefCell::new(
+        (0..4).map(|_| <u8>::default()).collect::<Box<[u8]>>(),
+    ));
+    let n: Value<isize> = Rc::new(RefCell::new(
+        match FdRegistry::with_fd((*fd.borrow()), |__fd| {
+            ((buf.as_pointer() as Ptr<u8>) as Ptr<u8>)
+                .to_any()
+                .reinterpret_cast::<u8>()
+                .with_slice_mut(::std::mem::size_of::<[u8; 4]>(), |__buf| {
+                    nix::unistd::read(__fd, __buf)
+                })
+        }) {
+            Ok(__n) => __n as isize,
+            Err(__e) => {
+                libcc2rs::cpp2rust_errno().write(__e as i32);
+                -1
+            }
+        },
+    ));
+    return if ((((*n.borrow()) == (-1_i32 as isize)) as i32) != 0) {
+        0
+    } else {
+        1
+    };
+}

--- a/tests/ub/out/refcount/fd_use_after_close.rs
+++ b/tests/ub/out/refcount/fd_use_after_close.rs
@@ -19,7 +19,7 @@ fn main_0() -> i32 {
             Ptr::from_string_literal(b"/dev/null")
                 .to_rust_string()
                 .as_str(),
-            nix::fcntl::OFlag::from_bits_retain(0),
+            nix::fcntl::OFlag::from_bits_retain(::libc::O_RDONLY),
             __mode,
         ) {
             Ok(__ofd) => FdRegistry::register(__ofd),

--- a/tests/ub/out/unsafe/fd_close_invalid.rs
+++ b/tests/ub/out/unsafe/fd_close_invalid.rs
@@ -1,0 +1,20 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    return if ((((libc::close(1234)) == (-1_i32)) as i32) != 0) {
+        0
+    } else {
+        1
+    };
+}

--- a/tests/ub/out/unsafe/fd_double_close.rs
+++ b/tests/ub/out/unsafe/fd_double_close.rs
@@ -1,0 +1,27 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut fd: i32 = (unsafe {
+        libc::open(
+            (c"/dev/null".as_ptr().cast_mut()).cast_const() as *const i8,
+            0 as i32,
+        )
+    });
+    libc::close(fd);
+    return if ((((libc::close(fd)) == (-1_i32)) as i32) != 0) {
+        0
+    } else {
+        1
+    };
+}

--- a/tests/ub/out/unsafe/fd_double_close.rs
+++ b/tests/ub/out/unsafe/fd_double_close.rs
@@ -15,7 +15,7 @@ unsafe fn main_0() -> i32 {
     let mut fd: i32 = (unsafe {
         libc::open(
             (c"/dev/null".as_ptr().cast_mut()).cast_const() as *const i8,
-            0 as i32,
+            ::libc::O_RDONLY as i32,
         )
     });
     libc::close(fd);

--- a/tests/ub/out/unsafe/fd_use_after_close.rs
+++ b/tests/ub/out/unsafe/fd_use_after_close.rs
@@ -1,0 +1,33 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut fd: i32 = (unsafe {
+        libc::open(
+            (c"/dev/null".as_ptr().cast_mut()).cast_const() as *const i8,
+            0 as i32,
+        )
+    });
+    libc::close(fd);
+    let mut buf: [libc::c_char; 4] = [(0 as libc::c_char); 4];
+    let mut n: isize = libc::read(
+        fd,
+        (buf.as_mut_ptr() as *mut libc::c_char as *mut ::libc::c_void),
+        ::std::mem::size_of::<[libc::c_char; 4]>(),
+    );
+    return if ((((n) == (-1_i32 as isize)) as i32) != 0) {
+        0
+    } else {
+        1
+    };
+}

--- a/tests/ub/out/unsafe/fd_use_after_close.rs
+++ b/tests/ub/out/unsafe/fd_use_after_close.rs
@@ -15,7 +15,7 @@ unsafe fn main_0() -> i32 {
     let mut fd: i32 = (unsafe {
         libc::open(
             (c"/dev/null".as_ptr().cast_mut()).cast_const() as *const i8,
-            0 as i32,
+            ::libc::O_RDONLY as i32,
         )
     });
     libc::close(fd);

--- a/tests/unit/fd_io.c
+++ b/tests/unit/fd_io.c
@@ -1,0 +1,22 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(void) {
+  const char *path = "/tmp/cpp2rust_fd_io_test.tmp";
+  int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+  assert(fd >= 0);
+  assert(write(fd, "hello world", 11) == 11);
+  assert(close(fd) == 0);
+  fd = open(path, O_RDONLY);
+  assert(fd >= 0);
+  char buf[16];
+  memset(buf, 0, sizeof(buf));
+  assert(read(fd, buf, sizeof(buf)) == 11);
+  assert(strcmp(buf, "hello world") == 0);
+  assert(read(fd, buf, sizeof(buf)) == 0);
+  assert(close(fd) == 0);
+  assert(unlink(path) == 0);
+  return 0;
+}

--- a/tests/unit/out/refcount/fd_io.rs
+++ b/tests/unit/out/refcount/fd_io.rs
@@ -1,0 +1,140 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let path: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal(
+        b"/tmp/cpp2rust_fd_io_test.tmp",
+    )));
+    let fd: Value<i32> = Rc::new(RefCell::new({
+        let __mode = match &[(420).into()].first() {
+            Some(__m) => nix::sys::stat::Mode::from_bits_truncate(i32::get(__m) as ::libc::mode_t),
+            None => nix::sys::stat::Mode::empty(),
+        };
+        match nix::fcntl::open(
+            (*path.borrow()).to_rust_string().as_str(),
+            nix::fcntl::OFlag::from_bits_retain(((1 | 64) | 512)),
+            __mode,
+        ) {
+            Ok(__ofd) => FdRegistry::register(__ofd),
+            Err(__e) => {
+                libcc2rs::cpp2rust_errno().write(__e as i32);
+                -1
+            }
+        }
+    }));
+    assert!(((((*fd.borrow()) >= 0) as i32) != 0));
+    assert!(
+        (((match FdRegistry::with_fd((*fd.borrow()), |__fd| {
+            Ptr::from_string_literal(b"hello world")
+                .to_any()
+                .reinterpret_cast::<u8>()
+                .with_slice(11_usize, |__buf| nix::unistd::write(__fd, __buf))
+        }) {
+            Ok(__n) => __n as isize,
+            Err(__e) => {
+                libcc2rs::cpp2rust_errno().write(__e as i32);
+                -1
+            }
+        } == 11_isize) as i32)
+            != 0)
+    );
+    assert!((((FdRegistry::close((*fd.borrow())) == 0) as i32) != 0));
+    (*fd.borrow_mut()) = {
+        let __mode = match &[].first() {
+            Some(__m) => nix::sys::stat::Mode::from_bits_truncate(i32::get(__m) as ::libc::mode_t),
+            None => nix::sys::stat::Mode::empty(),
+        };
+        match nix::fcntl::open(
+            (*path.borrow()).to_rust_string().as_str(),
+            nix::fcntl::OFlag::from_bits_retain(0),
+            __mode,
+        ) {
+            Ok(__ofd) => FdRegistry::register(__ofd),
+            Err(__e) => {
+                libcc2rs::cpp2rust_errno().write(__e as i32);
+                -1
+            }
+        }
+    };
+    assert!(((((*fd.borrow()) >= 0) as i32) != 0));
+    let buf: Value<Box<[u8]>> = Rc::new(RefCell::new(
+        (0..16).map(|_| <u8>::default()).collect::<Box<[u8]>>(),
+    ));
+    {
+        ((buf.as_pointer() as Ptr<u8>) as Ptr<u8>)
+            .to_any()
+            .memset((0) as u8, ::std::mem::size_of::<[u8; 16]>() as usize);
+        ((buf.as_pointer() as Ptr<u8>) as Ptr<u8>).to_any().clone()
+    };
+    assert!(
+        (((match FdRegistry::with_fd((*fd.borrow()), |__fd| {
+            ((buf.as_pointer() as Ptr<u8>) as Ptr<u8>)
+                .to_any()
+                .reinterpret_cast::<u8>()
+                .with_slice_mut(::std::mem::size_of::<[u8; 16]>(), |__buf| {
+                    nix::unistd::read(__fd, __buf)
+                })
+        }) {
+            Ok(__n) => __n as isize,
+            Err(__e) => {
+                libcc2rs::cpp2rust_errno().write(__e as i32);
+                -1
+            }
+        } == 11_isize) as i32)
+            != 0)
+    );
+    assert!(
+        ((({
+            let mut __it1 = (buf.as_pointer() as Ptr<u8>).to_c_string_iterator();
+            let mut __it2 = Ptr::from_string_literal(b"hello world").to_c_string_iterator();
+            loop {
+                let __c1 = __it1.next();
+                let __c2 = __it2.next();
+                if __c1 != __c2 {
+                    break (__c1.unwrap_or(0) as i32) - (__c2.unwrap_or(0) as i32);
+                }
+                if __c1.is_none() {
+                    break 0;
+                }
+            }
+        } == 0) as i32)
+            != 0)
+    );
+    assert!(
+        (((match FdRegistry::with_fd((*fd.borrow()), |__fd| {
+            ((buf.as_pointer() as Ptr<u8>) as Ptr<u8>)
+                .to_any()
+                .reinterpret_cast::<u8>()
+                .with_slice_mut(::std::mem::size_of::<[u8; 16]>(), |__buf| {
+                    nix::unistd::read(__fd, __buf)
+                })
+        }) {
+            Ok(__n) => __n as isize,
+            Err(__e) => {
+                libcc2rs::cpp2rust_errno().write(__e as i32);
+                -1
+            }
+        } == 0_isize) as i32)
+            != 0)
+    );
+    assert!((((FdRegistry::close((*fd.borrow())) == 0) as i32) != 0));
+    assert!(
+        (((match nix::unistd::unlink((*path.borrow()).to_rust_string().as_str()) {
+            Ok(()) => 0,
+            Err(__e) => {
+                libcc2rs::cpp2rust_errno().write(__e as i32);
+                -1
+            }
+        } == 0) as i32)
+            != 0)
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/fd_io.rs
+++ b/tests/unit/out/refcount/fd_io.rs
@@ -20,7 +20,9 @@ fn main_0() -> i32 {
         };
         match nix::fcntl::open(
             (*path.borrow()).to_rust_string().as_str(),
-            nix::fcntl::OFlag::from_bits_retain(((1 | 64) | 512)),
+            nix::fcntl::OFlag::from_bits_retain(
+                ((::libc::O_WRONLY | ::libc::O_CREAT) | ::libc::O_TRUNC),
+            ),
             __mode,
         ) {
             Ok(__ofd) => FdRegistry::register(__ofd),
@@ -54,7 +56,7 @@ fn main_0() -> i32 {
         };
         match nix::fcntl::open(
             (*path.borrow()).to_rust_string().as_str(),
-            nix::fcntl::OFlag::from_bits_retain(0),
+            nix::fcntl::OFlag::from_bits_retain(::libc::O_RDONLY),
             __mode,
         ) {
             Ok(__ofd) => FdRegistry::register(__ofd),

--- a/tests/unit/out/unsafe/fd_io.rs
+++ b/tests/unit/out/unsafe/fd_io.rs
@@ -14,8 +14,13 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut path: *const libc::c_char =
         (c"/tmp/cpp2rust_fd_io_test.tmp".as_ptr().cast_mut()).cast_const();
-    let mut fd: i32 =
-        (unsafe { libc::open(path as *const i8, (((1) | (64)) | (512)) as i32, (420)) });
+    let mut fd: i32 = (unsafe {
+        libc::open(
+            path as *const i8,
+            (((::libc::O_WRONLY) | (::libc::O_CREAT)) | (::libc::O_TRUNC)) as i32,
+            (420),
+        )
+    });
     assert!(((((fd) >= (0)) as i32) != 0));
     assert!(
         ((((libc::write(
@@ -26,7 +31,7 @@ unsafe fn main_0() -> i32 {
             != 0)
     );
     assert!(((((libc::close(fd)) == (0)) as i32) != 0));
-    fd = (unsafe { libc::open(path as *const i8, 0 as i32) });
+    fd = (unsafe { libc::open(path as *const i8, ::libc::O_RDONLY as i32) });
     assert!(((((fd) >= (0)) as i32) != 0));
     let mut buf: [libc::c_char; 16] = [(0 as libc::c_char); 16];
     {

--- a/tests/unit/out/unsafe/fd_io.rs
+++ b/tests/unit/out/unsafe/fd_io.rs
@@ -1,0 +1,65 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut path: *const libc::c_char =
+        (c"/tmp/cpp2rust_fd_io_test.tmp".as_ptr().cast_mut()).cast_const();
+    let mut fd: i32 =
+        (unsafe { libc::open(path as *const i8, (((1) | (64)) | (512)) as i32, (420)) });
+    assert!(((((fd) >= (0)) as i32) != 0));
+    assert!(
+        ((((libc::write(
+            fd,
+            (c"hello world".as_ptr().cast_mut() as *const libc::c_char as *const ::libc::c_void),
+            11_usize
+        )) == (11_isize)) as i32)
+            != 0)
+    );
+    assert!(((((libc::close(fd)) == (0)) as i32) != 0));
+    fd = (unsafe { libc::open(path as *const i8, 0 as i32) });
+    assert!(((((fd) >= (0)) as i32) != 0));
+    let mut buf: [libc::c_char; 16] = [(0 as libc::c_char); 16];
+    {
+        let byte_0 = (buf.as_mut_ptr() as *mut libc::c_char as *mut ::libc::c_void) as *mut u8;
+        for offset in 0..::std::mem::size_of::<[libc::c_char; 16]>() {
+            *byte_0.offset(offset as isize) = 0 as u8;
+        }
+        (buf.as_mut_ptr() as *mut libc::c_char as *mut ::libc::c_void)
+    };
+    assert!(
+        ((((libc::read(
+            fd,
+            (buf.as_mut_ptr() as *mut libc::c_char as *mut ::libc::c_void),
+            ::std::mem::size_of::<[libc::c_char; 16]>()
+        )) == (11_isize)) as i32)
+            != 0)
+    );
+    assert!(
+        ((((libc::strcmp(
+            (buf.as_mut_ptr()).cast_const(),
+            (c"hello world".as_ptr().cast_mut()).cast_const()
+        )) == (0)) as i32)
+            != 0)
+    );
+    assert!(
+        ((((libc::read(
+            fd,
+            (buf.as_mut_ptr() as *mut libc::c_char as *mut ::libc::c_void),
+            ::std::mem::size_of::<[libc::c_char; 16]>()
+        )) == (0_isize)) as i32)
+            != 0)
+    );
+    assert!(((((libc::close(fd)) == (0)) as i32) != 0));
+    assert!(((((libc::unlink(path)) == (0)) as i32) != 0));
+    return 0;
+}


### PR DESCRIPTION
This PR adds the building blocks of safe file descriptor IO translation. In Rust, C file descriptors (int), are usually translated as OwnedFd/BorroweFd. nix also uses OwnedFd/BorrowedFd inside the IO APIs, for example [open](https://docs.rs/nix/latest/nix/unistd/fn.write.html) is defined as: `pub fn open<P: ?Sized + NixPath>(path: &P, oflag: OFlag, mode: Mode, ) -> Result<OwnedFd>`

However, we cannot directly translate integers to OwnedFd/BorrowedFd. An integer can be used as both integer and OwnedFd at the same time, which Rust does not allow. For example:

```c
int fd = -1; // plain integer
fd = open(...) // file descriptor semantics
if (fd > 0) // plain integer
  write(fd, ...) // file descriptor semantics
```

To overcome this limitation, allow integers to be translated as i32, and keep a global FdRegistry which contains mappings of type `i32 -> OwnedFd`:

```rs
pub struct FdRegistry {
    fds: Vec<Option<OwnedFd>>,
}

impl FdRegistry {
  // Creates a new i32 -> OwnedFd entry
  pub fn register(fd: OwnedFd) -> i32

  // Applies function f over the BorrowedFd: f(FdRegistry[fd])
  pub fn with_fd<R>(fd: i32, f: impl FnOnce(BorrowedFd<'_>) -> R) -> R

  // Removes the i32 -> OwnedFd entry
  pub fn close(fd: i32) -> i32
}
```

This way, integer operations on file descriptors continue to work, for example `int fd = -1` or `if (fd > 0)` and functions that use file descriptor access the OwnedFd/BorrowedFd through the FdRegistry, for example:

```rs
let fd: i32 = -1;
fd = FdRegistry::register(nix::fcntl::open(...));
if (fd > 0)
  FdRegistry::with_fd(fd, |bfd: BorrowedFd| nix::unistd::write(bfd, ...))
```

In the following PRs I will add the remaining safe IO rules.