### PR TITLE
Translate template packs

### DIFF
--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -528,6 +528,16 @@ std::string GetNamedDeclAsString(const clang::NamedDecl *decl) {
             (ctor && ctor->isCopyOrMoveConstructor()))
                ? "self"
                : "_";
+  } else if (auto *pdecl = llvm::dyn_cast<clang::ParmVarDecl>(decl)) {
+    // Expanded parameter packs share one name across the expansion
+    if (auto *fn = llvm::dyn_cast_or_null<clang::FunctionDecl>(
+            pdecl->getDeclContext());
+        fn && llvm::count_if(fn->parameters(), [&](const auto *p) {
+                return p->getName() == pdecl->getName();
+              }) > 1) {
+      name += '_';
+      name += std::to_string(pdecl->getFunctionScopeIndex());
+    }
   }
 
   return name;

--- a/tests/unit/out/refcount/template_pack.rs
+++ b/tests/unit/out/refcount/template_pack.rs
@@ -1,0 +1,44 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn sum_0(args_0: i32, args_1: i32, args_2: i32) -> i32 {
+    let args_0: Value<i32> = Rc::new(RefCell::new(args_0));
+    let args_1: Value<i32> = Rc::new(RefCell::new(args_1));
+    let args_2: Value<i32> = Rc::new(RefCell::new(args_2));
+    return ((*args_0.borrow()) + ((*args_1.borrow()) + ((*args_2.borrow()) + 0)));
+}
+pub fn sum_1(args_0: i32, args_1: i32) -> i32 {
+    let args_0: Value<i32> = Rc::new(RefCell::new(args_0));
+    let args_1: Value<i32> = Rc::new(RefCell::new(args_1));
+    return ((*args_0.borrow()) + ((*args_1.borrow()) + 0));
+}
+pub fn sum_2(args: i32) -> i32 {
+    let args: Value<i32> = Rc::new(RefCell::new(args));
+    return ((*args.borrow()) + 0);
+}
+pub fn first_3(x: i32, args_1: i32, args_2: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    let args_1: Value<i32> = Rc::new(RefCell::new(args_1));
+    let args_2: Value<i32> = Rc::new(RefCell::new(args_2));
+    return ((*x.borrow()) + ({ sum_1((*args_1.borrow()), (*args_2.borrow())) }));
+}
+pub fn first_4(x: i32, args: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    let args: Value<i32> = Rc::new(RefCell::new(args));
+    return ((*x.borrow()) + ({ sum_2((*args.borrow())) }));
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!((({ sum_0(1, 2, 3,) }) == 6));
+    assert!((({ sum_1(4, 5,) }) == 9));
+    assert!((({ first_3(10, 1, 2,) }) == 13));
+    assert!((({ first_4(10, 0,) }) == 10));
+    return 0;
+}

--- a/tests/unit/out/unsafe/template_pack.rs
+++ b/tests/unit/out/unsafe/template_pack.rs
@@ -1,0 +1,35 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn sum_0(mut args_0: i32, mut args_1: i32, mut args_2: i32) -> i32 {
+    return ((args_0) + ((args_1) + ((args_2) + (0))));
+}
+pub unsafe fn sum_1(mut args_0: i32, mut args_1: i32) -> i32 {
+    return ((args_0) + ((args_1) + (0)));
+}
+pub unsafe fn sum_2(mut args: i32) -> i32 {
+    return ((args) + (0));
+}
+pub unsafe fn first_3(mut x: i32, mut args_1: i32, mut args_2: i32) -> i32 {
+    return ((x) + (unsafe { sum_1(args_1, args_2) }));
+}
+pub unsafe fn first_4(mut x: i32, mut args: i32) -> i32 {
+    return ((x) + (unsafe { sum_2(args) }));
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(((unsafe { sum_0(1, 2, 3,) }) == (6)));
+    assert!(((unsafe { sum_1(4, 5,) }) == (9)));
+    assert!(((unsafe { first_3(10, 1, 2,) }) == (13)));
+    assert!(((unsafe { first_4(10, 0,) }) == (10)));
+    return 0;
+}

--- a/tests/unit/template_pack.cpp
+++ b/tests/unit/template_pack.cpp
@@ -1,0 +1,15 @@
+#include <cassert>
+
+template <typename... Args> int sum(Args... args) { return (args + ... + 0); }
+
+template <typename T, typename... Args> T first(T x, Args... args) {
+  return x + sum(args...);
+}
+
+int main() {
+  assert(sum(1, 2, 3) == 6);
+  assert(sum(4, 5) == 9);
+  assert(first(10, 1, 2) == 13);
+  assert(first(10, 0) == 10);
+  return 0;
+}


### PR DESCRIPTION
Their body is fully instantiated at every call site.

In the AST, the names of all expanded arguments is `args` which is wrong in the translated code because arguments have to have different names. I added support in the converter to translate them as `args_1`, `args_2`, etc.