### PR TITLE
Add rule hint header

### DIFF
--- a/cpp2rust/CMakeLists.txt
+++ b/cpp2rust/CMakeLists.txt
@@ -43,3 +43,5 @@ target_link_libraries(cpp2rust PRIVATE cpp2rust_core)
 
 add_clang_executable(cpp-rule-preprocessor PARTIAL_SOURCES_INTENDED cpp_rule_preprocessor.cpp)
 target_link_libraries(cpp-rule-preprocessor PRIVATE cpp2rust_core)
+target_compile_definitions(cpp-rule-preprocessor PRIVATE
+  "-DRULES_LIB_INCLUDE_DIR=\"${PROJECT_SOURCE_DIR}/rules/lib\"")

--- a/cpp2rust/converter/mapper.cpp
+++ b/cpp2rust/converter/mapper.cpp
@@ -4,6 +4,7 @@
 #include "converter/mapper.h"
 
 #include <clang/AST/ExprCXX.h>
+#include <clang/Basic/OperatorKinds.h>
 #include <clang/Basic/SourceManager.h>
 #include <clang/Lex/Lexer.h>
 #include <llvm/Support/ThreadPool.h>
@@ -558,7 +559,8 @@ void addBuiltinTypes(Model model) {
   add_size_rules(ctx_->getSignedSizeType(), {"ssize_t"}, "isize");
 }
 
-clang::QualType normalizeQualType(clang::QualType qual_type) {
+clang::QualType normalizeQualType(clang::QualType qual_type,
+                                  const clang::DeclContext *dctx) {
   assert(ctx_);
 
   bool isLRef = qual_type->isLValueReferenceType();
@@ -584,6 +586,22 @@ clang::QualType normalizeQualType(clang::QualType qual_type) {
     qual_type = qual_type.getCanonicalType();
   }
 
+  bool sugared = false;
+  if (dctx && llvm::isa<clang::SubstTemplateTypeParmType>(qual_type)) {
+    const auto match = llvm::find_if(dctx->decls(), [&](const auto *d) {
+      const auto *td = llvm::dyn_cast<clang::TypedefNameDecl>(d);
+      return td && (td->getUnderlyingType().getCanonicalType() ==
+                    qual_type.getCanonicalType());
+    });
+
+    if (match != dctx->decls().end()) {
+      qual_type =
+          ctx_->getTypedefType(clang::ElaboratedTypeKeyword::None, std::nullopt,
+                               llvm::cast<clang::TypedefNameDecl>(*match));
+      sugared = true;
+    }
+  }
+
   qual_type = qual_type.withFastQualifiers(qualifiers.getFastQualifiers());
   if (qualifiers.hasNonFastQualifiers()) {
     qual_type = ctx_->getQualifiedType(qual_type, qualifiers);
@@ -597,6 +615,9 @@ clang::QualType normalizeQualType(clang::QualType qual_type) {
     qual_type = ctx_->getRValueReferenceType(qual_type);
   }
 
+  if (sugared) {
+    return qual_type;
+  }
   return qual_type.getCanonicalType().getUnqualifiedType().getDesugaredType(
       *ctx_);
 }
@@ -834,7 +855,8 @@ std::string ToRustName(std::string name) {
   return ReplaceAll(name, "::", "_");
 }
 
-std::string ToString(clang::QualType qual_type, ScalarSugar sugar) {
+std::string ToString(clang::QualType qual_type, ScalarSugar sugar,
+                     const clang::DeclContext *dctx) {
   assert(ctx_);
 
   if (sugar == ScalarSugar::kPreserve) {
@@ -864,7 +886,7 @@ std::string ToString(clang::QualType qual_type, ScalarSugar sugar) {
 
   if (auto cxx_record_decl = qual_type->getAsCXXRecordDecl()) {
     if (cxx_record_decl->isLambda()) {
-      return ToString(cxx_record_decl->getLambdaCallOperator());
+      return ToString(cxx_record_decl->getLambdaCallOperator(), dctx);
     }
   }
 
@@ -880,11 +902,12 @@ std::string ToString(clang::QualType qual_type, ScalarSugar sugar) {
 
   std::string type;
   llvm::raw_string_ostream os(type);
-  normalizeQualType(qual_type).print(os, getPrintPolicy());
+  normalizeQualType(qual_type, dctx).print(os, getPrintPolicy());
   return normalizeTranslationRule(std::move(type));
 }
 
-std::string ToString(const clang::NamedDecl *decl) {
+std::string ToString(const clang::NamedDecl *decl,
+                     const clang::DeclContext *dctx) {
   if (auto *record = clang::dyn_cast<clang::RecordDecl>(decl);
       record && !record->getIdentifier()) {
     if (auto renamed = DisambiguateAnonymousTag(record); !renamed.empty()) {
@@ -921,9 +944,32 @@ std::string ToString(const clang::NamedDecl *decl) {
     return normalizeTranslationRule(std::move(out));
   }
 
-  os << ToString(func_decl->getReturnType()) << ' ';
-  if (const auto *method_decl =
-          llvm::dyn_cast<clang::CXXMethodDecl>(func_decl)) {
+  os << ToString(func_decl->getReturnType(), ScalarSugar::kDesugar, dctx)
+     << ' ';
+  if (const auto op = func_decl->getOverloadedOperator();
+      op >= clang::OverloadedOperatorKind::OO_LessLess &&
+      op <= clang::OverloadedOperatorKind::OO_GreaterGreaterEqual) {
+    // ensure matchTemplate does not consider these operator names when matching
+    func_decl->getQualifier().print(os, getPrintPolicy());
+    os << "operator ";
+    switch (op) {
+    case clang::OverloadedOperatorKind::OO_LessLess:
+      os << "shl";
+      break;
+    case clang::OverloadedOperatorKind::OO_GreaterGreater:
+      os << "shr";
+      break;
+    case clang::OverloadedOperatorKind::OO_LessLessEqual:
+      os << "shleq";
+      break;
+    case clang::OverloadedOperatorKind::OO_GreaterGreaterEqual:
+      os << "shreq";
+      break;
+    default:
+      std::unreachable();
+    }
+  } else if (const auto *method_decl =
+                 llvm::dyn_cast<clang::CXXMethodDecl>(func_decl)) {
     if (method_decl->getParent()->isLambda() &&
         method_decl->getOverloadedOperator() == clang::OO_Call) {
       func_decl->printName(os, getPrintPolicy());
@@ -939,7 +985,8 @@ std::string ToString(const clang::NamedDecl *decl) {
     if (i) {
       os << ", ";
     }
-    os << ToString(func_decl->getParamDecl(i)->getType());
+    os << ToString(func_decl->getParamDecl(i)->getType(), ScalarSugar::kDesugar,
+                   dctx);
   }
   if (func_decl->isVariadic()) {
     if (func_decl->getNumParams()) {
@@ -972,7 +1019,7 @@ std::string ToString(const clang::NamedDecl *decl) {
   return normalizeTranslationRule(std::move(out));
 }
 
-std::string ToString(const clang::Expr *expr) {
+std::string ToString(const clang::Expr *expr, const clang::DeclContext *dctx) {
   if (!expr) {
     assert(0 && "!expr");
   }
@@ -991,13 +1038,13 @@ std::string ToString(const clang::Expr *expr) {
 
   if (const auto *CE = llvm::dyn_cast<clang::CallExpr>(expr)) {
     if (const auto *decl = CE->getDirectCallee()) {
-      return ToString(decl);
+      return ToString(decl, dctx);
     }
   }
 
   if (const auto *ctor = llvm::dyn_cast<clang::CXXConstructExpr>(expr)) {
     if (const auto *ctor_decl = ctor->getConstructor()) {
-      return ToString(ctor_decl);
+      return ToString(ctor_decl, dctx);
     }
     assert(0 && "expr is a CXXConstructExpr but could not get constructor");
   }
@@ -1007,14 +1054,15 @@ std::string ToString(const clang::Expr *expr) {
             llvm::dyn_cast<clang::NamedDecl>(ME->getMemberDecl())) {
       if (const auto *method_decl =
               llvm::dyn_cast<clang::CXXMethodDecl>(member_decl)) {
-        return ToString(method_decl);
+        return ToString(method_decl, dctx);
       }
       if (ME->isArrow()) {
         auto *base = ME->getBase()->IgnoreParenImpCasts();
         if (auto *op = llvm::dyn_cast<clang::CXXOperatorCallExpr>(base)) {
           if (op->getOperator() == clang::OO_Arrow) {
-            return ToString(op->getArg(0)->getType()) + "->" +
-                   ToString(member_decl);
+            return ToString(op->getArg(0)->getType(), ScalarSugar::kDesugar,
+                            dctx) +
+                   "->" + ToString(member_decl, dctx);
           }
         }
       } else if (auto for_range = GetParentForRange(*ctx_, ME)) {
@@ -1026,7 +1074,7 @@ std::string ToString(const clang::Expr *expr) {
           }
         }
       }
-      return ToString(member_decl);
+      return ToString(member_decl, dctx);
     }
     assert(0 && "expr is a MemberExpr but could not get named decl");
   }
@@ -1036,15 +1084,15 @@ std::string ToString(const clang::Expr *expr) {
             llvm::dyn_cast<clang::NamedDecl>(decl_ref->getDecl())) {
       if (const auto *tmpl_decl =
               llvm::dyn_cast<clang::FunctionTemplateDecl>(named_decl)) {
-        return ToString(tmpl_decl->getTemplatedDecl());
+        return ToString(tmpl_decl->getTemplatedDecl(), dctx);
       }
-      return ToString(named_decl);
+      return ToString(named_decl, dctx);
     }
     return "";
   }
 
   if (const auto *uop = llvm::dyn_cast<clang::UnaryOperator>(expr)) {
-    auto sub = ToString(uop->getSubExpr());
+    auto sub = ToString(uop->getSubExpr(), dctx);
     std::string_view opcode =
         clang::UnaryOperator::getOpcodeStr(uop->getOpcode());
     return uop->isPostfix() ? std::format("{}{}", sub, opcode)

--- a/cpp2rust/converter/mapper.h
+++ b/cpp2rust/converter/mapper.h
@@ -48,9 +48,12 @@ enum class ScalarSugar {
 
 clang::QualType GetTypeForDecl(const clang::NamedDecl *decl);
 std::string ToString(clang::QualType qual_type,
-                     ScalarSugar sugar = ScalarSugar::kDesugar);
-std::string ToString(const clang::Expr *expr);
-std::string ToString(const clang::NamedDecl *decl);
+                     ScalarSugar sugar = ScalarSugar::kDesugar,
+                     const clang::DeclContext *dctx = nullptr);
+std::string ToString(const clang::Expr *expr,
+                     const clang::DeclContext *dctx = nullptr);
+std::string ToString(const clang::NamedDecl *decl,
+                     const clang::DeclContext *dctx = nullptr);
 std::string ToRustName(std::string name);
 
 void LoadTranslationRules(Model model, clang::ASTContext &ctx,

--- a/cpp2rust/cpp_rule_preprocessor.cpp
+++ b/cpp2rust/cpp_rule_preprocessor.cpp
@@ -37,52 +37,6 @@ namespace fs = std::filesystem;
 
 namespace cpp2rust {
 
-enum LookupKind { RegularName, CXXMethodName, CXXConstructorName, ADL };
-
-struct LookupInfo {
-  clang::DeclarationName name;
-  LookupKind kind;
-  llvm::ArrayRef<clang::TemplateArgumentLoc> explicitArgs;
-
-  LookupInfo(const clang::Expr *expr) {
-    if (const auto *ul = llvm::dyn_cast<clang::UnresolvedLookupExpr>(expr)) {
-      clang::DeclarationName dname = ul->getName();
-      name = dname;
-      if (ul->requiresADL()) {
-        kind = LookupKind::ADL;
-      } else {
-        kind = LookupKind::RegularName;
-      }
-      explicitArgs = ul->template_arguments();
-    } else if (const auto *dm =
-                   llvm::dyn_cast<clang::CXXDependentScopeMemberExpr>(expr)) {
-      name = dm->getMember();
-      kind = LookupKind::CXXMethodName;
-      explicitArgs = dm->template_arguments();
-    } else if (const auto *um =
-                   llvm::dyn_cast<clang::UnresolvedMemberExpr>(expr)) {
-      name = um->getMemberName();
-      kind = LookupKind::CXXMethodName;
-      explicitArgs = um->template_arguments();
-    } else if (const auto *dref =
-                   llvm::dyn_cast<clang::DependentScopeDeclRefExpr>(expr)) {
-      clang::DeclarationName dname = dref->getDeclName();
-      if (dname.getNameKind() ==
-          clang::DeclarationName::NameKind::CXXConstructorName) {
-        name = dname;
-        kind = LookupKind::CXXConstructorName;
-      } else {
-        assert(0 && "Unsupported dref name kind");
-      }
-    } else if (llvm::isa<clang::CXXUnresolvedConstructExpr>(expr)) {
-      kind = LookupKind::CXXConstructorName;
-    } else {
-      expr->dump();
-      assert(0 && "Unsupported lookup expression");
-    }
-  }
-};
-
 class Callback : public clang::ast_matchers::MatchFinder::MatchCallback {
 public:
   explicit Callback(llvm::json::Object &out) : out_(out) {}
@@ -96,7 +50,10 @@ public:
   void run(const clang::ast_matchers::MatchFinder::MatchResult &R) override {
     assert(sema_);
     Mapper::PushASTContext scoped(*R.Context);
-    if (auto func = R.Nodes.getNodeAs<clang::FunctionDecl>("validate_func")) {
+    clang::NamespaceDecl *ns = createNamespaceDecl();
+    const clang::Sema::ContextRAII savedContext(*sema_, ns);
+
+    if (auto func = R.Nodes.getNodeAs<clang::FunctionDecl>("func")) {
       const char *err = nullptr;
       if (auto body =
               clang::dyn_cast_or_null<clang::CompoundStmt>(func->getBody())) {
@@ -114,100 +71,34 @@ public:
                      << err << '\n';
         std::exit(EXIT_FAILURE);
       }
+
+      auto *rule = func;
+      if (auto *tdecl = func->getDescribedFunctionTemplate()) {
+        rule = instantiateFunctionRule(tdecl);
+        assert(rule && "Instantiation failed");
+      }
+
+      auto *body = llvm::cast<clang::CompoundStmt>(rule->getBody());
+      auto *ret = llvm::cast<clang::ReturnStmt>(*body->body_begin());
+      auto src = Mapper::ToString(
+          ret->getRetValue()->IgnoreUnlessSpelledInSource(), sema_->CurContext);
+      assert(src != "Unhandled case in ToString");
+      out_.try_emplace(rule->getQualifiedNameAsString(), std::move(src));
       return;
     }
+
     if (auto var = R.Nodes.getNodeAs<clang::TypedefNameDecl>("tvar")) {
       clang::QualType type = var->getUnderlyingType();
       if (auto *alias = llvm::dyn_cast<clang::TypeAliasDecl>(var)) {
         if (auto *tdecl = alias->getDescribedAliasTemplate()) {
-          type = lookupType(tdecl);
+          type = instantiateTypeRule(tdecl);
         }
       }
-      auto src = Mapper::ToString(type, Mapper::ScalarSugar::kPreserve);
+      auto src = Mapper::ToString(type, Mapper::ScalarSugar::kPreserve,
+                                  sema_->CurContext);
+      assert(src != "Unhandled case in ToString");
       out_.try_emplace(var->getQualifiedNameAsString(), std::move(src));
       return;
-    }
-
-    if (auto func = R.Nodes.getNodeAs<clang::FunctionDecl>("func")) {
-      auto add = [&](std::string &&src) {
-        out_.try_emplace(func->getQualifiedNameAsString(), std::move(src));
-      };
-
-      if (const auto *fcall = R.Nodes.getNodeAs<clang::CallExpr>("fcall")) {
-        if (fcall->getDirectCallee()) {
-          add(Mapper::ToString(fcall));
-          return;
-        }
-
-        LookupInfo lookup(fcall->getCallee());
-        clang::NamedDecl *decl =
-            lookupCalledDecl(func->getDescribedFunctionTemplate(), lookup);
-        add(Mapper::ToString(decl));
-        return;
-      }
-      if (const auto *ctor =
-              R.Nodes.getNodeAs<clang::CXXConstructExpr>("ctor")) {
-        if (ctor->getConstructor()) {
-          add(Mapper::ToString(ctor));
-          return;
-        }
-      }
-      if (const auto *muse = R.Nodes.getNodeAs<clang::MemberExpr>("muse")) {
-        if (llvm::isa<clang::FieldDecl>(muse->getMemberDecl())) {
-          add(Mapper::ToString(muse));
-          return;
-        }
-      }
-      if (const auto *um =
-              R.Nodes.getNodeAs<clang::UnresolvedMemberExpr>("umuse")) {
-        add(Mapper::ToString(um));
-        return;
-      }
-      if (R.Nodes.getNodeAs<clang::DeclRefExpr>("declref")) {
-        if (const auto *enum_val =
-                R.Nodes.getNodeAs<clang::EnumConstantDecl>("enum_val")) {
-          add(Mapper::ToString(enum_val));
-          return;
-        } else if (const auto *decl =
-                       R.Nodes.getNodeAs<clang::VarDecl>("decl")) {
-          add(Mapper::ToString(decl));
-          return;
-        }
-      }
-      if (const auto *uop =
-              R.Nodes.getNodeAs<clang::UnaryOperator>("udeclref")) {
-        add(Mapper::ToString(uop));
-        return;
-      }
-      if (const auto *dsme =
-              R.Nodes.getNodeAs<clang::CXXDependentScopeMemberExpr>("dsme")) {
-        if (dsme->isArrow()) {
-          clang::MemberExpr *expr = lookupArrowAccess(
-              func->getDescribedFunctionTemplate(), dsme->getMemberNameInfo(),
-              dsme->getQualifierLoc());
-          add(Mapper::ToString(expr));
-          return;
-        }
-        clang::NamedDecl *decl = lookupMemberAccess(
-            func->getDescribedFunctionTemplate(), dsme->getMember());
-        add(Mapper::ToString(decl));
-        return;
-      }
-      if (const auto *uctor =
-              R.Nodes.getNodeAs<clang::CXXUnresolvedConstructExpr>("uctor")) {
-        LookupInfo lookup(uctor);
-        clang::NamedDecl *decl =
-            lookupCalledDecl(func->getDescribedFunctionTemplate(), lookup);
-        add(Mapper::ToString(decl));
-        return;
-      }
-      if (const auto *lit =
-              R.Nodes.getNodeAs<clang::IntegerLiteral>("macro_int")) {
-        if (lit->getBeginLoc().isMacroID()) {
-          add(Mapper::ToString(lit));
-        }
-        return;
-      }
     }
   }
 
@@ -215,81 +106,6 @@ private:
   llvm::json::Object &out_;
   clang::Sema *sema_ = nullptr;
   clang::SourceLocation loc_;
-
-  void forceCompleteDefinition(clang::QualType type) {
-    type = type.getCanonicalType();
-    if (type->isPointerType()) {
-      type = type->getPointeeType();
-    }
-
-    if (!type->isIncompleteType()) {
-      return;
-    }
-
-    sema_->RequireCompleteType(loc_, type,
-                               clang::Sema::CompleteTypeKind::Normal,
-                               clang::diag::err_incomplete_type);
-
-    if (auto *spec =
-            llvm::dyn_cast_or_null<clang::ClassTemplateSpecializationDecl>(
-                type->getAsCXXRecordDecl())) {
-      for (const auto *decl : spec->decls()) {
-        if (const auto *tdef = llvm::dyn_cast<clang::TypedefNameDecl>(decl)) {
-          clang::QualType tdef_t = tdef->getUnderlyingType();
-          forceCompleteDefinition(tdef_t);
-        }
-      }
-
-      for (const auto &arg : spec->getTemplateArgs().asArray()) {
-        if (arg.getKind() == clang::TemplateArgument::Type) {
-          forceCompleteDefinition(arg.getAsType());
-        }
-      }
-    }
-  }
-
-  clang::FunctionDecl *deduceTemplateArguments(
-      clang::FunctionTemplateDecl *decl, llvm::ArrayRef<clang::Expr *> callArgs,
-      clang::QualType obj_t, clang::Expr::Classification exprClass,
-      clang::TemplateArgumentListInfo *explicitArgs = nullptr) {
-    clang::FunctionDecl *spec = nullptr;
-    clang::sema::TemplateDeductionInfo info((loc_));
-    auto check = [](llvm::ArrayRef<clang::QualType>, bool) -> bool {
-      return false;
-    };
-
-    auto result = sema_->DeduceTemplateArguments(
-        decl, explicitArgs, callArgs, spec, info, false, false, false, obj_t,
-        exprClass, false, check);
-
-    if (result == clang::TemplateDeductionResult::Success) {
-      return spec;
-    }
-
-    if (result == clang::TemplateDeductionResult::SubstitutionFailure ||
-        result == clang::TemplateDeductionResult::ConstraintsNotSatisfied) {
-      if (const auto *deduced = info.takeCanonical()) {
-        clang::TemplateArgumentListInfo targsInfo;
-        for (const auto &arg : deduced->asArray()) {
-          targsInfo.addArgument(
-              sema_->getTrivialTemplateArgumentLoc(arg, {}, loc_));
-        }
-
-        clang::DefaultArguments defaultArgs;
-        clang::Sema::CheckTemplateArgumentInfo ctai;
-        clang::Sema::InstantiatingTemplate Inst(*sema_, loc_, decl);
-        auto invalid = sema_->CheckTemplateArgumentList(
-            decl, decl->getTemplateParameters(), loc_, targsInfo, defaultArgs,
-            true, ctai);
-
-        if (!invalid) {
-          return sema_->InstantiateFunctionDeclaration(decl, deduced, loc_);
-        }
-      }
-    }
-
-    return nullptr;
-  }
 
   clang::NamespaceDecl *createNamespaceDecl() {
     auto &ctx = sema_->getASTContext();
@@ -300,9 +116,7 @@ private:
     return ns;
   }
 
-  clang::RecordDecl *
-  createRecordDecl(llvm::StringRef name,
-                   clang::QualType base = clang::QualType()) {
+  clang::RecordDecl *createRecordDecl(llvm::StringRef name) {
     bool owned = true;
     bool dependent = false;
     clang::CXXScopeSpec scope;
@@ -317,14 +131,6 @@ private:
     auto *rdecl = decl.getAs<clang::RecordDecl>();
 
     rdecl->startDefinition();
-    if (!base.isNull()) {
-      clang::CXXBaseSpecifier baseSpec(
-          clang::SourceRange(loc_, loc_), false, true, clang::AS_public,
-          sema_->Context.getTrivialTypeSourceInfo(base, loc_),
-          /*EllipsisLoc=*/clang::SourceLocation());
-      const clang::CXXBaseSpecifier *bases[] = {&baseSpec};
-      llvm::cast<clang::CXXRecordDecl>(rdecl)->setBases(bases, 1);
-    }
     rdecl->completeDefinition();
     return rdecl;
   }
@@ -345,10 +151,11 @@ private:
   }
 
   clang::QualType
-  getTemplateIdType(clang::ClassTemplateDecl *decl,
+  getTemplateIdType(clang::TemplateDecl *decl,
                     llvm::ArrayRef<clang::TemplateArgument> args) {
     clang::TemplateArgumentListInfo info(loc_, loc_);
-    for (const clang::TemplateArgument &arg : args) {
+    for (const auto &arg : args) {
+      assert(!arg.getIsDefaulted());
       info.addArgument(
           sema_->getTrivialTemplateArgumentLoc(arg, getNTTPType(arg), loc_));
     }
@@ -358,115 +165,24 @@ private:
                                       /*ForNestedNameSpecifier=*/false);
   }
 
-  using MirrorMap = llvm::SmallDenseMap<const clang::ClassTemplateDecl *,
-                                        clang::ClassTemplateDecl *>;
-
-  clang::TypeSourceInfo *findMatch(MirrorMap &substs, clang::QualType type) {
-    const auto *tst = type->getAs<clang::TemplateSpecializationType>();
-    if (!tst) {
-      return nullptr;
-    }
-
-    const auto *tdecl = llvm::dyn_cast_or_null<clang::ClassTemplateDecl>(
-        tst->getTemplateName().getAsTemplateDecl());
-    if (!tdecl) {
-      return nullptr;
-    }
-
-    if (auto it = substs.find(tdecl->getCanonicalDecl()); it != substs.end()) {
-      auto match = getTemplateIdType(it->second, tst->template_arguments());
-      assert(!match.isNull());
-      return sema_->Context.getTrivialTypeSourceInfo(match, loc_);
-    }
-    return nullptr;
-  }
-
-  clang::ClassTemplateDecl *
-  createInheritingTemplate(llvm::StringRef name, clang::ClassTemplateDecl *decl,
-                           MirrorMap &substs) {
+  clang::QualType createAliasType(llvm::StringRef name, clang::QualType hint) {
     clang::ASTContext &ctx = sema_->Context;
-    auto *pattern = clang::CXXRecordDecl::Create(
-        ctx, clang::TagTypeKind::Struct, sema_->CurContext, loc_, loc_,
-        &ctx.Idents.get(name));
-
-    auto *mirror = clang::ClassTemplateDecl::Create(
-        ctx, sema_->CurContext, loc_,
-        clang::DeclarationName(&ctx.Idents.get(name)),
-        decl->getTemplateParameters(), pattern);
-    pattern->setDescribedClassTemplate(mirror);
-    mirror->setAccess(clang::AS_public);
-    substs.try_emplace(decl->getCanonicalDecl(), mirror);
-
-    clang::QualType base_t = getTemplateIdType(
-        decl, decl->getTemplateParameters()->getInjectedTemplateArgs(ctx));
-    assert(!base_t.isNull() && "Failed building mirror base");
-
-    pattern->startDefinition();
-    clang::CXXBaseSpecifier base(clang::SourceRange(loc_, loc_), false, true,
-                                 clang::AS_public,
-                                 ctx.getTrivialTypeSourceInfo(base_t, loc_),
-                                 /*EllipsisLoc=*/clang::SourceLocation());
-    const clang::CXXBaseSpecifier *bases[] = {&base};
-    pattern->setBases(bases, 1);
-
-    for (auto *member : decl->getTemplatedDecl()->decls()) {
-      if (const auto *td = llvm::dyn_cast<clang::TypedefNameDecl>(member)) {
-        if (auto *replacement = findMatch(substs, td->getUnderlyingType())) {
-          auto *copy = clang::TypedefDecl::Create(
-              ctx, pattern, loc_, loc_, td->getIdentifier(), replacement);
-          copy->setAccess(clang::AS_public);
-          pattern->addDecl(copy);
-        }
-      } else if (auto *tdecl =
-                     llvm::dyn_cast<clang::ClassTemplateDecl>(member)) {
-        clang::Sema::ContextRAII savedContext(*sema_, pattern);
-        createInheritingTemplate(tdecl->getName(), tdecl, substs);
-      }
-    }
-
-    pattern->completeDefinition();
-    sema_->CurContext->addDecl(mirror);
-    return mirror;
-  }
-
-  clang::QualType createMirrorType(llvm::StringRef name, clang::QualType hint) {
-    clang::ASTContext &ctx = sema_->Context;
-    forceCompleteDefinition(hint);
-
-    const auto *hdecl = hint->getAsCXXRecordDecl();
-    assert(hdecl && "Failed resolving hint record declaration");
-    assert(hdecl->isCompleteDefinition() && "Incomplete hint");
-
-    const auto *hspec =
-        llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(hdecl);
-    if (!hspec) {
-      // if it is not a template specialization inheriting from it suffices
-      clang::RecordDecl *rdecl = createRecordDecl(name, hint);
-      return ctx.getTagType(clang::ElaboratedTypeKeyword::None,
-                            rdecl->getQualifier(), rdecl, false);
-    }
-
-    MirrorMap substs;
-    auto *mirror =
-        createInheritingTemplate(name, hspec->getSpecializedTemplate(), substs);
-    clang::QualType spec =
-        getTemplateIdType(mirror, hspec->getTemplateArgs().asArray());
-    assert(!spec.isNull() && spec->getAsCXXRecordDecl());
 
     // required to print Tn instead of Tn<arg1, arg2, ...>
-    clang::NamespaceDecl *ns = createNamespaceDecl();
-    auto *alias =
-        clang::TypeAliasDecl::Create(ctx, ns, loc_, loc_, &ctx.Idents.get(name),
-                                     ctx.getTrivialTypeSourceInfo(spec, loc_));
-    ns->addDecl(alias);
+    auto *alias = clang::TypeAliasDecl::Create(
+        ctx, sema_->CurContext, loc_, loc_, &ctx.Idents.get(name),
+        ctx.getTrivialTypeSourceInfo(hint, loc_));
+    sema_->CurContext->addDecl(alias);
 
     clang::QualType alias_t = ctx.getTypedefType(
         clang::ElaboratedTypeKeyword::None, std::nullopt, alias);
-    spec->getAsCXXRecordDecl()->addAttr(
-        clang::PreferredNameAttr::CreateImplicit(
-            ctx, ctx.getTrivialTypeSourceInfo(alias_t, loc_)));
 
-    return ctx.getCanonicalType(spec);
+    if (auto *hdecl = hint->getAsCXXRecordDecl()) {
+      hdecl->dropAttr<clang::PreferredNameAttr>();
+      hdecl->addAttr(clang::PreferredNameAttr::CreateImplicit(
+          ctx, ctx.getTrivialTypeSourceInfo(alias_t, loc_)));
+    }
+    return hint;
   }
 
   clang::QualType getSubstType(const clang::Sema::InstantiatingTemplate &Inst,
@@ -497,38 +213,25 @@ private:
     return getSubstType(Inst, type, currentArgs);
   }
 
-  clang::VarDecl *createVarDecl(clang::QualType type, llvm::StringRef name,
-                                clang::StorageClass sclass = clang::SC_None) {
+  clang::DeclRefExpr *createConstexprDeclRefExpr(clang::QualType type,
+                                                 clang::Expr *init,
+                                                 llvm::StringRef name) {
     clang::ASTContext &ctx = sema_->Context;
     clang::VarDecl *decl = clang::VarDecl::Create(
         ctx, sema_->CurContext, loc_, loc_, &ctx.Idents.get(name),
-        type.getNonReferenceType(), nullptr, sclass);
+        type.getNonReferenceType(), nullptr, clang::SC_Static);
     sema_->CurContext->addDecl(decl);
     decl->markUsed(ctx);
-    return decl;
-  }
-
-  clang::DeclRefExpr *createDeclRefExpr(clang::VarDecl *decl) {
-    const clang::DeclarationNameInfo nameInfo(decl->getDeclName(), loc_);
-    return sema_->BuildDeclRefExpr(decl, decl->getType(), clang::VK_LValue,
-                                   nameInfo, decl->getQualifierLoc());
-  }
-
-  clang::DeclRefExpr *createConstexprDeclRefExpr(clang::QualType type,
-                                                 llvm::StringRef name) {
-    clang::VarDecl *decl = createVarDecl(type, name, clang::SC_Static);
     decl->setConstexpr(true);
 
-    clang::Expr *init;
-    clang::ASTContext &ctx = sema_->Context;
-    if (type->isIntegerType()) {
-      init = clang::IntegerLiteral::Create(
-          ctx, llvm::APInt(ctx.getIntWidth(type), 1), type, loc_);
-    } else {
+    if (!init) {
       init = new (ctx) clang::ImplicitValueInitExpr(type);
     }
     decl->setInit(init);
-    return createDeclRefExpr(decl);
+
+    const clang::DeclarationNameInfo nameInfo(decl->getDeclName(), loc_);
+    return sema_->BuildDeclRefExpr(decl, decl->getType(), clang::VK_LValue,
+                                   nameInfo, decl->getQualifierLoc());
   }
 
   clang::OpaqueValueExpr *createOpaqueValueExpr(clang::QualType type) {
@@ -551,7 +254,7 @@ private:
         if (ttp->hasDefaultArgument()) {
           clang::QualType hint = getDefaultArg(decl, ttp, out);
           assert(!hint.isNull() && "Failed retrieving type hint");
-          type = createMirrorType(param->getName(), hint);
+          type = createAliasType(param->getName(), hint);
         } else {
           clang::RecordDecl *rdecl = createRecordDecl(param->getName());
           type = sema_->Context.getTagType(clang::ElaboratedTypeKeyword::None,
@@ -566,8 +269,16 @@ private:
           const clang::Sema::InstantiatingTemplate Inst(*sema_, loc_, decl);
           type = getSubstType(Inst, type, out);
         }
+        clang::Expr *hint = nullptr;
+        if (nttp->hasDefaultArgument()) {
+          auto *arg = nttp->getDefaultArgument().getArgument().getAsExpr();
+          if (auto *init = llvm::dyn_cast<clang::DeclRefExpr>(arg)) {
+            hint = llvm::cast<clang::VarDecl>(init->getDecl())->getInit();
+            type = hint->getType();
+          }
+        }
         clang::DeclRefExpr *var =
-            createConstexprDeclRefExpr(type, param->getName());
+            createConstexprDeclRefExpr(type, hint, param->getName());
         out.emplace_back(var, true);
       } else {
         assert(0 && "Unsupported template param kind");
@@ -575,324 +286,28 @@ private:
     }
   }
 
-  clang::FunctionDecl *instantiateRuleDecl(clang::FunctionTemplateDecl *decl) {
+  clang::FunctionDecl *
+  instantiateFunctionRule(clang::FunctionTemplateDecl *decl) {
     llvm::SmallVector<clang::TemplateArgument, 8> args;
     createTemplateArguments(decl, args);
-    return sema_->InstantiateFunctionDeclaration(
+    auto *inst = sema_->InstantiateFunctionDeclaration(
         decl, clang::TemplateArgumentList::CreateCopy(sema_->Context, args),
         loc_);
+    assert(inst && "Function rule instantiation failed");
+    sema_->InstantiateFunctionDefinition(loc_, inst);
+    return inst;
   }
 
-  clang::FunctionDecl *createCandidate(
-      clang::NamedDecl *decl, llvm::ArrayRef<clang::Expr *> callArgs,
-      clang::TemplateArgumentListInfo *explicitArgs = nullptr,
-      clang::QualType obj_t = clang::QualType(),
-      clang::Expr::Classification eclass = clang::Expr::Classification()) {
-    if (auto *tdecl = llvm::dyn_cast<clang::FunctionTemplateDecl>(decl)) {
-      if (auto *fdecl = deduceTemplateArguments(tdecl, callArgs, obj_t, eclass,
-                                                explicitArgs)) {
-        return fdecl;
-      }
-      return nullptr;
-    }
-    return llvm::dyn_cast<clang::FunctionDecl>(decl);
-  }
-
-  clang::CXXRecordDecl *resolveCXXRecordDecl(clang::QualType obj_t) {
-    obj_t = obj_t.getCanonicalType();
-    while (obj_t->isPointerOrReferenceType()) {
-      obj_t = obj_t->getPointeeType();
-    }
-
-    forceCompleteDefinition(obj_t);
-    if (auto *rdecl = obj_t->getAsCXXRecordDecl()) {
-      return rdecl->getDefinition();
-    }
-    return nullptr;
-  }
-
-  void regularNameLookup(llvm::ArrayRef<clang::Expr *> callArgs,
-                         clang::TemplateArgumentListInfo *explicitTArgs,
-                         clang::DeclarationName &name,
-                         clang::OverloadCandidateSet &candidates) {
-    clang::LookupResult decls(*sema_, name, loc_,
-                              clang::Sema::LookupOrdinaryName);
-    if (clang::NamespaceDecl *std_ns = sema_->getStdNamespace()) {
-      sema_->LookupQualifiedName(decls, std_ns);
-    }
-    if (decls.empty()) {
-      decls.clear();
-      sema_->LookupQualifiedName(decls,
-                                 sema_->Context.getTranslationUnitDecl());
-    }
-    for (auto *ndecl : decls) {
-      if (auto *candidate = createCandidate(ndecl, callArgs, explicitTArgs)) {
-        sema_->AddOverloadCandidate(
-            candidate, clang::DeclAccessPair::make(candidate, clang::AS_public),
-            callArgs, candidates, false);
-      }
-    }
-
-    for (const auto *arg : callArgs) {
-      if (auto *rdecl = resolveCXXRecordDecl(arg->getType())) {
-        for (auto *frdecl : rdecl->friends()) {
-          auto *fd = frdecl->getFriendDecl();
-          if (!fd) {
-            continue;
-          }
-
-          if (auto *ndecl = llvm::dyn_cast<clang::NamedDecl>(fd);
-              ndecl && ndecl->getDeclName() == name) {
-            if (auto *candidate =
-                    createCandidate(ndecl, callArgs, explicitTArgs)) {
-              sema_->AddOverloadCandidate(
-                  candidate,
-                  clang::DeclAccessPair::make(candidate, clang::AS_public),
-                  callArgs, candidates, false);
-            }
-          }
-        }
-      }
-    }
-  }
-
-  void cxxMethodNameLookup(clang::QualType obj_t,
-                           llvm::ArrayRef<clang::Expr *> callArgs,
-                           clang::TemplateArgumentListInfo *explicitTArgs,
-                           clang::DeclarationName &name,
-                           clang::OverloadCandidateSet &candidates) {
-    clang::CXXRecordDecl *rdecl = resolveCXXRecordDecl(obj_t);
-    assert(rdecl && "Failed fetching record decl");
-    clang::LookupResult members(*sema_, name, loc_,
-                                clang::Sema::LookupMemberName);
-    sema_->LookupQualifiedName(members, rdecl);
-
-    auto eclass = clang::Expr::Classification::makeSimpleLValue();
-    for (auto *ndecl : members) {
-      if (auto *candidate =
-              createCandidate(ndecl, callArgs, explicitTArgs, obj_t, eclass)) {
-        sema_->AddMethodCandidate(
-            clang::DeclAccessPair::make(candidate, clang::AS_public), obj_t,
-            eclass, callArgs, candidates);
-      }
-    }
-  }
-
-  void cxxConstructorNameLookup(clang::QualType obj_t,
-                                llvm::ArrayRef<clang::Expr *> callArgs,
-                                clang::OverloadCandidateSet &candidates) {
-    clang::CXXRecordDecl *rdecl = resolveCXXRecordDecl(obj_t);
-    assert(rdecl && "Failed fetching record decl");
-    clang::DeclContextLookupResult ctors = sema_->LookupConstructors(rdecl);
-
-    for (auto *ndecl : ctors) {
-      if (auto *candidate = createCandidate(ndecl, callArgs)) {
-        sema_->AddOverloadCandidate(
-            candidate, clang::DeclAccessPair::make(candidate, clang::AS_public),
-            callArgs, candidates, false);
-      }
-    }
-  }
-
-  void adlLookup(llvm::ArrayRef<clang::Expr *> callArgs,
-                 clang::DeclarationName &name,
-                 clang::OverloadCandidateSet &candidates) {
-    clang::ADLResult adl;
-    sema_->ArgumentDependentLookup(name, loc_, callArgs, adl);
-
-    for (auto *ndecl : adl) {
-      if (auto *candidate = createCandidate(ndecl, callArgs)) {
-        sema_->AddOverloadCandidate(
-            candidate, clang::DeclAccessPair::make(candidate, clang::AS_public),
-            callArgs, candidates, false);
-      }
-    }
-  }
-
-  clang::FunctionDecl *lookupCalledDecl(clang::FunctionTemplateDecl *decl,
-                                        LookupInfo &lookup) {
-    clang::NamespaceDecl *ns = createNamespaceDecl();
-    clang::Sema::ContextRAII savedContext(*sema_, ns);
-    clang::FunctionDecl *rule = instantiateRuleDecl(decl);
-    assert(rule && "Rule instantiation failed");
-    llvm::ArrayRef<clang::ParmVarDecl *> parms = rule->parameters();
-    auto csk = lookup.name.getNameKind() ==
-                       clang::DeclarationName::NameKind::CXXOperatorName
-                   ? clang::OverloadCandidateSet::CSK_Operator
-                   : clang::OverloadCandidateSet::CSK_Normal;
-
-    llvm::SmallVector<clang::Expr *, 8> callArgs;
-    for (const auto *parm : parms) {
-      clang::QualType parm_t = parm->getType();
-      forceCompleteDefinition(parm_t);
-      callArgs.emplace_back(createOpaqueValueExpr(parm_t));
-    }
-
-    llvm::ArrayRef<clang::TemplateArgument> ruleTArgs =
-        rule->getTemplateSpecializationArgs()->asArray();
-    clang::TemplateArgumentListInfo explicitTArgs;
-
-    {
-      const clang::Sema::InstantiatingTemplate Inst(*sema_, loc_, decl);
-      assert(!Inst.isInvalid() && "Invalid instantiation context");
-      for (const auto &argloc : lookup.explicitArgs) {
-        const auto &arg = argloc.getArgument();
-        if (!arg.isDependent()) {
-          explicitTArgs.addArgument(argloc);
-          continue;
-        }
-
-        clang::TemplateArgument inst;
-        if (arg.getKind() == clang::TemplateArgument::Type) {
-          inst = clang::TemplateArgument(
-              getSubstType(Inst, arg.getAsType(), ruleTArgs));
-        } else if (arg.getKind() == clang::TemplateArgument::Expression) {
-          if (auto *expr =
-                  llvm::dyn_cast<clang::DeclRefExpr>(arg.getAsExpr())) {
-            const auto *nttp =
-                llvm::dyn_cast<clang::NonTypeTemplateParmDecl>(expr->getDecl());
-            assert(nttp && "Unexpected decl in expr");
-            inst = ruleTArgs[nttp->getIndex()];
-          } else {
-            assert(0 && "Unsupported explicit template argument expression");
-          }
-        } else {
-          assert(0 && "Unsupported explicit template argument kind");
-        }
-
-        explicitTArgs.addArgument(
-            sema_->getTrivialTemplateArgumentLoc(inst, {}, loc_));
-      }
-    }
-
-    clang::DeclarationName name = lookup.name;
-    if (clang::QualType nameType = name.getCXXNameType();
-        !nameType.isNull() && nameType->isDependentType()) {
-      const clang::Sema::InstantiatingTemplate Inst(*sema_, loc_, decl);
-      assert(!Inst.isInvalid() && "Invalid instantiation context");
-      clang::MultiLevelTemplateArgumentList mtal;
-      mtal.setKind(clang::TemplateSubstitutionKind::Rewrite);
-      mtal.addOuterTemplateArguments(ruleTArgs);
-      name = sema_->SubstDeclarationNameInfo({name, loc_}, mtal).getName();
-    }
-
-    clang::OverloadCandidateSet candidates(loc_, csk);
-    switch (lookup.kind) {
-    case LookupKind::RegularName:
-      regularNameLookup(callArgs, &explicitTArgs, name, candidates);
-      break;
-    case LookupKind::CXXMethodName: {
-      llvm::ArrayRef<clang::Expr *> margs = callArgs;
-      cxxMethodNameLookup(margs.front()->getType().getNonReferenceType(),
-                          margs.drop_front(), &explicitTArgs, name, candidates);
-      break;
-    }
-    case LookupKind::CXXConstructorName:
-      cxxConstructorNameLookup(rule->getReturnType(), callArgs, candidates);
-      break;
-    case LookupKind::ADL:
-      regularNameLookup(callArgs, &explicitTArgs, name, candidates);
-      adlLookup(callArgs, name, candidates);
-      break;
-    }
-
-    clang::OverloadCandidateSet::iterator best;
-    switch (candidates.BestViableFunction(*sema_, loc_, best)) {
-    case clang::OverloadingResult::OR_Success:
-      return best->Function;
-    case clang::OverloadingResult::OR_Ambiguous:
-      for (auto &candidate : candidates) {
-        if (candidate.Viable) {
-          return candidate.Function;
-        }
-      }
-      break;
-    case clang::OverloadingResult::OR_No_Viable_Function:
-      llvm::errs() << "No viable function\n";
-      break;
-    case clang::OverloadingResult::OR_Deleted:
-      llvm::errs() << "Deleted function selected\n";
-      break;
-    }
-
-    assert(0 && "Rule resolution failed");
-    return nullptr;
-  }
-
-  clang::NamedDecl *lookupMemberAccess(clang::FunctionTemplateDecl *decl,
-                                       clang::DeclarationName name) {
-    clang::NamespaceDecl *ns = createNamespaceDecl();
-    clang::Sema::ContextRAII savedContext(*sema_, ns);
-    clang::FunctionDecl *rule = instantiateRuleDecl(decl);
-    assert(rule && "Rule instantiation failed");
-    clang::CXXRecordDecl *rdecl =
-        resolveCXXRecordDecl(rule->getParamDecl(0)->getType());
-    assert(rdecl && "Failed fetching record decl");
-    clang::LookupResult members(*sema_, name, loc_,
-                                clang::Sema::LookupMemberName);
-    sema_->LookupQualifiedName(members, rdecl);
-    assert(!members.empty() && "Rule resolution failed");
-    return members.getRepresentativeDecl();
-  }
-
-  clang::MemberExpr *
-  lookupArrowAccess(clang::FunctionTemplateDecl *decl,
-                    const clang::DeclarationNameInfo &nameInfo,
-                    clang::NestedNameSpecifierLoc nns) {
-    clang::NamespaceDecl *ns = createNamespaceDecl();
-    clang::Sema::ContextRAII savedContext(*sema_, ns);
-    clang::FunctionDecl *rule = instantiateRuleDecl(decl);
-    assert(rule && "Rule instantiation failed");
-
-    clang::Expr *obj = createOpaqueValueExpr(
-        rule->getParamDecl(0)->getType().getNonReferenceType());
-    auto arrow =
-        sema_->BuildOverloadedArrowExpr(sema_->getCurScope(), obj, loc_);
-    assert(arrow.isUsable() && "Overloaded arrow operator not found");
-
-    auto *base = arrow.getAs<clang::CXXOperatorCallExpr>();
-    assert(base && "Unexpected base type");
-
-    clang::CXXRecordDecl *rdecl =
-        resolveCXXRecordDecl(base->getType()->getPointeeType());
-    assert(rdecl && "Failed fetching record decl");
-
-    clang::LookupResult members(*sema_, nameInfo.getName(), loc_,
-                                clang::Sema::LookupMemberName);
-    sema_->LookupQualifiedName(members, rdecl);
-    for (auto *ndecl : members) {
-      if (auto *vdecl = llvm::dyn_cast<clang::ValueDecl>(ndecl)) {
-        clang::MemberExpr *access = sema_->BuildMemberExpr(
-            base, true, loc_, nns, loc_, vdecl,
-            clang::DeclAccessPair::make(vdecl, clang::AS_public), false,
-            nameInfo, vdecl->getType(), clang::VK_LValue, clang::OK_Ordinary);
-        assert(access && "Rule resolution failed");
-        return access;
-      }
-    }
-    assert(0 && "Rule resolution failed");
-    return nullptr;
-  }
-
-  clang::QualType lookupType(clang::TypeAliasTemplateDecl *decl) {
-    clang::NamespaceDecl *ns = createNamespaceDecl();
-    clang::Sema::ContextRAII savedContext(*sema_, ns);
-
-    llvm::SmallVector<clang::TemplateArgument, 4> args;
+  clang::QualType instantiateTypeRule(clang::TypeAliasTemplateDecl *decl) {
+    llvm::SmallVector<clang::TemplateArgument, 8> args;
     createTemplateArguments(decl, args);
 
-    clang::MultiLevelTemplateArgumentList mtal;
-    mtal.setKind(clang::TemplateSubstitutionKind::Rewrite);
-    mtal.addOuterTemplateArguments(args);
+    clang::QualType type = getTemplateIdType(decl, args);
+    assert(!type.isNull() && "Type rule instantiation failed");
 
-    clang::Sema::InstantiatingTemplate TypeInst(*sema_, loc_, decl, args);
-    assert(!TypeInst.isInvalid() && "Invalid instantiation context");
-
-    clang::TypeSourceInfo *tsi =
-        sema_->SubstType(decl->getTemplatedDecl()->getTypeSourceInfo(), mtal,
-                         loc_, clang::DeclarationName());
-    assert(tsi && "Rule resolution failed");
-    return tsi->getType();
+    const auto *tst = type->getAs<clang::TemplateSpecializationType>();
+    assert(tst && tst->isTypeAlias());
+    return tst->getAliasedType();
   }
 };
 
@@ -901,39 +316,15 @@ public:
   explicit ActionFactory(llvm::json::Object &out) : cb_(out) {
     using namespace clang::ast_matchers;
     finder_.addMatcher(
-        returnStmt(
-            isExpansionInMainFile(),
-            hasReturnValue(ignoringImplicit(ignoringParenImpCasts(anyOf(
-                callExpr().bind("fcall"), cxxConstructExpr().bind("ctor"),
-                cxxFunctionalCastExpr(has(ignoringImplicit(
-                    ignoringParenImpCasts(cxxConstructExpr().bind("ctor"))))),
-                memberExpr(hasDeclaration(fieldDecl())).bind("muse"),
-                unresolvedMemberExpr().bind("umuse"),
-                declRefExpr(to(anyOf(enumConstantDecl().bind("enum_val"),
-                                     decl(unless(parmVarDecl())).bind("decl"))))
-                    .bind("declref"),
-                unaryOperator(hasUnaryOperand(
-                                  declRefExpr(to(decl(unless(parmVarDecl()))))))
-                    .bind("udeclref"),
-                cxxDependentScopeMemberExpr().bind("dsme"),
-                cxxUnresolvedConstructExpr().bind("uctor"),
-                integerLiteral().bind("macro_int"))))),
-            hasAncestor(functionDecl(isDefinition(),
-                                     matchesName("(^|::)f[0-9]+$"),
-                                     isExpansionInMainFile())
-                            .bind("func"))),
-        &cb_);
-
-    finder_.addMatcher(
         typedefNameDecl(matchesName("(^|::)t[0-9]+$"), isExpansionInMainFile())
             .bind("tvar"),
         &cb_);
 
-    finder_.addMatcher(functionDecl(isDefinition(),
-                                    matchesName("(^|::)f[0-9]+$"),
-                                    isExpansionInMainFile())
-                           .bind("validate_func"),
-                       &cb_);
+    finder_.addMatcher(
+        functionDecl(isDefinition(), matchesName("(^|::)f[0-9]+$"),
+                     isExpansionInMainFile(), unless(isTemplateInstantiation()))
+            .bind("func"),
+        &cb_);
   }
 
   std::unique_ptr<clang::FrontendAction> create() override {
@@ -948,10 +339,11 @@ public:
         if (DE.hasErrorOccurred()) {
           std::exit(EXIT_FAILURE);
         }
-        DE.setSuppressAllDiagnostics(true);
-        DE.setClient(new clang::IgnoringDiagConsumer(), true);
         CB_->init(CI_->getSema());
         AC_->HandleTranslationUnit(ctx);
+        if (DE.hasErrorOccurred()) {
+          std::exit(EXIT_FAILURE);
+        }
       }
 
     private:
@@ -1022,8 +414,13 @@ int main(int argc, char *argv[]) {
   llvm::cl::HideUnrelatedOptions(cat);
   llvm::cl::ParseCommandLineOptions(argc, argv);
 
-  llvm::SmallVector<llvm::StringRef, 4> cxx_flags(CXXFlags.begin(),
-                                                  CXXFlags.end());
+  llvm::SmallVector<llvm::StringRef, 4> cxx_flags = {
+      "-Wno-everything",
+      "-I",
+      RULES_LIB_INCLUDE_DIR,
+  };
+  cxx_flags.append(CXXFlags.begin(), CXXFlags.end());
+
   fs::path dir = SrcDir.getValue();
   llvm::json::Object root;
   for (const char *name : {"src.c", "src.cpp"}) {

--- a/libcc2rs/src/iterators.rs
+++ b/libcc2rs/src/iterators.rs
@@ -1,7 +1,10 @@
 // Copyright (c) 2022-present INESC-ID.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
-use crate::{PostfixDec, PostfixInc, PrefixDec, PrefixInc, Ptr, Value};
+use crate::{
+    PostfixDec, PostfixInc, PrefixDec, PrefixInc, Ptr, UnsafePostfixDec, UnsafePostfixInc,
+    UnsafePrefixDec, UnsafePrefixInc, Value,
+};
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::ops::Bound;
@@ -224,4 +227,10 @@ impl<K: Ord + Clone, MapRef: MapAccess<Key = K>> PostfixDec for MapIter<K, MapRe
         self.dec();
         ret
     }
+}
+
+pub trait UnsafeIterator:
+    UnsafePrefixInc + UnsafePostfixInc + UnsafePrefixDec + UnsafePostfixDec + Default + PartialEq
+{
+    fn offset(&self, n: isize) -> Self;
 }

--- a/rule-preprocessor/src/syntactic.rs
+++ b/rule-preprocessor/src/syntactic.rs
@@ -381,11 +381,9 @@ impl<'a> FnIrBuilder<'a> {
             for pred in wc.predicates() {
                 let Some(ty) = pred.ty() else { continue };
                 let name = ty.syntax().text().to_string();
-                let bounds = extract_bounds(pred.type_bound_list());
-                generics
-                    .entry(name)
-                    .and_modify(|existing| existing.extend(bounds.clone()))
-                    .or_insert(bounds);
+                if let Some(generic) = generics.get_mut(&name) {
+                    generic.extend(extract_bounds(pred.type_bound_list()));
+                }
             }
         }
 

--- a/rules/algorithm/src.cpp
+++ b/rules/algorithm/src.cpp
@@ -7,114 +7,52 @@
 #include <string>
 #include <vector>
 
+#include "rule_hints.h"
+
 struct T2 {
   friend bool operator<(T2 a, T2 b) { return false; }
 };
 
-struct T1 {
-  using value_type = T2;
-  using difference_type = std::ptrdiff_t;
-  using reference = T2 &;
-  using pointer = T2 *;
-  using iterator_category = std::random_access_iterator_tag;
-
-  pointer p = nullptr;
-
-  T1() = default;
-
-  operator T2() const { return {}; }
-
-  reference operator*() const { return *p; }
-  pointer operator->() const { return p; }
-  reference operator[](difference_type n) const { return p[n]; }
-
-  T1 &operator++() {
-    ++p;
-    return *this;
-  }
-  T1 operator++(int) {
-    T1 tmp = *this;
-    ++*this;
-    return tmp;
-  }
-  T1 &operator--() {
-    --p;
-    return *this;
-  }
-  T1 operator--(int) {
-    T1 tmp = *this;
-    --*this;
-    return tmp;
-  }
-
-  T1 &operator+=(difference_type n) {
-    p += n;
-    return *this;
-  }
-  T1 &operator-=(difference_type n) {
-    p -= n;
-    return *this;
-  }
-  friend T1 operator+(T1 it, difference_type n) {
-    it += n;
-    return it;
-  }
-  friend T1 operator+(difference_type n, T1 it) {
-    it += n;
-    return it;
-  }
-  friend T1 operator-(T1 it, difference_type n) {
-    it -= n;
-    return it;
-  }
-  friend difference_type operator-(T1 a, T1 b) { return a.p - b.p; }
-
-  friend bool operator==(T1 a, T1 b) { return a.p == b.p; }
-  friend bool operator!=(T1 a, T1 b) { return a.p != b.p; }
-  friend bool operator<(T1 a, T1 b) { return a.p < b.p; }
-  friend bool operator>(T1 a, T1 b) { return a.p > b.p; }
-  friend bool operator<=(T1 a, T1 b) { return a.p <= b.p; }
-  friend bool operator>=(T1 a, T1 b) { return a.p >= b.p; }
-
-  T1 &operator=(const T2 &rhs) { return *this; }
-};
-
-template <typename T1> void f1(T1 first, T1 last) {
+template <typename T1 = Iterator<Comparable, Long>> void f1(T1 first, T1 last) {
   return std::sort(first, last);
 }
 
-template <typename T1, typename T2> T2 f2(T1 first, T1 last, T2 d_first) {
+template <typename T1 = Iterator<Plain, Long>,
+          typename T2 = Iterator<Plain, Long>>
+T2 f2(T1 first, T1 last, T2 d_first) {
   return std::copy(first, last, d_first);
 }
 
-template <class T1, class T2> T1 f3(T1 first, T1 last, const T2 &value) {
+template <typename T2 = Comparable, typename T1 = Iterator<T2, Long>>
+T1 f3(T1 first, T1 last, const T2 &value) {
   return std::find(first, last, value);
 }
 
 // TODO
 auto lambda = [](const T2 &a, const T2 &b) { return false; };
+template <typename T1 = Iterator<Plain, Long>>
 void f6(T1 first, T1 last, decltype(lambda) comp) {
   return std::stable_sort(first, last, comp);
 }
 
-template <typename T1, typename T2>
+template <typename T2, typename T1 = Iterator<T2, Long>>
 void f7(T1 first, T1 last, bool (*comp)(const T2 &, const T2 &)) {
   return std::stable_sort(first, last, comp);
 }
 
-template <typename T1> T1 *f8(T1 *first, T1 *last) {
+template <typename T1 = Comparable> T1 *f8(T1 *first, T1 *last) {
   return std::max_element(first, last);
 }
 
 template <typename T1> void f9(T1 &a0, T1 &a1) { return std::swap(a0, a1); }
 
-template <typename T1>
+template <typename T1 = Comparable>
 typename std::vector<T1>::iterator f10(typename std::vector<T1>::iterator a0,
                                        typename std::vector<T1>::iterator a1) {
   return std::unique(a0, a1);
 }
 
-template <typename T1, typename T2>
+template <typename T1, typename T2 = ImplicitlyConvertible>
 void f12(typename std::vector<T1>::iterator a0,
          typename std::vector<T1>::iterator a1, const T2 &a2) {
   return std::fill(a0, a1, a2);
@@ -128,19 +66,20 @@ std::ostream_iterator<char> f13(std::string::iterator a0,
 
 // TODO
 auto lambda_nref = [](T2 a, T2 b) { return false; };
+template <typename T1 = Iterator<Plain, Long>>
 void f14(T1 *first, T1 *last, decltype(lambda_nref) comp) {
   return std::stable_sort(first, last, comp);
 }
 
-template <typename T1, typename T2>
+template <typename T2, typename T1 = ImplicitlyConvertible>
 void f15(T1 *first, T1 *last, bool (*comp)(T2, T2)) {
   return std::stable_sort(first, last, comp);
 }
 
-template <typename T1> const T1 &f16(const T1 &a, const T1 &b) {
+template <typename T1 = Comparable> const T1 &f16(const T1 &a, const T1 &b) {
   return std::min(a, b);
 }
 
-template <typename T1> const T1 &f17(const T1 &a, const T1 &b) {
+template <typename T1 = Comparable> const T1 &f17(const T1 &a, const T1 &b) {
   return std::max(a, b);
 }

--- a/rules/array/src.cpp
+++ b/rules/array/src.cpp
@@ -3,8 +3,7 @@
 
 #include <array>
 
-template <typename T1, std::size_t T2>
-using t1 = std::array<T1, T2>;
+template <typename T1, std::size_t T2> using t1 = std::array<T1, T2>;
 
 template <typename T1, std::size_t T2>
 const T1 *f1(const std::array<T1, T2> &o) {

--- a/rules/cstddef/src.cpp
+++ b/rules/cstddef/src.cpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cstddef>
+
+#include "rule_hints.h"
+
+using t1 = std::byte;
+
+template <typename T1 = Integer> std::byte f1(const std::byte &a0, T1 a1) {
+  return operator<<(a0, a1);
+}
+
+template <typename T1 = Integer> std::byte f2(const std::byte &a0, T1 a1) {
+  return operator>>(a0, a1);
+}
+
+template <typename T1 = Integer> std::byte f3(std::byte &a0, T1 a1) {
+  return operator<<=(a0, a1);
+}
+
+template <typename T1 = Integer> std::byte f4(std::byte &a0, T1 a1) {
+  return operator>>=(a0, a1);
+}

--- a/rules/cstddef/tgt_unsafe.rs
+++ b/rules/cstddef/tgt_unsafe.rs
@@ -1,0 +1,38 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+fn t1() -> u8 {
+    Default::default()
+}
+
+fn f1<T1>(a0: &mut u8, a1: T1) -> u8
+where
+    u8: std::ops::Shl<T1, Output = u8>,
+{
+    *a0 << a1
+}
+
+fn f2<T1>(a0: &mut u8, a1: T1) -> u8
+where
+    u8: std::ops::Shr<T1, Output = u8>,
+{
+    *a0 >> a1
+}
+
+fn f3<T1>(a0: &mut u8, a1: T1) -> u8
+where
+    u8: std::ops::Shl<T1, Output = u8>,
+{
+    let n_ = *a0 << a1;
+    *a0 = n_;
+    *a0
+}
+
+fn f4<T1>(a0: &mut u8, a1: T1) -> u8
+where
+    u8: std::ops::Shr<T1, Output = u8>,
+{
+    let n_ = *a0 >> a1;
+    *a0 = n_;
+    *a0
+}

--- a/rules/iterator/src.cpp
+++ b/rules/iterator/src.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <iterator>
+
+#include "rule_hints.h"
+
+template <typename T1 = Iterator<Plain, Long>>
+using t1 = std::reverse_iterator<T1>;
+
+template <typename T1 = Iterator<Plain, Long>>
+using t2 = typename std::reverse_iterator<T1>::difference_type;
+
+template <typename T1 = Iterator<Plain, Long>> std::reverse_iterator<T1> f1() {
+  return std::reverse_iterator<T1>();
+}
+
+template <typename T1 = Iterator<Plain, Long>>
+std::reverse_iterator<T1>
+f2(typename std::reverse_iterator<T1>::iterator_type a0) {
+  return std::reverse_iterator<T1>(a0);
+}
+
+template <typename T1 = Iterator<Plain, Long>>
+typename std::reverse_iterator<T1>::iterator_type
+f3(const std::reverse_iterator<T1> &a0) {
+  return a0.base();
+}
+
+template <typename T2, typename T1 = Iterator<T2, Long>>
+typename std::reverse_iterator<T1>::reference
+f4(const std::reverse_iterator<T1> &a0) {
+  return a0.operator*();
+}
+
+template <typename T2, typename T1 = Iterator<T2, Long>>
+typename std::reverse_iterator<T1>::pointer
+f5(const std::reverse_iterator<T1> &a0) {
+  return a0.operator->();
+}
+
+template <typename T1 = Iterator<Plain, Long>>
+std::reverse_iterator<T1> &f6(std::reverse_iterator<T1> &a0) {
+  return a0.operator++();
+}
+
+template <typename T1 = Iterator<Plain, Long>>
+std::reverse_iterator<T1> f7(std::reverse_iterator<T1> &a0, int a1) {
+  return a0.operator++(a1);
+}
+
+template <typename T2 = Long, typename T1 = Iterator<Plain, T2>>
+std::reverse_iterator<T1>
+f8(const std::reverse_iterator<T1> &a0,
+   typename std::reverse_iterator<T1>::difference_type a1) {
+  return a0.operator+(a1);
+}
+
+template <typename T2 = Long, typename T1 = Iterator<Plain, T2>>
+std::reverse_iterator<T1>
+f9(const std::reverse_iterator<T1> &a0,
+   typename std::reverse_iterator<T1>::difference_type a1) {
+  return a0.operator-(a1);
+}
+
+template <typename T1 = Iterator<Plain, Long>,
+          typename T2 = Iterator<ImplicitlyConvertible, Long>>
+bool f10(const std::reverse_iterator<T1> &a0,
+         const std::reverse_iterator<T2> &a1) {
+  return operator==(a0, a1);
+}

--- a/rules/iterator/tgt_unsafe.rs
+++ b/rules/iterator/tgt_unsafe.rs
@@ -1,0 +1,52 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+use libcc2rs::*;
+
+fn t1<T1: UnsafeIterator>() -> T1 {
+    Default::default()
+}
+
+fn t2() -> isize {
+    Default::default()
+}
+
+fn f1<T1: UnsafeIterator>() -> T1 {
+    Default::default()
+}
+
+fn f2<T1>(a0: T1) -> T1 {
+    a0
+}
+
+fn f3<T1>(a0: T1) -> T1 {
+    a0
+}
+
+fn f4<T1: UnsafeIterator, T2>(a0: T1) -> T1 {
+    a0.offset(-1)
+}
+
+fn f5<T1: UnsafeIterator, T2>(a0: T1) -> T1 {
+    a0.offset(-1)
+}
+
+unsafe fn f6<T1: UnsafeIterator>(mut a0: T1) -> T1 {
+    a0.prefix_dec()
+}
+
+unsafe fn f7<T1: UnsafeIterator>(mut a0: T1) -> T1 {
+    a0.postfix_dec()
+}
+
+fn f8<T1: UnsafeIterator>(a0: T1, a1: isize) -> T1 {
+    a0.offset(Into::<isize>::into(-a1))
+}
+
+fn f9<T1: UnsafeIterator>(a0: T1, a1: isize) -> T1 {
+    a0.offset(Into::<isize>::into(a1))
+}
+
+fn f10<T1: UnsafeIterator>(a0: T1, a1: T1) -> bool {
+    a0 == a1
+}

--- a/rules/lib/rule_hints.h
+++ b/rules/lib/rule_hints.h
@@ -1,0 +1,462 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#pragma once
+
+#include <execution>
+#include <locale>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <variant>
+#include <vector>
+
+#include "rule_tags.h"
+
+namespace Synthesis {
+template <typename...> struct Slot;
+using BindExisting = void;
+using BindAny = void *;
+} // namespace Synthesis
+
+#define ARG(...) __VA_ARGS__
+
+#define DECLARE_HINT(name) template <int = 0> struct name
+
+#define DECLARE_PARAMETERIZABLE_HINT(name)                                     \
+  struct [[clang::annotate(CPP2RUST_PARAMETERIZABLE_RULE_TAG)]] name
+
+#define DECLARE_BUILTIN_HINT(name, type)                                       \
+  using name [[clang::annotate(CPP2RUST_BUILTIN_RULE_TAG)]] = type;
+
+#define DECLARE_PARAMETERIZABLE_BUILTIN_HINT(name, type)                       \
+  using name [[clang::annotate(CPP2RUST_BUILTIN_RULE_TAG),                     \
+               clang::annotate(CPP2RUST_PARAMETERIZABLE_RULE_TAG)]] = type;
+
+#define DECLARE_NON_TYPE_HINT(name, type, expr) constexpr type name = expr;
+
+DECLARE_BUILTIN_HINT(Integer, int)
+
+DECLARE_BUILTIN_HINT(Long, long)
+
+DECLARE_BUILTIN_HINT(Char, char)
+
+DECLARE_BUILTIN_HINT(WChar, wchar_t)
+
+DECLARE_BUILTIN_HINT(UnsignedInteger, unsigned)
+
+DECLARE_BUILTIN_HINT(ErrorCodeEnum, std::io_errc)
+
+DECLARE_BUILTIN_HINT(ErrorConditionEnum, std::errc)
+
+#if defined(__linux__)
+DECLARE_BUILTIN_HINT(ExecutionPolicy, std::execution::parallel_policy)
+#endif
+
+DECLARE_HINT(Plain){};
+
+DECLARE_HINT(Comparable) {
+  template <typename Other> bool operator==(const Other &) const;
+  template <typename Other> bool operator!=(const Other &) const;
+  template <typename Other> bool operator<(const Other &) const;
+  template <typename Other> bool operator>(const Other &) const;
+  template <typename Other> bool operator<=(const Other &) const;
+  template <typename Other> bool operator>=(const Other &) const;
+#if __cplusplus >= 202002L
+  template <typename Other>
+  std::strong_ordering operator<=>(const Other &) const;
+#endif
+};
+
+DECLARE_HINT(MoveAssignable) {
+  template <typename Other> MoveAssignable &operator=(Other &&);
+  template <typename Other> MoveAssignable &operator=(Other &&) const;
+};
+
+DECLARE_HINT(NonConvertibleComparable) {
+  template <typename Other> bool operator==(const Other &) const;
+  template <typename Other> bool operator!=(const Other &) const;
+  template <typename Other> bool operator<(const Other &) const;
+  template <typename Other> bool operator>(const Other &) const;
+  template <typename Other> bool operator<=(const Other &) const;
+  template <typename Other> bool operator>=(const Other &) const;
+#if __cplusplus >= 202002L
+  template <typename Other>
+  std::strong_ordering operator<=>(const Other &) const;
+#endif
+};
+
+template <typename> struct is_non_convertible : std::false_type {};
+
+template <auto N>
+struct is_non_convertible<NonConvertibleComparable<N>> : std::true_type {};
+
+template <typename Tp>
+inline constexpr bool is_non_convertible_v = is_non_convertible<Tp>::value;
+
+template <typename T>
+using enable_unless_non_convertible_t = std::enable_if_t<!is_non_convertible_v<
+    std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<T>>>>>;
+
+DECLARE_HINT(ExplicitlyConvertible) {
+  template <typename Other, typename = enable_unless_non_convertible_t<Other>>
+  explicit operator Other() const;
+};
+
+DECLARE_HINT(ImplicitlyConvertible) {
+  template <typename Other, typename = enable_unless_non_convertible_t<Other>>
+  operator Other() const;
+};
+
+template <typename T = Synthesis::Slot<ImplicitlyConvertible<>>>
+DECLARE_PARAMETERIZABLE_BUILTIN_HINT(Variant, std::variant<T>)
+
+template <typename T1 = Synthesis::Slot<ImplicitlyConvertible<>>,
+          typename T2 = Synthesis::Slot<ImplicitlyConvertible<>>>
+DECLARE_PARAMETERIZABLE_BUILTIN_HINT(TupleLike, ARG(std::tuple<T1, T2>))
+
+DECLARE_HINT(StringLike) {
+  template <typename CharT, typename Traits,
+            typename = enable_unless_non_convertible_t<CharT>>
+  operator std::basic_string<CharT, Traits>() const;
+
+  template <typename CharT, typename Traits,
+            typename = enable_unless_non_convertible_t<CharT>>
+  operator std::basic_string_view<CharT, Traits>() const;
+};
+
+template <typename T1, typename T2>
+using enable_any_convertible_t =
+    std::enable_if_t<std::is_convertible_v<T1, T2> ||
+                     std::is_convertible_v<T2, T1>>;
+
+template <typename InnerT = Synthesis::Slot<
+              Synthesis::BindExisting, Comparable<>, ExplicitlyConvertible<>,
+              ImplicitlyConvertible<>, MoveAssignable<>>,
+          typename DiffT = Synthesis::Slot<Long>>
+DECLARE_PARAMETERIZABLE_HINT(Iterator) {
+  using value_type = InnerT;
+  using difference_type = DiffT;
+  using pointer = value_type *;
+  using reference = value_type &;
+  using iterator_category = std::random_access_iterator_tag;
+#if __cplusplus >= 202002L
+  using iterator_concept = std::contiguous_iterator_tag;
+#endif
+
+  reference operator*() const;
+  pointer operator->() const;
+  reference operator[](difference_type) const;
+
+  Iterator &operator++();
+  Iterator operator++(int) const;
+  Iterator &operator--();
+  Iterator operator--(int) const;
+
+  Iterator &operator+=(difference_type);
+  Iterator &operator-=(difference_type);
+  Iterator operator+(difference_type) const;
+  Iterator operator-(difference_type) const;
+  difference_type operator-(const Iterator &) const;
+  friend Iterator operator+(difference_type, const Iterator &);
+
+  template <typename OInnerT, typename ODiffT,
+            typename = enable_any_convertible_t<OInnerT, InnerT>,
+            typename = enable_any_convertible_t<ODiffT, DiffT>>
+  bool operator==(const Iterator<OInnerT, ODiffT> &) const;
+
+  template <typename OInnerT, typename ODiffT,
+            typename = enable_any_convertible_t<OInnerT, InnerT>,
+            typename = enable_any_convertible_t<ODiffT, DiffT>>
+  bool operator!=(const Iterator<OInnerT, ODiffT> &) const;
+
+  template <typename OInnerT, typename ODiffT,
+            typename = enable_any_convertible_t<OInnerT, InnerT>,
+            typename = enable_any_convertible_t<ODiffT, DiffT>>
+  bool operator<(const Iterator<OInnerT, ODiffT> &) const;
+
+  template <typename OInnerT, typename ODiffT,
+            typename = enable_any_convertible_t<OInnerT, InnerT>,
+            typename = enable_any_convertible_t<ODiffT, DiffT>>
+  bool operator>(const Iterator<OInnerT, ODiffT> &) const;
+
+  template <typename OInnerT, typename ODiffT,
+            typename = enable_any_convertible_t<OInnerT, InnerT>,
+            typename = enable_any_convertible_t<ODiffT, DiffT>>
+  bool operator<=(const Iterator<OInnerT, ODiffT> &) const;
+
+  template <typename OInnerT, typename ODiffT,
+            typename = enable_any_convertible_t<OInnerT, InnerT>,
+            typename = enable_any_convertible_t<ODiffT, DiffT>>
+  bool operator>=(const Iterator<OInnerT, ODiffT> &) const;
+
+#if __cplusplus >= 202002L
+  template <typename OInnerT, typename ODiffT,
+            typename = enable_any_convertible_t<OInnerT, InnerT>,
+            typename = enable_any_convertible_t<ODiffT, DiffT>>
+  std::strong_ordering operator<=>(const Iterator<OInnerT, ODiffT> &) const;
+#endif
+
+#if defined(__linux__)
+  template <typename Other = InnerT,
+            typename = std::enable_if_t<std::is_same_v<Other, bool>>>
+  operator std::_Bit_const_iterator() const;
+
+  template <typename Other = InnerT,
+            typename = std::enable_if_t<std::is_same_v<Other, bool>>>
+  operator std::_Bit_iterator() const;
+#endif
+
+  template <typename OInnerT, typename ODiffT,
+            typename = enable_any_convertible_t<OInnerT, InnerT>,
+            typename = enable_any_convertible_t<ODiffT, DiffT>>
+  operator Iterator<OInnerT, ODiffT>() const;
+};
+
+template <typename InnerT = Synthesis::Slot<
+              Synthesis::BindExisting, Comparable<>, ExplicitlyConvertible<>,
+              ImplicitlyConvertible<>, MoveAssignable<>>,
+          typename DiffT = Synthesis::Slot<Long>>
+DECLARE_PARAMETERIZABLE_HINT(InputIterator) {
+  using value_type = InnerT;
+  using difference_type = DiffT;
+  using pointer = const value_type *;
+  using reference = const value_type &;
+  using iterator_concept = std::input_iterator_tag;
+  using iterator_category = std::input_iterator_tag;
+
+  reference operator*() const;
+  pointer operator->() const;
+  InputIterator &operator++();
+  InputIterator operator++(int);
+
+  template <typename OInnerT, typename ODiffT,
+            typename = enable_any_convertible_t<OInnerT, InnerT>,
+            typename = enable_any_convertible_t<ODiffT, DiffT>>
+  bool operator==(const InputIterator<OInnerT, ODiffT> &) const;
+
+  template <typename OInnerT, typename ODiffT,
+            typename = enable_any_convertible_t<OInnerT, InnerT>,
+            typename = enable_any_convertible_t<ODiffT, DiffT>>
+  bool operator!=(const InputIterator<OInnerT, ODiffT> &) const;
+
+  template <typename OInnerT, typename ODiffT,
+            typename = enable_any_convertible_t<OInnerT, InnerT>,
+            typename = enable_any_convertible_t<ODiffT, DiffT>>
+  bool operator<(const InputIterator<OInnerT, ODiffT> &) const;
+
+  template <typename OInnerT, typename ODiffT,
+            typename = enable_any_convertible_t<OInnerT, InnerT>,
+            typename = enable_any_convertible_t<ODiffT, DiffT>>
+  bool operator>(const InputIterator<OInnerT, ODiffT> &) const;
+
+  template <typename OInnerT, typename ODiffT,
+            typename = enable_any_convertible_t<OInnerT, InnerT>,
+            typename = enable_any_convertible_t<ODiffT, DiffT>>
+  bool operator<=(const InputIterator<OInnerT, ODiffT> &) const;
+
+  template <typename OInnerT, typename ODiffT,
+            typename = enable_any_convertible_t<OInnerT, InnerT>,
+            typename = enable_any_convertible_t<ODiffT, DiffT>>
+  bool operator>=(const InputIterator<OInnerT, ODiffT> &) const;
+
+#if __cplusplus >= 202002L
+  template <typename OInnerT, typename ODiffT,
+            typename = enable_any_convertible_t<OInnerT, InnerT>,
+            typename = enable_any_convertible_t<ODiffT, DiffT>>
+  std::strong_ordering operator<=>(const InputIterator<OInnerT, ODiffT> &)
+      const;
+#endif
+
+  template <typename OInnerT, typename ODiffT,
+            typename = enable_any_convertible_t<OInnerT, InnerT>,
+            typename = enable_any_convertible_t<ODiffT, DiffT>>
+  operator InputIterator<OInnerT, ODiffT>() const;
+};
+
+DECLARE_HINT(Callable) {
+  using is_transparent = void;
+
+  template <typename... Args> int operator()(Args...) noexcept;
+  template <typename... Args> int operator()(Args...) const noexcept;
+
+  template <typename Return, typename... Args>
+  Return operator()(Args...) noexcept;
+
+  template <typename Return, typename... Args>
+  Return operator()(Args...) const noexcept;
+
+  template <typename T> operator std::default_delete<T>() const;
+};
+
+template <typename T = Synthesis::Slot<Synthesis::BindExisting, Plain<>>>
+DECLARE_PARAMETERIZABLE_HINT(Allocator) {
+  using value_type = T;
+
+  Allocator() noexcept;
+  template <typename U> Allocator(const Allocator<U> &) noexcept;
+
+  T *allocate(std::size_t);
+  void deallocate(T *, std::size_t);
+
+  template <typename U> bool operator==(const Allocator<U> &) const noexcept;
+  template <typename U> bool operator!=(const Allocator<U> &) const noexcept;
+};
+
+DECLARE_HINT(BoolConstant) {
+  static constexpr bool value = false;
+  using value_type = bool;
+  constexpr operator value_type() const noexcept { return value; }
+  constexpr value_type operator()() const noexcept { return value; }
+};
+
+template <typename InnerT = Synthesis::Slot<
+              Synthesis::BindExisting, Comparable<>, ExplicitlyConvertible<>,
+              ImplicitlyConvertible<>, MoveAssignable<>>,
+          typename SizeT = Synthesis::Slot<Long>,
+          typename DiffT = Synthesis::Slot<Long>>
+DECLARE_PARAMETERIZABLE_HINT(Container) {
+  using value_type = InnerT;
+  using size_type = SizeT;
+  using difference_type = DiffT;
+  using reference = value_type &;
+  using const_reference = const value_type &;
+  using iterator = Iterator<value_type, DiffT>;
+  using const_iterator = Iterator<const value_type>;
+  using reverse_iterator = Iterator<value_type>;
+  using const_reverse_iterator = Iterator<const value_type>;
+
+  reference operator[](size_type) const;
+
+  void push_back(const value_type &);
+  void push_back(value_type &&);
+  void push_front(const value_type &);
+  void push_front(value_type &&);
+
+  iterator insert(const_iterator, const InnerT &);
+  iterator insert(const_iterator, InnerT &&);
+  iterator insert(const_iterator, size_type, const InnerT &);
+  template <typename InputIt> iterator insert(const_iterator, InputIt, InputIt);
+  iterator insert(const_iterator, std::initializer_list<InnerT>);
+
+  iterator begin() noexcept;
+  const_iterator begin() const noexcept;
+  const_iterator cbegin() const noexcept;
+  reverse_iterator rbegin() noexcept;
+
+  iterator end() noexcept;
+  const_iterator end() const noexcept;
+  const_iterator cend() const noexcept;
+  reverse_iterator rend() noexcept;
+
+  size_type size() const noexcept;
+  bool empty() const noexcept;
+
+  reference front();
+  reference back();
+  reference at(size_type);
+  InnerT *data() noexcept;
+
+  void clear() noexcept;
+  void pop_back();
+  template <typename... Args> reference emplace_back(Args && ...);
+  iterator erase(const_iterator);
+  void resize(size_type);
+};
+
+template <typename CharT = Synthesis::Slot<Synthesis::BindExisting>,
+          typename IntT = Synthesis::Slot<Integer>>
+DECLARE_PARAMETERIZABLE_HINT(CharTraits) {
+  using char_type = CharT;
+  using int_type = IntT;
+  using off_type = std::streamoff;
+  using pos_type = std::streampos;
+  using state_type = std::mbstate_t;
+
+  static void assign(char_type &, const char_type &);
+  static char_type *assign(char_type *, std::size_t, char_type);
+
+  static bool eq(char_type, char_type);
+  static bool lt(char_type, char_type);
+  static int compare(const char_type *, const char_type *, std::size_t);
+
+  static char_type *move(char_type *, const char_type *, std::size_t);
+  static char_type *copy(char_type *, const char_type *, std::size_t);
+
+  static std::size_t length(const char_type *);
+
+  static const char_type *find(const char_type *, std::size_t,
+                               const char_type &);
+
+  static char_type to_char_type(int_type);
+  static int_type to_int_type(char_type);
+  static bool eq_int_type(int_type, int_type);
+
+  static int_type eof();
+  static int_type not_eof(int_type);
+};
+
+template <typename T = Synthesis::Slot<Synthesis::BindExisting>>
+DECLARE_PARAMETERIZABLE_HINT(Range) {
+  T *begin();
+  T *end();
+
+  const T *begin() const;
+  const T *end() const;
+};
+
+template <typename T = Synthesis::Slot<Synthesis::BindExisting>>
+DECLARE_PARAMETERIZABLE_HINT(Derived) : T{};
+
+DECLARE_HINT(Mutex) {
+  void lock();
+  void unlock();
+
+  bool try_lock();
+  template <typename Duration> bool try_lock_for(Duration);
+  template <typename Duration> bool try_lock_until(Duration);
+};
+
+template <typename InternT = Synthesis::Slot<Char, WChar>,
+          typename ExternT = Synthesis::Slot<Char>>
+DECLARE_PARAMETERIZABLE_HINT(Facet)
+    : public std::codecvt<InternT, ExternT, std::mbstate_t>{};
+
+template <typename T = Synthesis::Slot<UnsignedInteger>>
+DECLARE_PARAMETERIZABLE_HINT(NumberGenerator) {
+  using result_type = T;
+  static constexpr result_type min() { return T{}; }
+  static constexpr result_type max() { return T{}; }
+  result_type operator()();
+};
+
+template <typename T =
+              Synthesis::Slot<Synthesis::BindExisting, ImplicitlyConvertible<>>>
+DECLARE_PARAMETERIZABLE_BUILTIN_HINT(Const, const T)
+
+template <typename T = Synthesis::Slot<Synthesis::BindExisting>>
+DECLARE_PARAMETERIZABLE_BUILTIN_HINT(Pointer, T *)
+
+template <typename T = Synthesis::Slot<Synthesis::BindExisting, Plain<>>>
+DECLARE_PARAMETERIZABLE_BUILTIN_HINT(Array, T[])
+
+template <typename T = Synthesis::Slot<Synthesis::BindExisting>>
+DECLARE_PARAMETERIZABLE_BUILTIN_HINT(DefaultDelete, std::default_delete<T>)
+
+DECLARE_NON_TYPE_HINT(NonNullInteger, int, 1)
+
+#if __cplusplus >= 202002L
+    DECLARE_NON_TYPE_HINT(SizedSubRangeKind, std::ranges::subrange_kind,
+                          std::ranges::subrange_kind::sized)
+#endif
+
+#define Plain Plain<__COUNTER__>
+#define Comparable Comparable<__COUNTER__>
+#define MoveAssignable MoveAssignable<__COUNTER__>
+#define NonConvertibleComparable NonConvertibleComparable<__COUNTER__>
+#define ExplicitlyConvertible ExplicitlyConvertible<__COUNTER__>
+#define ImplicitlyConvertible ImplicitlyConvertible<__COUNTER__>
+#define StringLike StringLike<__COUNTER__>
+#define Callable Callable<__COUNTER__>
+#define BoolConstant BoolConstant<__COUNTER__>
+#define Mutex Mutex<__COUNTER__>

--- a/rules/lib/rule_tags.h
+++ b/rules/lib/rule_tags.h
@@ -1,0 +1,5 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#define CPP2RUST_PARAMETERIZABLE_RULE_TAG "cpp2rust::parameterizable_rule_hint"
+#define CPP2RUST_BUILTIN_RULE_TAG "cpp2rust::builtin_rule_hint"

--- a/rules/map/src.cpp
+++ b/rules/map/src.cpp
@@ -4,6 +4,8 @@
 #include <map>
 #include <utility>
 
+#include "rule_hints.h"
+
 template <typename T1, typename T2> using t1 = std::map<T1, T2>;
 
 template <typename T1, typename T2>
@@ -12,7 +14,8 @@ using t2 = typename std::map<T1, T2>::const_iterator;
 template <typename T1, typename T2>
 using t3 = typename std::map<T1, T2>::iterator;
 
-template <typename T1, typename T2> T2 &f1(std::map<T1, T2> &o, const T1 &key) {
+template <typename T1 = Comparable, typename T2>
+T2 &f1(std::map<T1, T2> &o, const T1 &key) {
   return o.operator[](key);
 }
 
@@ -35,11 +38,13 @@ std::map<T1, T2> f6(const std::map<T1, T2> &&o) {
   return std::map<T1, T2>(std::move(o));
 }
 
-template <typename T1, typename T2> T2 &f7(std::map<T1, T2> &o, const T1 &key) {
+template <typename T1 = Comparable, typename T2>
+T2 &f7(std::map<T1, T2> &o, const T1 &key) {
   return o.at(key);
 }
 
-template <typename T1, typename T2> T2 &f8(std::map<T1, T2> &o, T1 &&key) {
+template <typename T1 = Comparable, typename T2>
+T2 &f8(std::map<T1, T2> &o, T1 &&key) {
   return o.operator[](std::move(key));
 }
 
@@ -48,7 +53,7 @@ typename std::map<T1, T2>::const_iterator f9(const std::map<T1, T2> &o) {
   return o.end();
 }
 
-template <typename T1, typename T2>
+template <typename T1 = Comparable, typename T2>
 typename std::map<T1, T2>::iterator f10(std::map<T1, T2> &o, const T1 &key) {
   return o.find(key);
 }
@@ -75,7 +80,7 @@ typename std::map<T1, T2>::iterator f14(std::map<T1, T2> &o) {
   return o.end();
 }
 
-template <typename T1, typename T2>
+template <typename T1 = Comparable, typename T2>
 const T2 &f15(const std::map<T1, T2> &o, const T1 &key) {
   return o.at(key);
 }
@@ -86,7 +91,7 @@ bool f16(typename std::map<T1, T2>::iterator a,
   return operator==(a, b);
 }
 
-template <typename T1, typename T2>
+template <typename T1 = Comparable, typename T2>
 typename std::map<T1, T2>::const_iterator f17(const std::map<T1, T2> &o,
                                               const T1 &key) {
   return o.find(key);

--- a/rules/pair/src.cpp
+++ b/rules/pair/src.cpp
@@ -3,6 +3,8 @@
 
 #include <utility>
 
+#include "rule_hints.h"
+
 template <typename T1, typename T2> using t1 = std::pair<T1, T2>;
 
 template <typename T1, typename T2> T2 &f1(std::pair<T1, T2> &o) {
@@ -19,17 +21,20 @@ std::pair<T1, T2> f4(const T1 &a0, const T2 &a1) {
   return std::pair<T1, T2>(a0, a1);
 }
 
-template <class T1, class T2, class T3, class T4>
+template <typename T1, typename T2, typename T3 = ExplicitlyConvertible,
+          typename T4 = ExplicitlyConvertible>
 std::pair<T1, T2> f5(const T3 &a0, T4 &a1) {
   return std::pair<T1, T2>(a0, a1);
 }
 
-template <class T1, class T2, class T3, class T4>
+template <typename T1, typename T2, typename T3 = ExplicitlyConvertible,
+          typename T4 = ExplicitlyConvertible>
 std::pair<T1, T2> f6(T3 &a0, T4 &a1) {
   return std::pair<T1, T2>(a0, a1);
 }
 
-template <typename T1, typename T2, typename T3, typename T4>
+template <typename T1, typename T2, typename T3 = ExplicitlyConvertible,
+          typename T4 = ExplicitlyConvertible>
 std::pair<T1, T2> f7(T3 &&a0, T4 &&a1) {
   return std::pair<T1, T2>(std::move(a0), std::move(a1));
 }

--- a/rules/src/modules.rs
+++ b/rules/src/modules.rs
@@ -28,6 +28,8 @@ pub mod carray_tgt_refcount;
 pub mod carray_tgt_unsafe;
 #[path = r#"../cmath/tgt_unsafe.rs"#]
 pub mod cmath_tgt_unsafe;
+#[path = r#"../cstddef/tgt_unsafe.rs"#]
+pub mod cstddef_tgt_unsafe;
 #[path = r#"../cstdlib/tgt_refcount.rs"#]
 pub mod cstdlib_tgt_refcount;
 #[path = r#"../cstdlib/tgt_unsafe.rs"#]
@@ -86,6 +88,8 @@ pub mod iostream_tgt_unsafe;
 pub mod ip_tgt_refcount;
 #[path = r#"../ip/tgt_unsafe.rs"#]
 pub mod ip_tgt_unsafe;
+#[path = r#"../iterator/tgt_unsafe.rs"#]
+pub mod iterator_tgt_unsafe;
 #[path = r#"../limits/tgt_unsafe.rs"#]
 pub mod limits_tgt_unsafe;
 #[path = r#"../locale/tgt_refcount.rs"#]

--- a/rules/unique_ptr/src.cpp
+++ b/rules/unique_ptr/src.cpp
@@ -4,6 +4,8 @@
 #include <cstddef>
 #include <memory>
 
+#include "rule_hints.h"
+
 template <typename T1> using t1 = std::unique_ptr<T1>;
 template <typename T1> using t2 = std::unique_ptr<T1[]>;
 
@@ -40,7 +42,8 @@ template <typename T1> T1 *f7(std::unique_ptr<T1[]> &o) { return o.get(); }
 // versions for make_unique with 1, 2, 3, etc arguments and translate the
 // specialized versions.
 
-template <typename T1, typename T2> std::unique_ptr<T1> f8(T2 &&a0) {
+template <typename T1, typename T2 = ImplicitlyConvertible>
+std::unique_ptr<T1> f8(T2 &&a0) {
   return std::make_unique<T1>(std::move(a0));
 }
 

--- a/rules/vector/src.cpp
+++ b/rules/vector/src.cpp
@@ -5,18 +5,20 @@
 #include <initializer_list>
 #include <vector>
 
+#include "rule_hints.h"
+
 template <typename T1> using t1 = std::vector<T1>;
 template <typename T1> using t2 = typename std::vector<T1>::iterator;
 template <typename T1> using t3 = std::vector<std::vector<T1>>;
 template <typename T1> using t4 = typename std::vector<T1>::const_iterator;
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 using t5 = std::vector<T1, T2>;
 
 #if defined(__linux__)
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 using t6 = typename std::vector<T1, T2>::iterator;
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 using t7 = typename std::vector<T1, T2>::const_iterator;
 #endif
 
@@ -181,7 +183,8 @@ std::vector<T1> f36(const std::initializer_list<T1> &a0) {
   return std::vector<T1>(a0);
 }
 
-template <typename T1, typename T2> std::vector<T1> f37(T2 *first, T2 *last) {
+template <typename T1, typename T2 = ImplicitlyConvertible>
+std::vector<T1> f37(T2 *first, T2 *last) {
   return std::vector<T1>(first, last);
 }
 
@@ -189,7 +192,8 @@ std::vector<bool> f38(std::size_t n, const bool &value) {
   return std::vector<bool>(n, value);
 }
 
-template <class T1, std::size_t T2> const T1 *f40(T1 const (&a0)[T2]) {
+template <typename T1, std::size_t T2 = NonNullInteger>
+const T1 *f40(T1 const (&a0)[T2]) {
   return std::end(a0);
 }
 
@@ -197,7 +201,7 @@ template <typename T1> const T1 *f41(const std::vector<T1> &o) {
   return o.data();
 }
 
-template <typename T1>
+template <typename T1 = Comparable>
 typename std::vector<T1>::const_iterator
 f42(typename std::vector<T1>::const_iterator first,
     typename std::vector<T1>::const_iterator last) {
@@ -214,7 +218,9 @@ typename std::vector<T1>::const_iterator f44(const std::vector<T1> &o) {
   return o.end();
 }
 
-bool f47(std::vector<bool> &o) { return o[0]; }
+bool f47(std::vector<bool> &a0, std::vector<bool>::size_type a1) {
+  return a0[a1].operator bool();
+}
 
 template <typename T1> void f48(std::vector<T1> &o, std::vector<T1> &a0) {
   return o.swap(a0);
@@ -270,260 +276,260 @@ template <typename T1> void f59(std::vector<T1> &o) {
   return o.shrink_to_fit();
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 typename std::vector<T1, T2>::iterator
 f60(std::vector<T1, T2> &o, typename std::vector<T1, T2>::const_iterator it) {
   return o.erase(it);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 std::size_t f61(const std::vector<T1, T2> &o) {
   return o.size();
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 bool f62(const std::vector<T1, T2> &o) {
   return o.empty();
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
-std::vector<T1, T2> f63() {
+template <typename T1, typename T2 = Allocator<T1>> std::vector<T1, T2> f63() {
   return std::vector<T1, T2>();
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 void f64(std::vector<T1, T2> &o) {
   return o.pop_back();
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 T1 *f65(std::vector<T1, T2> &o) {
   return o.data();
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 T1 &f66(std::vector<T1, T2> &o, std::size_t idx) {
   return o.at(idx);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 std::vector<T1, T2> f67(std::size_t n) {
   return std::vector<T1, T2>(n);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 T1 &f68(std::vector<T1, T2> &o) {
   return o.front();
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 T1 &f69(std::vector<T1, T2> &o) {
   return o.back();
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 std::size_t f70(const std::vector<T1, T2> &o) {
   return o.capacity();
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 void f71(std::vector<T1, T2> &o, std::size_t n) {
   return o.reserve(n);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 typename std::vector<T1, T2>::iterator f72(std::vector<T1, T2> &o) {
   return o.begin();
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 void f73(std::vector<T1, T2> &o, T1 &&value) {
   return o.push_back(std::move(value));
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 void f74(std::vector<T1, T2> &o, std::size_t n) {
   return o.resize(n);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 void f75(std::vector<T1, T2> &o) {
   return o.clear();
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 typename std::vector<T1, T2>::iterator f76(std::vector<T1, T2> &o) {
   return o.end();
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 typename std::vector<T1, T2>::iterator
 f77(std::vector<T1, T2> &o, typename std::vector<T1, T2>::const_iterator it,
     T1 &&value) {
   return o.insert(it, std::move(value));
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 std::vector<T1, T2> f78(std::size_t n, const T1 &value) {
   return std::vector<T1, T2>(n, value);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 typename std::vector<T1, T2>::iterator
 f79(std::vector<T1, T2> &o, typename std::vector<T1, T2>::const_iterator it,
     const T1 &value) {
   return o.insert(it, value);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 void f80(std::vector<T1, T2> &o, const T1 &value) {
   return o.push_back(value);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 typename std::vector<T1, T2>::reference
 f81(typename std::vector<T1, T2>::iterator it) {
   return it.operator*();
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 typename std::vector<T1, T2>::iterator
 f82(const typename std::vector<T1, T2>::iterator &it) {
   return typename std::vector<T1, T2>::iterator(it);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 typename std::vector<T1, T2>::const_iterator
 f83(const typename std::vector<T1, T2>::iterator &it) {
   return typename std::vector<T1, T2>::const_iterator(it);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 typename std::vector<T1, T2>::iterator
 f84(typename std::vector<T1, T2>::iterator it, std::size_t n) {
   return it.operator+(n);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 bool f85(const typename std::vector<T1, T2>::iterator &it1,
          const typename std::vector<T1, T2>::iterator &it2) {
   return operator!=(it1, it2);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 bool f86(const typename std::vector<T1, T2>::iterator &it1,
          const typename std::vector<T1, T2>::iterator &it2) {
   return operator==(it1, it2);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 typename std::vector<T1, T2>::iterator
 f87(typename std::vector<T1, T2>::iterator a0, int a1) {
   return a0.operator++(a1);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 typename std::vector<T1, T2>::iterator::difference_type
 f88(const typename std::vector<T1, T2>::iterator &it1,
     const typename std::vector<T1, T2>::iterator &it2) {
   return operator-(it1, it2);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 typename std::vector<T1, T2>::iterator &
 f89(typename std::vector<T1, T2>::iterator &it) {
   return it.operator++();
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 std::vector<T1, T2> f90(const T1 *first, const T1 *last) {
   return std::vector<T1, T2>(first, last);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 std::vector<T1, T2> f91(const std::initializer_list<T1> &a0) {
   return std::vector<T1, T2>(a0);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>, typename T3>
+template <typename T1, typename T2 = Allocator<T1>,
+          typename T3 = ImplicitlyConvertible>
 std::vector<T1, T2> f92(T3 *first, T3 *last) {
   return std::vector<T1, T2>(first, last);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 const T1 *f93(const std::vector<T1, T2> &o) {
   return o.data();
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1 = Comparable, typename T2 = Allocator<T1>>
 typename std::vector<T1, T2>::const_iterator
 f94(typename std::vector<T1, T2>::const_iterator first,
     typename std::vector<T1, T2>::const_iterator last) {
   return std::max_element(first, last);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 typename std::vector<T1, T2>::const_iterator f95(const std::vector<T1, T2> &o) {
   return o.begin();
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 typename std::vector<T1, T2>::const_iterator f96(const std::vector<T1, T2> &o) {
   return o.end();
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 void f97(std::vector<T1, T2> &o, std::vector<T1, T2> &a0) {
   return o.swap(a0);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 const T1 &f98(const std::vector<T1, T2> &o, std::size_t idx) {
   return o.at(idx);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 const T1 &f99(const std::vector<T1, T2> &o) {
   return o.back();
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 void f100(std::vector<std::vector<T1, T2>> &o,
           const std::vector<T1, T2> &value) {
   return o.push_back(value);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 typename std::vector<T1, T2>::iterator
 f101(std::vector<T1, T2> &o, typename std::vector<T1, T2>::const_iterator pos,
      const T1 *first, const T1 *last) {
   return o.insert(pos, first, last);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 void f102(std::vector<T1, T2> &o, std::size_t n,
           const typename std::vector<T1, T2>::value_type &value) {
   return o.resize(n, value);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 std::vector<T1, T2> &f103(std::vector<T1, T2> &dst, std::vector<T1, T2> &&src) {
   return dst.operator=(std::move(src));
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 typename std::vector<T1, T2>::const_iterator
 f104(const std::vector<T1, T2> &o) {
   return o.cend();
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 std::vector<T1, T2> &f105(std::vector<T1, T2> &dst,
                           const std::vector<T1, T2> &src) {
   return dst.operator=(src);
 }
 
-template <typename T1, typename T2 = std::allocator<T1>>
+template <typename T1, typename T2 = Allocator<T1>>
 void f106(std::vector<T1, T2> &o) {
   return o.shrink_to_fit();
 }

--- a/tests/unit/byte.cpp
+++ b/tests/unit/byte.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+#include <cstddef>
+
+int main() {
+  std::byte b1{0x01};
+
+  int ishift1 = 3;
+  std::byte shl1 = b1 << ishift1;
+  assert(shl1 == std::byte(0x08));
+
+  int ishift2 = 2;
+  std::byte shr1 = shl1 >> ishift2;
+  assert(shr1 == std::byte(0x02));
+
+  int ishift3 = 5;
+  b1 <<= ishift3;
+  assert(b1 == std::byte(0x20));
+
+  int ishift4 = 3;
+  b1 >>= ishift4;
+  assert(b1 == std::byte(0x04));
+
+  std::byte b2{0x01};
+
+  unsigned ushift1 = 3;
+  std::byte shl2 = b2 << ushift1;
+  assert(shl2 == std::byte(0x08));
+
+  unsigned ushift2 = 2;
+  std::byte shr2 = shl2 >> ushift2;
+  assert(shr2 == std::byte(0x02));
+
+  unsigned ushift3 = 5;
+  b2 <<= ushift3;
+  assert(b2 == std::byte(0x20));
+
+  unsigned ushift4 = 3;
+  b2 >>= ushift4;
+  assert(b2 == std::byte(0x04));
+  return 0;
+}

--- a/tests/unit/out/refcount/byte.rs
+++ b/tests/unit/out/refcount/byte.rs
@@ -1,0 +1,56 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let b1: Value<u8> = Rc::new(RefCell::new(1_u8));
+    let ishift1: Value<i32> = Rc::new(RefCell::new(3));
+    let shl1: Value<u8> = Rc::new(RefCell::new((*b1.borrow()) << (*ishift1.borrow())));
+    assert!(((*shl1.borrow()) == 8));
+    let ishift2: Value<i32> = Rc::new(RefCell::new(2));
+    let shr1: Value<u8> = Rc::new(RefCell::new((*shl1.borrow()) >> (*ishift2.borrow())));
+    assert!(((*shr1.borrow()) == 2));
+    let ishift3: Value<i32> = Rc::new(RefCell::new(5));
+    {
+        let n_ = (*b1.borrow()) << (*ishift3.borrow());
+        (*b1.borrow_mut()) = n_;
+        (*b1.borrow())
+    };
+    assert!(((*b1.borrow()) == 32));
+    let ishift4: Value<i32> = Rc::new(RefCell::new(3));
+    {
+        let n_ = (*b1.borrow()) >> (*ishift4.borrow());
+        (*b1.borrow_mut()) = n_;
+        (*b1.borrow())
+    };
+    assert!(((*b1.borrow()) == 4));
+    let b2: Value<u8> = Rc::new(RefCell::new(1_u8));
+    let ushift1: Value<u32> = Rc::new(RefCell::new(3_u32));
+    let shl2: Value<u8> = Rc::new(RefCell::new((*b2.borrow()) << (*ushift1.borrow())));
+    assert!(((*shl2.borrow()) == 8));
+    let ushift2: Value<u32> = Rc::new(RefCell::new(2_u32));
+    let shr2: Value<u8> = Rc::new(RefCell::new((*shl2.borrow()) >> (*ushift2.borrow())));
+    assert!(((*shr2.borrow()) == 2));
+    let ushift3: Value<u32> = Rc::new(RefCell::new(5_u32));
+    {
+        let n_ = (*b2.borrow()) << (*ushift3.borrow());
+        (*b2.borrow_mut()) = n_;
+        (*b2.borrow())
+    };
+    assert!(((*b2.borrow()) == 32));
+    let ushift4: Value<u32> = Rc::new(RefCell::new(3_u32));
+    {
+        let n_ = (*b2.borrow()) >> (*ushift4.borrow());
+        (*b2.borrow_mut()) = n_;
+        (*b2.borrow())
+    };
+    assert!(((*b2.borrow()) == 4));
+    return 0;
+}

--- a/tests/unit/out/refcount/reverse_iterator.rs
+++ b/tests/unit/out/refcount/reverse_iterator.rs
@@ -1,0 +1,84 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+#[derive(Default)]
+pub struct Foo {
+    pub v: Value<i32>,
+}
+impl Foo {
+    pub fn get(&self) -> i32 {
+        return (*self.v.borrow());
+    }
+}
+impl Clone for Foo {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            v: Rc::new(RefCell::new((*self.v.borrow()))),
+        };
+        this
+    }
+}
+impl ByteRepr for Foo {
+    fn byte_size() -> usize {
+        4
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.v.borrow()).to_bytes(&mut buf[0..4]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            v: Rc::new(RefCell::new(<i32>::from_bytes(&buf[0..4]))),
+        }
+    }
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let a1: Value<Box<[Foo]>> = Rc::new(RefCell::new(Box::new([
+        Foo {
+            v: Rc::new(RefCell::new(10)),
+        },
+        Foo {
+            v: Rc::new(RefCell::new(20)),
+        },
+        Foo {
+            v: Rc::new(RefCell::new(30)),
+        },
+        Foo {
+            v: Rc::new(RefCell::new(40)),
+        },
+        Foo {
+            v: Rc::new(RefCell::new(50)),
+        },
+    ])));
+    let def: Value<Ptr<Foo>> = Rc::new(RefCell::new(Default::default()));
+    let first: Value<Ptr<Foo>> = Rc::new(RefCell::new(
+        (a1.as_pointer() as Ptr<Foo>).offset((5) as isize),
+    ));
+    assert!(((*first.borrow()) == (a1.as_pointer() as Ptr<Foo>).offset((5) as isize)));
+    let ref_: Ptr<Foo> = (*first.borrow()).offset(-1);
+    assert!((({ (*ref_.upgrade().deref()).get() }) == 50));
+    assert!((({ (*(*first.borrow()).offset(-1).upgrade().deref()).get() }) == 50));
+    (*first.borrow_mut()).prefix_dec();
+    assert!((({ (*(*first.borrow()).offset(-1).upgrade().deref()).get() }) == 40));
+    let inc: Value<Ptr<Foo>> = Rc::new(RefCell::new((*first.borrow_mut()).postfix_dec()));
+    assert!((({ (*(*inc.borrow()).offset(-1).upgrade().deref()).get() }) == 40));
+    assert!((({ (*(*first.borrow()).offset(-1).upgrade().deref()).get() }) == 30));
+    let n: Value<isize> = Rc::new(RefCell::new(2_isize));
+    let plus: Value<Ptr<Foo>> = Rc::new(RefCell::new(
+        (*first.borrow()).offset(Into::<isize>::into(-(*n.borrow()))),
+    ));
+    assert!((({ (*(*plus.borrow()).offset(-1).upgrade().deref()).get() }) == 10));
+    let minus: Value<Ptr<Foo>> = Rc::new(RefCell::new(
+        (*plus.borrow()).offset(Into::<isize>::into((*n.borrow()))),
+    ));
+    assert!((({ (*(*minus.borrow()).offset(-1).upgrade().deref()).get() }) == 30));
+    assert!((*minus.borrow()) == (*first.borrow()));
+    return 0;
+}

--- a/tests/unit/out/unsafe/byte.rs
+++ b/tests/unit/out/unsafe/byte.rs
@@ -1,0 +1,58 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut b1: u8 = 1_u8;
+    let mut ishift1: i32 = 3;
+    let mut shl1: u8 = b1 << ishift1;
+    assert!(((shl1) == (8)));
+    let mut ishift2: i32 = 2;
+    let mut shr1: u8 = shl1 >> ishift2;
+    assert!(((shr1) == (2)));
+    let mut ishift3: i32 = 5;
+    {
+        let n_ = b1 << ishift3;
+        b1 = n_;
+        b1
+    };
+    assert!(((b1) == (32)));
+    let mut ishift4: i32 = 3;
+    {
+        let n_ = b1 >> ishift4;
+        b1 = n_;
+        b1
+    };
+    assert!(((b1) == (4)));
+    let mut b2: u8 = 1_u8;
+    let mut ushift1: u32 = 3_u32;
+    let mut shl2: u8 = b2 << ushift1;
+    assert!(((shl2) == (8)));
+    let mut ushift2: u32 = 2_u32;
+    let mut shr2: u8 = shl2 >> ushift2;
+    assert!(((shr2) == (2)));
+    let mut ushift3: u32 = 5_u32;
+    {
+        let n_ = b2 << ushift3;
+        b2 = n_;
+        b2
+    };
+    assert!(((b2) == (32)));
+    let mut ushift4: u32 = 3_u32;
+    {
+        let n_ = b2 >> ushift4;
+        b2 = n_;
+        b2
+    };
+    assert!(((b2) == (4)));
+    return 0;
+}

--- a/tests/unit/out/unsafe/reverse_iterator.rs
+++ b/tests/unit/out/unsafe/reverse_iterator.rs
@@ -1,0 +1,50 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct Foo {
+    pub v: i32,
+}
+impl Foo {
+    pub unsafe fn get(&self) -> i32 {
+        return self.v;
+    }
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut a1: [Foo; 5] = [
+        Foo { v: 10 },
+        Foo { v: 20 },
+        Foo { v: 30 },
+        Foo { v: 40 },
+        Foo { v: 50 },
+    ];
+    let mut def: *mut Foo = Default::default();
+    let mut first: *mut Foo = a1.as_mut_ptr().offset((5) as isize);
+    assert!(((first) == (a1.as_mut_ptr().offset((5) as isize))));
+    let ref_: *mut Foo = &mut (*first.offset(-1)) as *mut Foo;
+    assert!(((unsafe { (*ref_).get() }) == (50)));
+    assert!(((unsafe { (*(first.offset(-1)).cast_const()).get() }) == (50)));
+    first.prefix_dec();
+    assert!(((unsafe { (*(first.offset(-1)).cast_const()).get() }) == (40)));
+    let mut inc: *mut Foo = first.postfix_dec();
+    assert!(((unsafe { (*(inc.offset(-1)).cast_const()).get() }) == (40)));
+    assert!(((unsafe { (*(first.offset(-1)).cast_const()).get() }) == (30)));
+    let mut n: isize = 2_isize;
+    let mut plus: *mut Foo = first.offset(Into::<isize>::into(-n));
+    assert!(((unsafe { (*(plus.offset(-1)).cast_const()).get() }) == (10)));
+    let mut minus: *mut Foo = plus.offset(Into::<isize>::into(n));
+    assert!(((unsafe { (*(minus.offset(-1)).cast_const()).get() }) == (30)));
+    assert!(minus == first);
+    return 0;
+}

--- a/tests/unit/reverse_iterator.cpp
+++ b/tests/unit/reverse_iterator.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+#include <cassert>
+#include <iterator>
+
+struct Foo {
+  int v;
+  int get() const { return v; }
+};
+
+int main() {
+  Foo a1[] = {{10}, {20}, {30}, {40}, {50}};
+
+  std::reverse_iterator<Foo *> def;
+  std::reverse_iterator<Foo *> first(a1 + 5);
+  assert(first.base() == a1 + 5);
+
+  std::reverse_iterator<Foo *>::reference ref = *first;
+  assert(ref.get() == 50);
+  assert(first->get() == 50);
+
+  ++first;
+  assert(first->get() == 40);
+
+  std::reverse_iterator<Foo *> inc = first++;
+  assert(inc->get() == 40);
+  assert(first->get() == 30);
+
+  std::reverse_iterator<Foo *>::difference_type n = 2;
+
+  std::reverse_iterator<Foo *> plus = first + n;
+  assert(plus->get() == 10);
+  std::reverse_iterator<Foo *> minus = plus - n;
+  assert(minus->get() == 30);
+  assert(minus == first);
+  return 0;
+}


### PR DESCRIPTION
Previously, `cpp-rule-preprocessor` worked by synthesizing the template arguments required by a given template rule and forcing its instantiation, sidestepping type checking. In the presence of hints, the synthesized types would inherit the hints, which also introduced problems. This solution was neither robust nor easily extensible.

This PR adds a header containing hints that can be used by rule authors and refactors how the preprocessor works. Each template rule is now directly instantiated using the appropriate `Sema` APIs. Additionally, compilation errors are no longer suppressed, a compilation error that arises during preprocessing now means that a rule is malformed. This makes the preprocessor much simpler and more robust.

The template arguments used to instantiate each rule are created based on the provided hints. If a template parameter does not have a default, a POD is synthesized. If a parameter has a default, that default is wrapped in a type alias and used directly.

The following rule:
```cpp
template <typename T1, typename T2 = ImplicitlyConvertible>
std::vector<T1> f37(T2 *first, T2 *last) {
  return std::vector<T1>(first, last);
}
```
Is instantiated by the preprocessor by synthesizing the following:
```cpp
namespace {
struct T1 {};
using T2 = ImplicitlyConvertible;
template <T1, T2> std::vector<T1> f37(T2 *first, T2 *last);
};
```
These changes to the preprocessor mean that, going forward, any rule that cannot be instantiated using a POD must use an appropriate hint.

Hints that correspond to classes are printed in their generic form, `T<digit>`, by attaching a PreferredName attribute to the declaration. This does not work for hints defined as builtin types. These hints are instead printed as `T<digit>` by having `normalizeQualType` search for a corresponding typedef in the enclosing namespace. This lookup is only performed for `SubstTemplateTypeParmType` types, which ensures that there are no collisions between builtin hints and actual builtin types spelled in the rule. This is tested by the `std::byte` rules this patch adds.

Hints that expose inner type aliases, such as `Iterator`, must be parameterized over those types. Otherwise, these types are leaked into the IR. For instance, a rule such as the following:
```cpp
template <typename T2, typename T1 = Iterator<T2, Long>>
typename std::reverse_iterator<T1>::reference
f4(const std::reverse_iterator<T1> &a0) {
  return a0.operator*();
}
```
Is currently represented as `T2 & std::reverse_iterator<T1>::operator*()` const in the IR. If we were to use a fixed type for the `Iterator` hint's `reference` type alias, such as `using reference = long &`, this rule would be incorrectly printed as `long & std::reverse_iterator<T1>::operator*() const`. This is tested by the `std::reverse_iterator` rules added by this patch. If a given rule does not rely on an inner type alias, the extra template parameter can be omitted:
```cpp
template <typename T1 = Iterator<Comparable, Long>> void f1(T1 first, T1 last) {
  return std::sort(first, last);
}
```

The `__COUNTER__` macro is used to ensure that every use of a given hint in a rule acts as a unique type, reflecting the intended semantics when declaring multiple template parameters.

I'm working on a utility that automatically generates these `src.cpp` files. Hints are defined using a set of macros that ensure each hint is properly annotated with the information required by this synthesizer. The structs and typedefs inside the `Synthesis` namespace are also used by this utility. These constructs were included in the file to avoid having to duplicate `rule_hints.h` in my project. All remaining synthesizer-specific helpers are kept separate.

Additionally, this patch was tested by confirming that the pre-existing IR remained unchanged. These changes to the preprocessor allow it to preprocess 1911 automatically generated rules.

Other changes:
- Cleaned up the matching logic in the preprocessor, which was essentially a duplicate of the logic in `Mapper::ToString`.
- Changed how the Rust rule preprocessor handles `where` clauses. Previously, the preprocessor iterated over each predicate in the clause and added any types in it to the list of generics. This meant that, for clauses such as `where u8: std::ops::Shl<T1, Output = u8>`, `u8` was incorrectly added as a generic parameter. This patch changes this behavior, types in the where clause that are not present on the generics list are now skipped. I believe this is correct, since a `where` clause cannot be used to declare new generics anyway.
- Added the `UnsafeIterator` trait, which is useful for writing rules where we know that a given generic is an iterator that will be translated to `Ptr`.
- Changed how operators that are spelled using `<` or `>` are printed. Printing `<` or `>` collided with the search performed by `Mapper::matchTemplate`.