### PR TITLE
Add full function type when converting FnPtr::null

### DIFF
--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -1966,7 +1966,10 @@ std::string ConverterRefCount::GetDefaultAsString(clang::QualType qual_type) {
   if (qual_type->isPointerType()) {
     auto pointee_type = qual_type->getPointeeType();
     if (pointee_type->isFunctionType()) {
-      ret = "FnPtr::null()";
+      auto *proto = pointee_type->getAs<clang::FunctionProtoType>();
+      assert(proto && "Function pointer default without a prototype");
+      ret =
+          std::format("FnPtr::<{}>::null()", ConvertFunctionPointerType(proto));
     } else {
       if (pointee_type->isVoidType()) {
         ret = "AnyPtr::default()";

--- a/tests/unit/out/refcount/default_in_statics.rs
+++ b/tests/unit/out/refcount/default_in_statics.rs
@@ -75,7 +75,7 @@ impl Default for Outer {
             pp: Rc::new(RefCell::new(Ptr::<Ptr<i32>>::null())),
             inner: <Value<Inner>>::default(),
             x: <Value<i32>>::default(),
-            fn_: Rc::new(RefCell::new(FnPtr::null())),
+            fn_: Rc::new(RefCell::new(FnPtr::<fn(i32) -> i32>::null())),
         }
     }
 }
@@ -133,8 +133,8 @@ impl Default for Foo {
         Foo {
             s1: Rc::new(RefCell::new(Ptr::<u8>::null())),
             s2: Rc::new(RefCell::new(Ptr::<u8>::null())),
-            fn1: Rc::new(RefCell::new(FnPtr::null())),
-            fn2: Rc::new(RefCell::new(FnPtr::null())),
+            fn1: Rc::new(RefCell::new(FnPtr::<fn(i32) -> i32>::null())),
+            fn2: Rc::new(RefCell::new(FnPtr::<fn(i32) -> i32>::null())),
             n: <Value<i32>>::default(),
         }
     }
@@ -165,7 +165,8 @@ impl ByteRepr for Foo {
     }
 }
 thread_local!(
-    pub static static_fn_0: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::null()));
+    pub static static_fn_0: Value<FnPtr<fn(i32) -> i32>> =
+        Rc::new(RefCell::new(FnPtr::<fn(i32) -> i32>::null()));
 );
 thread_local!(
     pub static static_outer_1: Value<Outer> = Rc::new(RefCell::new(<Outer>::default()));
@@ -179,8 +180,8 @@ thread_local!(
     pub static static_foo_3: Value<Foo> = Rc::new(RefCell::new(Foo {
         s1: Rc::new(RefCell::new(Ptr::from_string_literal(b"hello"))),
         s2: Rc::new(RefCell::new(Ptr::<u8>::null())),
-        fn1: Rc::new(RefCell::new(FnPtr::null())),
-        fn2: Rc::new(RefCell::new(FnPtr::null())),
+        fn1: Rc::new(RefCell::new(FnPtr::<fn(i32) -> i32>::null())),
+        fn2: Rc::new(RefCell::new(FnPtr::<fn(i32) -> i32>::null())),
         n: Rc::new(RefCell::new(42)),
     }));
 );
@@ -189,15 +190,15 @@ thread_local!(
         Foo {
             s1: Rc::new(RefCell::new(Ptr::from_string_literal(b"first"))),
             s2: Rc::new(RefCell::new(Ptr::<u8>::null())),
-            fn1: Rc::new(RefCell::new(FnPtr::null())),
-            fn2: Rc::new(RefCell::new(FnPtr::null())),
+            fn1: Rc::new(RefCell::new(FnPtr::<fn(i32) -> i32>::null())),
+            fn2: Rc::new(RefCell::new(FnPtr::<fn(i32) -> i32>::null())),
             n: Rc::new(RefCell::new(1)),
         },
         Foo {
             s1: Rc::new(RefCell::new(Ptr::from_string_literal(b"second"))),
             s2: Rc::new(RefCell::new(Ptr::<u8>::null())),
-            fn1: Rc::new(RefCell::new(FnPtr::null())),
-            fn2: Rc::new(RefCell::new(FnPtr::null())),
+            fn1: Rc::new(RefCell::new(FnPtr::<fn(i32) -> i32>::null())),
+            fn2: Rc::new(RefCell::new(FnPtr::<fn(i32) -> i32>::null())),
             n: Rc::new(RefCell::new(2)),
         },
     ])));
@@ -207,7 +208,8 @@ pub fn check_local_static_5() {
         static local_outer_6: Value<Outer> = Rc::new(RefCell::new(<Outer>::default()));
     );
     thread_local!(
-        static local_fn_7: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::null()));
+        static local_fn_7: Value<FnPtr<fn(i32) -> i32>> =
+            Rc::new(RefCell::new(FnPtr::<fn(i32) -> i32>::null()));
     );
     thread_local!(
         static local_p_8: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));

--- a/tests/unit/out/refcount/fn_ptr.rs
+++ b/tests/unit/out/refcount/fn_ptr.rs
@@ -19,7 +19,8 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    let fn_: Value<FnPtr<fn(AnyPtr) -> i32>> = Rc::new(RefCell::new(FnPtr::null()));
+    let fn_: Value<FnPtr<fn(AnyPtr) -> i32>> =
+        Rc::new(RefCell::new(FnPtr::<fn(AnyPtr) -> i32>::null()));
     assert!((*fn_.borrow()).is_null());
     assert!({
         let _lhs = (*fn_.borrow()).clone();

--- a/tests/unit/out/refcount/fn_ptr_as_condition.rs
+++ b/tests/unit/out/refcount/fn_ptr_as_condition.rs
@@ -28,9 +28,9 @@ fn main_0() -> i32 {
     ({ maybe_call_1(FnPtr::<fn(Ptr<i32>)>::new(double_it_0), (a.as_pointer())) });
     assert!(((*a.borrow()) == 10));
     let b: Value<i32> = Rc::new(RefCell::new(5));
-    ({ maybe_call_1(FnPtr::null(), (b.as_pointer())) });
+    ({ maybe_call_1(FnPtr::<fn(Ptr<i32>)>::null(), (b.as_pointer())) });
     assert!(((*b.borrow()) == 5));
-    let fn_: Value<FnPtr<fn(Ptr<i32>)>> = Rc::new(RefCell::new(FnPtr::null()));
+    let fn_: Value<FnPtr<fn(Ptr<i32>)>> = Rc::new(RefCell::new(FnPtr::<fn(Ptr<i32>)>::null()));
     if !!(*fn_.borrow()).is_null() {
         (*fn_.borrow_mut()) = FnPtr::<fn(Ptr<i32>)>::new(double_it_0);
     }

--- a/tests/unit/out/refcount/fn_ptr_conditional.rs
+++ b/tests/unit/out/refcount/fn_ptr_conditional.rs
@@ -49,6 +49,6 @@ fn main_0() -> i32 {
     assert!((({ (*({ pick_3(-1_i32,) }))(10,) }) == 9));
     assert!((({ (*({ pick_3(0,) }))(10,) }) == 10));
     assert!((({ apply_4(FnPtr::<fn(i32) -> i32>::new(inc_0), 5,) }) == 6));
-    assert!((({ apply_4(FnPtr::null(), 5,) }) == 5));
+    assert!((({ apply_4(FnPtr::<fn(i32) -> i32>::null(), 5,) }) == 5));
     return 0;
 }

--- a/tests/unit/out/refcount/fn_ptr_default_arg.rs
+++ b/tests/unit/out/refcount/fn_ptr_default_arg.rs
@@ -12,7 +12,8 @@ pub fn identity_0(x: i32) -> i32 {
 }
 pub fn apply_1(x: i32, fn_: Option<FnPtr<fn(i32) -> i32>>) -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(x));
-    let fn_: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(fn_.unwrap_or(FnPtr::null())));
+    let fn_: Value<FnPtr<fn(i32) -> i32>> =
+        Rc::new(RefCell::new(fn_.unwrap_or(FnPtr::<fn(i32) -> i32>::null())));
     if !(*fn_.borrow()).is_null() {
         return ({ (*(*fn_.borrow()))((*x.borrow())) });
     }
@@ -23,7 +24,7 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     assert!((({ apply_1(5, Some(Default::default()),) }) == 5));
-    assert!((({ apply_1(5, Some(FnPtr::null()),) }) == 5));
+    assert!((({ apply_1(5, Some(FnPtr::<fn(i32) -> i32>::null()),) }) == 5));
     assert!((({ apply_1(5, Some(FnPtr::<fn(i32) -> i32>::new(identity_0)),) }) == 5));
     let negate: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::new(
         (|x: i32| {

--- a/tests/unit/out/refcount/fn_ptr_global.rs
+++ b/tests/unit/out/refcount/fn_ptr_global.rs
@@ -15,7 +15,8 @@ pub fn triple_it_1(x: i32) -> i32 {
     return ((*x.borrow()) * 3);
 }
 thread_local!(
-    pub static g_op_2: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::null()));
+    pub static g_op_2: Value<FnPtr<fn(i32) -> i32>> =
+        Rc::new(RefCell::new(FnPtr::<fn(i32) -> i32>::null()));
 );
 pub fn set_op_3(fn_: FnPtr<fn(i32) -> i32>) {
     let fn_: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(fn_));
@@ -46,7 +47,7 @@ fn main_0() -> i32 {
         _lhs == FnPtr::<fn(i32) -> i32>::new(triple_it_1)
     });
     assert!((({ call_op_4(5,) }) == 15));
-    ({ set_op_3(FnPtr::null()) });
+    ({ set_op_3(FnPtr::<fn(i32) -> i32>::null()) });
     assert!((*g_op_2.with(Value::clone).borrow()).is_null());
     assert!((({ call_op_4(5,) }) == 5));
     return 0;

--- a/tests/unit/out/refcount/fn_ptr_reassign.rs
+++ b/tests/unit/out/refcount/fn_ptr_reassign.rs
@@ -32,7 +32,7 @@ fn main_0() -> i32 {
     assert!((({ (*(*fn_.borrow()))(10, 3,) }) == 7));
     (*fn_.borrow_mut()) = FnPtr::<fn(i32, i32) -> i32>::new(mul_2);
     assert!((({ (*(*fn_.borrow()))(6, 7,) }) == 42));
-    (*fn_.borrow_mut()) = FnPtr::null();
+    (*fn_.borrow_mut()) = FnPtr::<fn(i32, i32) -> i32>::null();
     assert!((*fn_.borrow()).is_null());
     (*fn_.borrow_mut()) = FnPtr::<fn(i32, i32) -> i32>::new(add_0);
     assert!(!((*fn_.borrow()).is_null()));

--- a/tests/unit/out/refcount/fn_ptr_struct.rs
+++ b/tests/unit/out/refcount/fn_ptr_struct.rs
@@ -24,7 +24,7 @@ impl Default for Handler {
     fn default() -> Self {
         Handler {
             tag: <Value<i32>>::default(),
-            cb: Rc::new(RefCell::new(FnPtr::null())),
+            cb: Rc::new(RefCell::new(FnPtr::<fn(i32) -> i32>::null())),
         }
     }
 }

--- a/tests/unit/out/refcount/fn_ptr_vtable.rs
+++ b/tests/unit/out/refcount/fn_ptr_vtable.rs
@@ -25,9 +25,9 @@ impl Clone for Vtable {
 impl Default for Vtable {
     fn default() -> Self {
         Vtable {
-            create: Rc::new(RefCell::new(FnPtr::null())),
-            get: Rc::new(RefCell::new(FnPtr::null())),
-            destroy: Rc::new(RefCell::new(FnPtr::null())),
+            create: Rc::new(RefCell::new(FnPtr::<fn(i32) -> AnyPtr>::null())),
+            get: Rc::new(RefCell::new(FnPtr::<fn(AnyPtr) -> i32>::null())),
+            destroy: Rc::new(RefCell::new(FnPtr::<fn(AnyPtr)>::null())),
         }
     }
 }
@@ -84,7 +84,7 @@ fn main_0() -> i32 {
     assert!((({ (*(*(*vt.borrow()).get.borrow()))((*obj.borrow()).clone(),) }) == 42));
     ({ (*(*(*vt.borrow()).destroy.borrow()))((*obj.borrow()).clone()) });
     assert!(((*storage_0.with(Value::clone).borrow()) == 0));
-    (*(*vt.borrow()).get.borrow_mut()) = FnPtr::null();
+    (*(*vt.borrow()).get.borrow_mut()) = FnPtr::<fn(AnyPtr) -> i32>::null();
     assert!((*(*vt.borrow()).get.borrow()).is_null());
     return 0;
 }

--- a/tests/unit/out/refcount/goto_aggregate_default.rs
+++ b/tests/unit/out/refcount/goto_aggregate_default.rs
@@ -50,7 +50,7 @@ pub fn agg_0(n: i32) -> i32 {
     ));
     let p: Value<Point> = <Value<Point>>::default();
     let ptr: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
-    let fp: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::null()));
+    let fp: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::<fn(i32) -> i32>::null()));
     let file: Value<Ptr<CFile>> = Rc::new(RefCell::new(Ptr::null()));
     let total: Value<i32> = <Value<i32>>::default();
     goto_block!({

--- a/tests/unit/out/refcount/string_literal_ptr_init.rs
+++ b/tests/unit/out/refcount/string_literal_ptr_init.rs
@@ -25,7 +25,7 @@ impl Default for label {
     fn default() -> Self {
         label {
             name: Rc::new(RefCell::new(Ptr::<u8>::null())),
-            probe: Rc::new(RefCell::new(FnPtr::null())),
+            probe: Rc::new(RefCell::new(FnPtr::<fn() -> i32>::null())),
             mask: <Value<i32>>::default(),
         }
     }
@@ -54,7 +54,7 @@ thread_local!(
     pub static table_1: Value<Box<[label]>> = Rc::new(RefCell::new(Box::new([
         label {
             name: Rc::new(RefCell::new(Ptr::from_string_literal(b"first"))),
-            probe: Rc::new(RefCell::new(FnPtr::null())),
+            probe: Rc::new(RefCell::new(FnPtr::<fn() -> i32>::null())),
             mask: Rc::new(RefCell::new((1 << 4))),
         },
         label {


### PR DESCRIPTION
This avoids situations when rustc cannot infer the type of the null function pointer.