### PR TITLE
Pin ruff version and fix sporadic double unlink in tests

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,7 +26,7 @@ jobs:
           llvm-version: 22
 
       - name: Setup Python
-        run: pip install ruff
+        run: pip install ruff==0.15.22
 
       - name: Configure
         run: cmake -GNinja -B build -S .

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ On Ubuntu, install the required dependencies with:
 
 ```bash
 sudo apt install libclang-22-dev clang++-22 ninja-build cmake
-curl -LsSf https://astral.sh/ruff/install.sh | sh
+pip install ruff==0.15.22
 ```
 
 

--- a/tests/lit/lit/formats/Cpp2RustTest.py
+++ b/tests/lit/lit/formats/Cpp2RustTest.py
@@ -261,14 +261,18 @@ class TestContext:
     def run_cpp(self):
         if self.skip_run:
             return None
-        self.cpp_result = RunResult(*lit.util.executeCommand(str(self.cpp_bin)))
+        self.cpp_result = RunResult(
+            *lit.util.executeCommand(str(self.cpp_bin), str(self.tmp_dir))
+        )
         return None
 
     def run_rust(self):
         exp = self.expectations
         if self.skip_run:
             return None
-        self.rust_result = RunResult(*lit.util.executeCommand(str(self.rust_bin)))
+        self.rust_result = RunResult(
+            *lit.util.executeCommand(str(self.rust_bin), str(self.tmp_dir))
+        )
 
         if exp.should_panic_ub:
             err = str(self.rust_result.stderr)

--- a/tests/unit/fd_io.c
+++ b/tests/unit/fd_io.c
@@ -4,7 +4,7 @@
 #include <unistd.h>
 
 int main(void) {
-  const char *path = "/tmp/cpp2rust_fd_io_test.tmp";
+  const char *path = "cpp2rust_fd_io_test.tmp";
   int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
   assert(fd >= 0);
   assert(write(fd, "hello world", 11) == 11);

--- a/tests/unit/fstat.c
+++ b/tests/unit/fstat.c
@@ -4,7 +4,7 @@
 #include <unistd.h>
 
 int main(void) {
-  const char *path = "/tmp/cpp2rust_fstat_test.tmp";
+  const char *path = "cpp2rust_fstat_test.tmp";
   int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
   assert(fd >= 0);
   assert(write(fd, "hello", 5) == 5);

--- a/tests/unit/isatty.c
+++ b/tests/unit/isatty.c
@@ -3,7 +3,7 @@
 #include <unistd.h>
 
 int main(void) {
-  const char *path = "/tmp/cpp2rust_isatty_test.tmp";
+  const char *path = "cpp2rust_isatty_test.tmp";
   int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
   assert(fd >= 0);
   assert(isatty(fd) == 0);

--- a/tests/unit/lseek_ftruncate.c
+++ b/tests/unit/lseek_ftruncate.c
@@ -4,7 +4,7 @@
 #include <unistd.h>
 
 int main(void) {
-  const char *path = "/tmp/cpp2rust_lseek_ftruncate_test.tmp";
+  const char *path = "cpp2rust_lseek_ftruncate_test.tmp";
   int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
   assert(fd >= 0);
   assert(write(fd, "hello world", 11) == 11);

--- a/tests/unit/out/refcount/fd_io.rs
+++ b/tests/unit/out/refcount/fd_io.rs
@@ -11,7 +11,7 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let path: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal(
-        b"/tmp/cpp2rust_fd_io_test.tmp",
+        b"cpp2rust_fd_io_test.tmp",
     )));
     let fd: Value<i32> = Rc::new(RefCell::new({
         let __mode = match &[(420).into()].first() {

--- a/tests/unit/out/refcount/fstat.rs
+++ b/tests/unit/out/refcount/fstat.rs
@@ -11,7 +11,7 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let path: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal(
-        b"/tmp/cpp2rust_fstat_test.tmp",
+        b"cpp2rust_fstat_test.tmp",
     )));
     let fd: Value<i32> = Rc::new(RefCell::new({
         let __mode = match &[(420).into()].first() {

--- a/tests/unit/out/refcount/isatty.rs
+++ b/tests/unit/out/refcount/isatty.rs
@@ -11,7 +11,7 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let path: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal(
-        b"/tmp/cpp2rust_isatty_test.tmp",
+        b"cpp2rust_isatty_test.tmp",
     )));
     let fd: Value<i32> = Rc::new(RefCell::new({
         let __mode = match &[(420).into()].first() {

--- a/tests/unit/out/refcount/lseek_ftruncate.rs
+++ b/tests/unit/out/refcount/lseek_ftruncate.rs
@@ -11,7 +11,7 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let path: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal(
-        b"/tmp/cpp2rust_lseek_ftruncate_test.tmp",
+        b"cpp2rust_lseek_ftruncate_test.tmp",
     )));
     let fd: Value<i32> = Rc::new(RefCell::new({
         let __mode = match &[(420).into()].first() {

--- a/tests/unit/out/refcount/stdio_nofd.rs
+++ b/tests/unit/out/refcount/stdio_nofd.rs
@@ -8,7 +8,7 @@ use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 pub fn test_fputc_fputs_0() {
     let path: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal(
-        b"/tmp/cpp2rust_stdio_nofd_puts.tmp",
+        b"cpp2rust_stdio_nofd_puts.tmp",
     )));
     let fp: Value<Ptr<::std::fs::File>> = Rc::new(RefCell::new(
         match Ptr::from_string_literal(b"wb").to_rust_string() {
@@ -154,7 +154,7 @@ pub fn test_puts_1() {
 }
 pub fn test_fgets_getc_2() {
     let path: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal(
-        b"/tmp/cpp2rust_stdio_nofd_gets.tmp",
+        b"cpp2rust_stdio_nofd_gets.tmp",
     )));
     let fp: Value<Ptr<::std::fs::File>> = Rc::new(RefCell::new(
         match Ptr::from_string_literal(b"wb").to_rust_string() {
@@ -464,7 +464,7 @@ pub fn test_fgets_getc_2() {
 }
 pub fn test_freopen_3() {
     let path: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal(
-        b"/tmp/cpp2rust_stdio_nofd_reopen.tmp",
+        b"cpp2rust_stdio_nofd_reopen.tmp",
     )));
     let fp: Value<Ptr<::std::fs::File>> = Rc::new(RefCell::new(
         match Ptr::from_string_literal(b"wb").to_rust_string() {
@@ -571,7 +571,7 @@ pub fn test_freopen_3() {
 }
 pub fn test_fseeko_4() {
     let path: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal(
-        b"/tmp/cpp2rust_stdio_nofd_seek.tmp",
+        b"cpp2rust_stdio_nofd_seek.tmp",
     )));
     let fp: Value<Ptr<::std::fs::File>> = Rc::new(RefCell::new(
         match Ptr::from_string_literal(b"wb").to_rust_string() {
@@ -758,10 +758,10 @@ pub fn test_fseeko_4() {
 }
 pub fn test_rename_5() {
     let from: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal(
-        b"/tmp/cpp2rust_stdio_nofd_from.tmp",
+        b"cpp2rust_stdio_nofd_from.tmp",
     )));
     let to: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal(
-        b"/tmp/cpp2rust_stdio_nofd_to.tmp",
+        b"cpp2rust_stdio_nofd_to.tmp",
     )));
     let fp: Value<Ptr<::std::fs::File>> = Rc::new(RefCell::new(
         match Ptr::from_string_literal(b"wb").to_rust_string() {
@@ -884,7 +884,7 @@ pub fn test_rename_5() {
 }
 pub fn test_setvbuf_6() {
     let path: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal(
-        b"/tmp/cpp2rust_stdio_nofd_vbuf.tmp",
+        b"cpp2rust_stdio_nofd_vbuf.tmp",
     )));
     let fp: Value<Ptr<::std::fs::File>> = Rc::new(RefCell::new(
         match Ptr::from_string_literal(b"wb").to_rust_string() {

--- a/tests/unit/out/refcount/termios.rs
+++ b/tests/unit/out/refcount/termios.rs
@@ -11,7 +11,7 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let path: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::from_string_literal(
-        b"/tmp/cpp2rust_termios_test.tmp",
+        b"cpp2rust_termios_test.tmp",
     )));
     let fd: Value<i32> = Rc::new(RefCell::new({
         let __mode = match &[(420).into()].first() {

--- a/tests/unit/out/unsafe/fd_io.rs
+++ b/tests/unit/out/unsafe/fd_io.rs
@@ -13,7 +13,7 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut path: *const libc::c_char =
-        (c"/tmp/cpp2rust_fd_io_test.tmp".as_ptr().cast_mut()).cast_const();
+        (c"cpp2rust_fd_io_test.tmp".as_ptr().cast_mut()).cast_const();
     let mut fd: i32 = (unsafe {
         libc::open(
             path as *const i8,

--- a/tests/unit/out/unsafe/fstat.rs
+++ b/tests/unit/out/unsafe/fstat.rs
@@ -13,7 +13,7 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut path: *const libc::c_char =
-        (c"/tmp/cpp2rust_fstat_test.tmp".as_ptr().cast_mut()).cast_const();
+        (c"cpp2rust_fstat_test.tmp".as_ptr().cast_mut()).cast_const();
     let mut fd: i32 = (unsafe {
         libc::open(
             path as *const i8,

--- a/tests/unit/out/unsafe/isatty.rs
+++ b/tests/unit/out/unsafe/isatty.rs
@@ -13,7 +13,7 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut path: *const libc::c_char =
-        (c"/tmp/cpp2rust_isatty_test.tmp".as_ptr().cast_mut()).cast_const();
+        (c"cpp2rust_isatty_test.tmp".as_ptr().cast_mut()).cast_const();
     let mut fd: i32 = (unsafe {
         libc::open(
             path as *const i8,

--- a/tests/unit/out/unsafe/lseek_ftruncate.rs
+++ b/tests/unit/out/unsafe/lseek_ftruncate.rs
@@ -12,10 +12,8 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut path: *const libc::c_char = (c"/tmp/cpp2rust_lseek_ftruncate_test.tmp"
-        .as_ptr()
-        .cast_mut())
-    .cast_const();
+    let mut path: *const libc::c_char =
+        (c"cpp2rust_lseek_ftruncate_test.tmp".as_ptr().cast_mut()).cast_const();
     let mut fd: i32 = (unsafe {
         libc::open(
             path as *const i8,

--- a/tests/unit/out/unsafe/stdio.rs
+++ b/tests/unit/out/unsafe/stdio.rs
@@ -39,7 +39,7 @@ pub unsafe fn test_fileno_3() {
     assert!(((((libc::fileno(libcc2rs::stdout_unsafe())) == (1)) as i32) != 0));
     assert!(((((libc::fileno(libcc2rs::stderr_unsafe())) == (2)) as i32) != 0));
     let mut file: *const libc::c_char =
-        (c"/tmp/cpp2rust_fileno_test.tmp".as_ptr().cast_mut()).cast_const();
+        (c"cpp2rust_fileno_test.tmp".as_ptr().cast_mut()).cast_const();
     let mut fp: *mut ::libc::FILE = libc::fopen(file, (c"wb".as_ptr().cast_mut()).cast_const());
     assert!((((!((fp).is_null())) as i32) != 0));
     assert!(((((libc::fileno(fp)) > (2)) as i32) != 0));

--- a/tests/unit/out/unsafe/stdio_nofd.rs
+++ b/tests/unit/out/unsafe/stdio_nofd.rs
@@ -8,7 +8,7 @@ use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn test_fputc_fputs_0() {
     let mut path: *const libc::c_char =
-        (c"/tmp/cpp2rust_stdio_nofd_puts.tmp".as_ptr().cast_mut()).cast_const();
+        (c"cpp2rust_stdio_nofd_puts.tmp".as_ptr().cast_mut()).cast_const();
     let mut fp: *mut ::libc::FILE = libc::fopen(path, (c"wb".as_ptr().cast_mut()).cast_const());
     assert!((((!((fp).is_null())) as i32) != 0));
     assert!(((((libc::fputc(('A' as i32), fp)) == ('A' as i32)) as i32) != 0));
@@ -78,7 +78,7 @@ pub unsafe fn test_puts_1() {
 }
 pub unsafe fn test_fgets_getc_2() {
     let mut path: *const libc::c_char =
-        (c"/tmp/cpp2rust_stdio_nofd_gets.tmp".as_ptr().cast_mut()).cast_const();
+        (c"cpp2rust_stdio_nofd_gets.tmp".as_ptr().cast_mut()).cast_const();
     let mut fp: *mut ::libc::FILE = libc::fopen(path, (c"wb".as_ptr().cast_mut()).cast_const());
     assert!((((!((fp).is_null())) as i32) != 0));
     assert!(
@@ -166,7 +166,7 @@ pub unsafe fn test_fgets_getc_2() {
 }
 pub unsafe fn test_freopen_3() {
     let mut path: *const libc::c_char =
-        (c"/tmp/cpp2rust_stdio_nofd_reopen.tmp".as_ptr().cast_mut()).cast_const();
+        (c"cpp2rust_stdio_nofd_reopen.tmp".as_ptr().cast_mut()).cast_const();
     let mut fp: *mut ::libc::FILE = libc::fopen(path, (c"wb".as_ptr().cast_mut()).cast_const());
     assert!((((!((fp).is_null())) as i32) != 0));
     assert!(
@@ -221,7 +221,7 @@ pub unsafe fn test_freopen_3() {
 }
 pub unsafe fn test_fseeko_4() {
     let mut path: *const libc::c_char =
-        (c"/tmp/cpp2rust_stdio_nofd_seek.tmp".as_ptr().cast_mut()).cast_const();
+        (c"cpp2rust_stdio_nofd_seek.tmp".as_ptr().cast_mut()).cast_const();
     let mut fp: *mut ::libc::FILE = libc::fopen(path, (c"wb".as_ptr().cast_mut()).cast_const());
     assert!((((!((fp).is_null())) as i32) != 0));
     assert!(
@@ -282,9 +282,9 @@ pub unsafe fn test_fseeko_4() {
 }
 pub unsafe fn test_rename_5() {
     let mut from: *const libc::c_char =
-        (c"/tmp/cpp2rust_stdio_nofd_from.tmp".as_ptr().cast_mut()).cast_const();
+        (c"cpp2rust_stdio_nofd_from.tmp".as_ptr().cast_mut()).cast_const();
     let mut to: *const libc::c_char =
-        (c"/tmp/cpp2rust_stdio_nofd_to.tmp".as_ptr().cast_mut()).cast_const();
+        (c"cpp2rust_stdio_nofd_to.tmp".as_ptr().cast_mut()).cast_const();
     let mut fp: *mut ::libc::FILE = libc::fopen(from, (c"wb".as_ptr().cast_mut()).cast_const());
     assert!((((!((fp).is_null())) as i32) != 0));
     assert!(((((libc::fputs((c"data".as_ptr().cast_mut()).cast_const(), fp)) >= (0)) as i32) != 0));
@@ -301,7 +301,7 @@ pub unsafe fn test_rename_5() {
 }
 pub unsafe fn test_setvbuf_6() {
     let mut path: *const libc::c_char =
-        (c"/tmp/cpp2rust_stdio_nofd_vbuf.tmp".as_ptr().cast_mut()).cast_const();
+        (c"cpp2rust_stdio_nofd_vbuf.tmp".as_ptr().cast_mut()).cast_const();
     let mut fp: *mut ::libc::FILE = libc::fopen(path, (c"wb".as_ptr().cast_mut()).cast_const());
     assert!((((!((fp).is_null())) as i32) != 0));
     assert!(((((libc::setvbuf(fp, std::ptr::null_mut(), 2, 0_usize)) == (0)) as i32) != 0));

--- a/tests/unit/out/unsafe/sys_stat.rs
+++ b/tests/unit/out/unsafe/sys_stat.rs
@@ -8,7 +8,7 @@ use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn test_stat_0() {
     let mut path: *const libc::c_char =
-        (c"/tmp/cpp2rust_stat_test.tmp".as_ptr().cast_mut()).cast_const();
+        (c"cpp2rust_stat_test.tmp".as_ptr().cast_mut()).cast_const();
     let mut fp: *mut ::libc::FILE = libc::fopen(path, (c"wb".as_ptr().cast_mut()).cast_const());
     assert!((((!((fp).is_null())) as i32) != 0));
     libc::fputs((c"hello".as_ptr().cast_mut()).cast_const(), fp);
@@ -21,7 +21,7 @@ pub unsafe fn test_stat_0() {
 }
 pub unsafe fn test_fstat_1() {
     let mut path: *const libc::c_char =
-        (c"/tmp/cpp2rust_fstat_test.tmp".as_ptr().cast_mut()).cast_const();
+        (c"cpp2rust_fstat_test.tmp".as_ptr().cast_mut()).cast_const();
     let mut fp: *mut ::libc::FILE = libc::fopen(path, (c"wb".as_ptr().cast_mut()).cast_const());
     assert!((((!((fp).is_null())) as i32) != 0));
     libc::fputs((c"hello world".as_ptr().cast_mut()).cast_const(), fp);

--- a/tests/unit/out/unsafe/termios.rs
+++ b/tests/unit/out/unsafe/termios.rs
@@ -13,7 +13,7 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut path: *const libc::c_char =
-        (c"/tmp/cpp2rust_termios_test.tmp".as_ptr().cast_mut()).cast_const();
+        (c"cpp2rust_termios_test.tmp".as_ptr().cast_mut()).cast_const();
     let mut fd: i32 = (unsafe {
         libc::open(
             path as *const i8,

--- a/tests/unit/out/unsafe/unistd.rs
+++ b/tests/unit/out/unsafe/unistd.rs
@@ -23,7 +23,7 @@ pub unsafe fn test_close_0() {
 }
 pub unsafe fn test_lseek_1() {
     let mut path: *const libc::c_char =
-        (c"/tmp/cpp2rust_lseek_test.tmp".as_ptr().cast_mut()).cast_const();
+        (c"cpp2rust_lseek_test.tmp".as_ptr().cast_mut()).cast_const();
     let mut fp: *mut ::libc::FILE = libc::fopen(path, (c"wb".as_ptr().cast_mut()).cast_const());
     assert!((((!((fp).is_null())) as i32) != 0));
     libc::fputs((c"hello world".as_ptr().cast_mut()).cast_const(), fp);
@@ -78,7 +78,7 @@ pub unsafe fn test_lseek_1() {
 }
 pub unsafe fn test_read_2() {
     let mut path: *const libc::c_char =
-        (c"/tmp/cpp2rust_read_test.tmp".as_ptr().cast_mut()).cast_const();
+        (c"cpp2rust_read_test.tmp".as_ptr().cast_mut()).cast_const();
     let mut fp: *mut ::libc::FILE = libc::fopen(path, (c"wb".as_ptr().cast_mut()).cast_const());
     assert!((((!((fp).is_null())) as i32) != 0));
     libc::fputs((c"hello world".as_ptr().cast_mut()).cast_const(), fp);
@@ -139,7 +139,7 @@ pub unsafe fn test_read_2() {
 }
 pub unsafe fn test_unlink_3() {
     let mut path: *const libc::c_char =
-        (c"/tmp/cpp2rust_unlink_test.tmp".as_ptr().cast_mut()).cast_const();
+        (c"cpp2rust_unlink_test.tmp".as_ptr().cast_mut()).cast_const();
     let mut fp: *mut ::libc::FILE = libc::fopen(path, (c"wb".as_ptr().cast_mut()).cast_const());
     assert!((((!((fp).is_null())) as i32) != 0));
     assert!(((((libc::fclose(fp)) == (0)) as i32) != 0));
@@ -210,7 +210,7 @@ pub unsafe fn test_pipe_4() {
 }
 pub unsafe fn test_ftruncate_5() {
     let mut path: *const libc::c_char =
-        (c"/tmp/cpp2rust_ftruncate_test.tmp".as_ptr().cast_mut()).cast_const();
+        (c"cpp2rust_ftruncate_test.tmp".as_ptr().cast_mut()).cast_const();
     let mut fp: *mut ::libc::FILE = libc::fopen(path, (c"wb".as_ptr().cast_mut()).cast_const());
     assert!((((!((fp).is_null())) as i32) != 0));
     libc::fputs((c"hello world".as_ptr().cast_mut()).cast_const(), fp);

--- a/tests/unit/stdio.c
+++ b/tests/unit/stdio.c
@@ -30,7 +30,7 @@ static void test_fileno(void) {
   assert(fileno(stdin) == 0);
   assert(fileno(stdout) == 1);
   assert(fileno(stderr) == 2);
-  const char *file = "/tmp/cpp2rust_fileno_test.tmp";
+  const char *file = "cpp2rust_fileno_test.tmp";
   FILE *fp = fopen(file, "wb");
   assert(fp != NULL);
   assert(fileno(fp) > 2);

--- a/tests/unit/stdio_nofd.c
+++ b/tests/unit/stdio_nofd.c
@@ -4,7 +4,7 @@
 #include <unistd.h>
 
 static void test_fputc_fputs(void) {
-  const char *path = "/tmp/cpp2rust_stdio_nofd_puts.tmp";
+  const char *path = "cpp2rust_stdio_nofd_puts.tmp";
   FILE *fp = fopen(path, "wb");
   assert(fp != NULL);
   assert(fputc('A', fp) == 'A');
@@ -22,7 +22,7 @@ static void test_fputc_fputs(void) {
 static void test_puts(void) { assert(puts("hello from puts") >= 0); }
 
 static void test_fgets_getc(void) {
-  const char *path = "/tmp/cpp2rust_stdio_nofd_gets.tmp";
+  const char *path = "cpp2rust_stdio_nofd_gets.tmp";
   FILE *fp = fopen(path, "wb");
   assert(fp != NULL);
   assert(fputs("line1\nline2\n", fp) >= 0);
@@ -44,7 +44,7 @@ static void test_fgets_getc(void) {
 }
 
 static void test_freopen(void) {
-  const char *path = "/tmp/cpp2rust_stdio_nofd_reopen.tmp";
+  const char *path = "cpp2rust_stdio_nofd_reopen.tmp";
   FILE *fp = fopen(path, "wb");
   assert(fp != NULL);
   assert(fputs("hello", fp) >= 0);
@@ -58,7 +58,7 @@ static void test_freopen(void) {
 }
 
 static void test_fseeko(void) {
-  const char *path = "/tmp/cpp2rust_stdio_nofd_seek.tmp";
+  const char *path = "cpp2rust_stdio_nofd_seek.tmp";
   FILE *fp = fopen(path, "wb");
   assert(fp != NULL);
   assert(fputs("hello world", fp) >= 0);
@@ -78,8 +78,8 @@ static void test_fseeko(void) {
 }
 
 static void test_rename(void) {
-  const char *from = "/tmp/cpp2rust_stdio_nofd_from.tmp";
-  const char *to = "/tmp/cpp2rust_stdio_nofd_to.tmp";
+  const char *from = "cpp2rust_stdio_nofd_from.tmp";
+  const char *to = "cpp2rust_stdio_nofd_to.tmp";
   FILE *fp = fopen(from, "wb");
   assert(fp != NULL);
   assert(fputs("data", fp) >= 0);
@@ -94,7 +94,7 @@ static void test_rename(void) {
 }
 
 static void test_setvbuf(void) {
-  const char *path = "/tmp/cpp2rust_stdio_nofd_vbuf.tmp";
+  const char *path = "cpp2rust_stdio_nofd_vbuf.tmp";
   FILE *fp = fopen(path, "wb");
   assert(fp != NULL);
   assert(setvbuf(fp, NULL, _IONBF, 0) == 0);

--- a/tests/unit/sys_stat.c
+++ b/tests/unit/sys_stat.c
@@ -6,7 +6,7 @@
 #include <unistd.h>
 
 static void test_stat(void) {
-  const char *path = "/tmp/cpp2rust_stat_test.tmp";
+  const char *path = "cpp2rust_stat_test.tmp";
   FILE *fp = fopen(path, "wb");
   assert(fp != NULL);
   fputs("hello", fp);
@@ -19,7 +19,7 @@ static void test_stat(void) {
 }
 
 static void test_fstat(void) {
-  const char *path = "/tmp/cpp2rust_fstat_test.tmp";
+  const char *path = "cpp2rust_fstat_test.tmp";
   FILE *fp = fopen(path, "wb");
   assert(fp != NULL);
   fputs("hello world", fp);

--- a/tests/unit/termios.c
+++ b/tests/unit/termios.c
@@ -4,7 +4,7 @@
 #include <unistd.h>
 
 int main(void) {
-  const char *path = "/tmp/cpp2rust_termios_test.tmp";
+  const char *path = "cpp2rust_termios_test.tmp";
   int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
   assert(fd >= 0);
   struct termios tio;

--- a/tests/unit/unistd.c
+++ b/tests/unit/unistd.c
@@ -17,7 +17,7 @@ static void test_close(void) {
 }
 
 static void test_lseek(void) {
-  const char *path = "/tmp/cpp2rust_lseek_test.tmp";
+  const char *path = "cpp2rust_lseek_test.tmp";
   FILE *fp = fopen(path, "wb");
   assert(fp != NULL);
   fputs("hello world", fp);
@@ -35,7 +35,7 @@ static void test_lseek(void) {
 }
 
 static void test_read(void) {
-  const char *path = "/tmp/cpp2rust_read_test.tmp";
+  const char *path = "cpp2rust_read_test.tmp";
   FILE *fp = fopen(path, "wb");
   assert(fp != NULL);
   fputs("hello world", fp);
@@ -51,7 +51,7 @@ static void test_read(void) {
 }
 
 static void test_unlink(void) {
-  const char *path = "/tmp/cpp2rust_unlink_test.tmp";
+  const char *path = "cpp2rust_unlink_test.tmp";
   FILE *fp = fopen(path, "wb");
   assert(fp != NULL);
   assert(fclose(fp) == 0);
@@ -73,7 +73,7 @@ static void test_pipe(void) {
 }
 
 static void test_ftruncate(void) {
-  const char *path = "/tmp/cpp2rust_ftruncate_test.tmp";
+  const char *path = "cpp2rust_ftruncate_test.tmp";
   FILE *fp = fopen(path, "wb");
   assert(fp != NULL);
   fputs("hello world", fp);


### PR DESCRIPTION
ruff got suddenly updated and our python linting broke. Pin ruff to a fixed version so linting is stable.