### PR TITLE
Add a `rust-toolchain.toml` for the rule-preprocessor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ add_custom_command(
     OUTPUT "${RUST_STAMP_FILE}"
     COMMAND rustup toolchain install ${RUST_STABLE_VERSION} --component clippy --component rustfmt
     COMMAND rustup toolchain install ${RUST_NIGHTLY_VERSION} --component rustc-dev --component llvm-tools --component clippy --component rustfmt
+    COMMAND rustup override set ${RUST_NIGHTLY_VERSION} --path ${PROJECT_SOURCE_DIR}/rule-preprocessor
     COMMAND ${CMAKE_COMMAND} -E touch "${RUST_STAMP_FILE}"
     DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/rust-toolchain.cmake"
     USES_TERMINAL


### PR DESCRIPTION
As this crate requires the `rustc-dev` component, which is not bundled by default, we need to add it explicitly.
Now, a user can just do `cargo build` on this crate.