### PR TITLE
Avoid generating empty `thread_local`s

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -457,6 +457,17 @@ void Converter::ConvertVaListVarDecl(clang::VarDecl *decl) {
   StrCat(keyword_mut_, GetNamedDeclAsString(decl), token::kColon, "VaList");
 }
 
+bool Converter::IsConvertableGlobalVarDecl(clang::VarDecl *decl) {
+  if (!decl->isFileVarDecl()) {
+    return true;
+  }
+  if (decl->isThisDeclarationADefinition() == clang::VarDecl::DeclarationOnly &&
+      !decl->hasInit()) {
+    return false;
+  }
+  return !globals_.contains(GetNamedDeclAsString(decl));
+}
+
 bool Converter::ConvertVarDeclSkipInit(clang::VarDecl *decl) {
   auto qual_type = decl->getType();
   auto name = GetNamedDeclAsString(decl);
@@ -467,12 +478,10 @@ bool Converter::ConvertVarDeclSkipInit(clang::VarDecl *decl) {
   }
 
   if (decl->isFileVarDecl()) {
-    if ((decl->isThisDeclarationADefinition() ==
-             clang::VarDecl::DeclarationOnly &&
-         !decl->hasInit()) ||
-        !globals_.insert(name).second) {
+    if (!IsConvertableGlobalVarDecl(decl)) {
       return false;
     }
+    globals_.insert(name);
     StrCat(AccessSpecifierAsString(decl->getAccess()), keyword::kStatic,
            keyword_mut_);
     ENSURE(decl_ids_.insert(GetID(decl)).second);

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -100,6 +100,8 @@ public:
 
   virtual void ConvertGlobalVarDecl(clang::VarDecl *decl);
 
+  bool IsConvertableGlobalVarDecl(clang::VarDecl *decl);
+
   virtual void ConvertVaListVarDecl(clang::VarDecl *decl);
 
   virtual bool ConvertVarDeclSkipInit(clang::VarDecl *decl);

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -740,6 +740,9 @@ void ConverterRefCount::EmitHoistedInArmAssignment(clang::VarDecl *decl) {
 }
 
 void ConverterRefCount::ConvertGlobalVarDecl(clang::VarDecl *decl) {
+  if (!IsConvertableGlobalVarDecl(decl)) {
+    return;
+  }
   StrCat("thread_local!");
   {
     PushParen paren(*this);

--- a/tests/unit/extern_global.c
+++ b/tests/unit/extern_global.c
@@ -1,0 +1,4 @@
+extern int x;
+int x;
+
+int main(void) { return x; }

--- a/tests/unit/out/refcount/extern_global.rs
+++ b/tests/unit/out/refcount/extern_global.rs
@@ -1,0 +1,17 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+thread_local!(
+    pub static x_0: Value<i32> = <Value<i32>>::default();
+);
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    return (*x_0.with(Value::clone).borrow());
+}

--- a/tests/unit/out/unsafe/extern_global.rs
+++ b/tests/unit/out/unsafe/extern_global.rs
@@ -1,0 +1,17 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub static mut x_0: i32 = unsafe { 0_i32 };
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    return x_0;
+}


### PR DESCRIPTION
A new `IsConvertableGlobalVarDecl` function was introduced to determine whether the global variable declaration would emit any code.
This was needed because empty thread locals were previously being generated (i.e., `thread_local!()`).