### PR TITLE
Translate C++ enums as Rust integers

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -2070,25 +2070,24 @@ bool Converter::VisitCXXBoolLiteralExpr(clang::CXXBoolLiteralExpr *expr) {
 
 void Converter::ConvertIntegerToEnumeralCast(clang::Expr *to,
                                              clang::Expr *from) {
-  // Short circuit `Enum::from(X as i32)` to `X`
+  // Short circuit `(X as i32) as Enum` to `X`
   if (auto ref =
           clang::dyn_cast<clang::DeclRefExpr>(from->IgnoreParenImpCasts())) {
     if (auto ec = clang::dyn_cast<clang::EnumConstantDecl>(ref->getDecl())) {
       auto src_enum = clang::dyn_cast<clang::EnumDecl>(ec->getDeclContext());
       auto dst_enum = to->getType()->getAs<clang::EnumType>();
       if (src_enum && dst_enum && dst_enum->getDecl() == src_enum) {
-        StrCat(std::format("{}::{}", GetRecordName(src_enum),
-                           std::string_view(ec->getName())));
+        StrCat(EnumeratorName(ec));
         return;
       }
     }
   }
-  StrCat(GetUnsafeTypeAsString(to->getType()), "::from");
   PushParen paren(*this);
-  Convert(from);
-  if (!from->getType()->isSpecificBuiltinType(clang::BuiltinType::Int)) {
-    StrCat(keyword::kAs, "i32");
+  {
+    PushParen inner(*this);
+    Convert(from);
   }
+  StrCat(keyword::kAs, GetUnsafeTypeAsString(to->getType()));
 }
 
 void Converter::ConvertIntegralToBooleanCast(clang::ImplicitCastExpr *expr) {
@@ -2107,11 +2106,7 @@ void Converter::ConvertIntegralToBooleanCast(clang::ImplicitCastExpr *expr) {
   PushParen paren(*this);
   Convert(sub_expr);
   StrCat(token::kDiff);
-  if (sub_expr->getType()->isEnumeralType()) {
-    StrCat(GetUnsafeTypeAsString(sub_expr->getType()), "::from(0)");
-  } else /* sub_expr->getType()->isIntegerType() */ {
-    StrCat(token::kZero);
-  }
+  StrCat(token::kZero);
 }
 
 bool Converter::IsCastRedundantInRust(clang::Expr *expr,
@@ -2657,14 +2652,11 @@ std::string Converter::ConvertDeclRefExpr(clang::DeclRefExpr *expr) {
   }
 
   if (auto enum_constant = clang::dyn_cast<clang::EnumConstantDecl>(decl)) {
-    auto qualified = std::format("{}::{}",
-                                 GetRecordName(clang::dyn_cast<clang::EnumDecl>(
-                                     enum_constant->getDeclContext())),
-                                 std::string_view(enum_constant->getName()));
+    auto name = EnumeratorName(enum_constant);
     if (!expr->getType()->isEnumeralType()) {
-      return std::format("({} as i32)", qualified);
+      return std::format("({} as i32)", name);
     }
-    return qualified;
+    return name;
   }
 
   if (IsGlobalVar(expr)) {
@@ -3237,50 +3229,23 @@ bool Converter::VisitEnumDecl(clang::EnumDecl *decl) {
     return false;
   }
   Mapper::AddRuleForUserDefinedType(decl);
-  Mapper::SetDerives(ctx_.getCanonicalTagType(decl),
-                     {"Clone", "Copy", "PartialEq", "Debug", "Default"});
-  StrCat("#[derive(Clone, Copy, PartialEq, Debug, Default)]");
-  StrCat(std::format("enum {}", GetRecordName(decl)));
-  StrCat('{');
-  bool first_enumerator = true;
+  auto name = GetRecordName(decl);
+  StrCat(std::format("pub type {} = {};", name,
+                     GetUnsafeTypeAsString(decl->getIntegerType())));
   for (auto e : decl->enumerators()) {
     llvm::SmallVector<char, 32> init;
     e->getInitVal().toString(init, 10);
-    if (first_enumerator) {
-      StrCat("#[default]");
-      first_enumerator = false;
-    }
-    StrCat(std::format("{} = {},", std::string_view(e->getName()),
+    StrCat(std::format("pub const {}: {} = {};", EnumeratorName(e), name,
                        std::string_view(init.data(), init.size())));
   }
-  StrCat('}');
-
-  AddFromImpl(decl);
-  AddIncDecImpls(decl);
-  AddByteReprTrait(decl);
   return false;
 }
 
-void Converter::AddFromImpl(clang::EnumDecl *decl) {
-  auto name = GetRecordName(decl);
-  StrCat(std::format("impl From<i32> for {}", name));
-  PushBrace impl(*this);
-  StrCat(std::format("fn from(n: i32) -> {}", name));
-  PushBrace fn(*this);
-  StrCat("match n");
-  PushBrace match(*this);
-  for (auto e : decl->enumerators()) {
-    llvm::SmallVector<char, 32> init;
-    e->getInitVal().toString(init, 10);
-    StrCat(std::format("{} => {}::{},",
-                       std::string_view(init.data(), init.size()), name,
-                       std::string_view(e->getName())));
-  }
-  StrCat(std::format("_ => panic!(\"invalid {} value: {{}}\", n),", name));
-}
-
-void Converter::AddIncDecImpls(clang::EnumDecl *decl) {
-  StrCat(std::format("libcc2rs::impl_enum_inc_dec!({});", GetRecordName(decl)));
+std::string
+Converter::EnumeratorName(const clang::EnumConstantDecl *decl) const {
+  auto *enum_decl = clang::cast<clang::EnumDecl>(decl->getDeclContext());
+  return std::format("{}_{}", GetRecordName(enum_decl),
+                     std::string_view(decl->getName()));
 }
 
 bool Converter::VisitCXXDefaultArgExpr(clang::CXXDefaultArgExpr *expr) {
@@ -3570,9 +3535,10 @@ std::string Converter::GetDefaultAsStringFallback(clang::QualType qual_type) {
 
   if (qual_type->isEnumeralType()) {
     auto enum_decl = qual_type->castAs<clang::EnumType>()->getDecl();
-    return std::format(
-        "{}::{}", GetRecordName(enum_decl),
-        std::string_view(enum_decl->enumerator_begin()->getName()));
+    if (enum_decl->enumerators().empty()) {
+      return std::string(1, token::kZero);
+    }
+    return EnumeratorName(*enum_decl->enumerator_begin());
   }
 
   return std::format("<{}>::default()", ToString(qual_type));
@@ -4048,8 +4014,6 @@ void Converter::EmitDefaultStructLiteral(const clang::RecordDecl *decl) {
 }
 
 void Converter::AddByteReprTrait(const clang::RecordDecl *decl) {}
-
-void Converter::AddByteReprTrait(const clang::EnumDecl *decl) {}
 
 void Converter::ConvertUnsignedArithBinaryOperator(clang::BinaryOperator *op,
                                                    clang::Expr *expr) {

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -558,7 +558,6 @@ protected:
 
   virtual void AddByteReprTrait(const clang::RecordDecl *decl);
 
-
   virtual void
   ConvertUnsignedArithBinaryOperator(clang::BinaryOperator *binary_operator,
                                      clang::Expr *expr);

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -374,9 +374,7 @@ public:
 
   virtual bool VisitEnumDecl(clang::EnumDecl *decl);
 
-  virtual void AddFromImpl(clang::EnumDecl *decl);
-
-  virtual void AddIncDecImpls(clang::EnumDecl *decl);
+  virtual std::string EnumeratorName(const clang::EnumConstantDecl *decl) const;
 
   virtual bool VisitCXXDefaultArgExpr(clang::CXXDefaultArgExpr *expr);
 
@@ -560,7 +558,6 @@ protected:
 
   virtual void AddByteReprTrait(const clang::RecordDecl *decl);
 
-  virtual void AddByteReprTrait(const clang::EnumDecl *decl);
 
   virtual void
   ConvertUnsignedArithBinaryOperator(clang::BinaryOperator *binary_operator,

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -654,17 +654,6 @@ void ConverterRefCount::AddByteReprTrait(const clang::RecordDecl *decl) {
   }
 }
 
-void ConverterRefCount::AddByteReprTrait(const clang::EnumDecl *decl) {
-  auto name = GetRecordName(decl);
-  StrCat(std::format("impl ByteRepr for {}", name));
-  PushBrace impl_brace(*this);
-  StrCat(
-      "fn to_bytes(&self, buf: &mut [u8]) { (*self as i32).to_bytes(buf); }");
-  StrCat(std::format("fn from_bytes(buf: &[u8]) -> Self {{ "
-                     "<{}>::from(i32::from_bytes(buf)) }}",
-                     name));
-}
-
 std::string
 ConverterRefCount::GetSelfMaybeWithMut(const clang::CXXMethodDecl *decl) {
   return "&self";

--- a/cpp2rust/converter/models/converter_refcount.h
+++ b/cpp2rust/converter/models/converter_refcount.h
@@ -45,7 +45,6 @@ public:
 
   void AddByteReprTrait(const clang::RecordDecl *decl) override;
 
-  void AddByteReprTrait(const clang::EnumDecl *decl) override;
 
   bool
   VisitUnaryExprOrTypeTraitExpr(clang::UnaryExprOrTypeTraitExpr *expr) override;

--- a/cpp2rust/converter/models/converter_refcount.h
+++ b/cpp2rust/converter/models/converter_refcount.h
@@ -45,7 +45,6 @@ public:
 
   void AddByteReprTrait(const clang::RecordDecl *decl) override;
 
-
   bool
   VisitUnaryExprOrTypeTraitExpr(clang::UnaryExprOrTypeTraitExpr *expr) override;
 

--- a/libcc2rs/src/inc.rs
+++ b/libcc2rs/src/inc.rs
@@ -124,38 +124,6 @@ impl<T> UnsafePrefixInc for *mut T {
     }
 }
 
-#[macro_export]
-macro_rules! impl_enum_inc_dec {
-    ($t:ty) => {
-        impl PostfixInc for $t {
-            fn postfix_inc(&mut self) -> Self {
-                let copy = *self;
-                *self = <$t>::from((*self as i32).wrapping_add(1));
-                copy
-            }
-        }
-        impl PrefixInc for $t {
-            fn prefix_inc(&mut self) -> Self {
-                *self = <$t>::from((*self as i32).wrapping_add(1));
-                *self
-            }
-        }
-        impl PostfixDec for $t {
-            fn postfix_dec(&mut self) -> Self {
-                let copy = *self;
-                *self = <$t>::from((*self as i32).wrapping_sub(1));
-                copy
-            }
-        }
-        impl PrefixDec for $t {
-            fn prefix_dec(&mut self) -> Self {
-                *self = <$t>::from((*self as i32).wrapping_sub(1));
-                *self
-            }
-        }
-    };
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/multi-file/cross_tu_anon_enum_collision/out/refcount/cross_tu_anon_enum_collision.rs
+++ b/tests/multi-file/cross_tu_anon_enum_collision/out/refcount/cross_tu_anon_enum_collision.rs
@@ -6,31 +6,11 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum anon_0 {
-    #[default]
-    ALPHA = 7,
-}
-impl From<i32> for anon_0 {
-    fn from(n: i32) -> anon_0 {
-        match n {
-            7 => anon_0::ALPHA,
-            _ => panic!("invalid anon_0 value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(anon_0);
-impl ByteRepr for anon_0 {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <anon_0>::from(i32::from_bytes(buf))
-    }
-}
+pub type anon_0 = u32;
+pub const anon_0_ALPHA: anon_0 = 7;
 pub fn a_value_1() -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(0));
-    (*x.borrow_mut()) |= (anon_0::ALPHA as i32);
+    (*x.borrow_mut()) |= (anon_0_ALPHA as i32);
     return (*x.borrow());
 }
 pub fn main() {
@@ -41,30 +21,10 @@ fn main_0() -> i32 {
     assert!((((({ b_value_2() }) == 9) as i32) != 0));
     return 0;
 }
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum anon_3 {
-    #[default]
-    BETA = 9,
-}
-impl From<i32> for anon_3 {
-    fn from(n: i32) -> anon_3 {
-        match n {
-            9 => anon_3::BETA,
-            _ => panic!("invalid anon_3 value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(anon_3);
-impl ByteRepr for anon_3 {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <anon_3>::from(i32::from_bytes(buf))
-    }
-}
+pub type anon_3 = u32;
+pub const anon_3_BETA: anon_3 = 9;
 pub fn b_value_2() -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(0));
-    (*x.borrow_mut()) |= (anon_3::BETA as i32);
+    (*x.borrow_mut()) |= (anon_3_BETA as i32);
     return (*x.borrow());
 }

--- a/tests/multi-file/cross_tu_anon_enum_collision/out/unsafe/cross_tu_anon_enum_collision.rs
+++ b/tests/multi-file/cross_tu_anon_enum_collision/out/unsafe/cross_tu_anon_enum_collision.rs
@@ -6,23 +6,11 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum anon_0 {
-    #[default]
-    ALPHA = 7,
-}
-impl From<i32> for anon_0 {
-    fn from(n: i32) -> anon_0 {
-        match n {
-            7 => anon_0::ALPHA,
-            _ => panic!("invalid anon_0 value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(anon_0);
+pub type anon_0 = u32;
+pub const anon_0_ALPHA: anon_0 = 7;
 pub unsafe fn a_value_1() -> i32 {
     let mut x: i32 = 0;
-    x |= (anon_0::ALPHA as i32);
+    x |= (anon_0_ALPHA as i32);
     return x;
 }
 pub fn main() {
@@ -35,22 +23,10 @@ unsafe fn main_0() -> i32 {
     assert!(((((unsafe { b_value_2() }) == (9)) as i32) != 0));
     return 0;
 }
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum anon_3 {
-    #[default]
-    BETA = 9,
-}
-impl From<i32> for anon_3 {
-    fn from(n: i32) -> anon_3 {
-        match n {
-            9 => anon_3::BETA,
-            _ => panic!("invalid anon_3 value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(anon_3);
+pub type anon_3 = u32;
+pub const anon_3_BETA: anon_3 = 9;
 pub unsafe fn b_value_2() -> i32 {
     let mut x: i32 = 0;
-    x |= (anon_3::BETA as i32);
+    x |= (anon_3_BETA as i32);
     return x;
 }

--- a/tests/multi-file/cross_tu_tag_collision/out/refcount/cross_tu_tag_collision.rs
+++ b/tests/multi-file/cross_tu_tag_collision/out/refcount/cross_tu_tag_collision.rs
@@ -43,33 +43,11 @@ fn main_0() -> i32 {
     assert!((((({ b_value_1() }) == 2) as i32) != 0));
     return 0;
 }
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum widget_enum {
-    #[default]
-    WIDGET_A = 0,
-    WIDGET_B = 1,
-    WIDGET_C = 2,
-}
-impl From<i32> for widget_enum {
-    fn from(n: i32) -> widget_enum {
-        match n {
-            0 => widget_enum::WIDGET_A,
-            1 => widget_enum::WIDGET_B,
-            2 => widget_enum::WIDGET_C,
-            _ => panic!("invalid widget_enum value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(widget_enum);
-impl ByteRepr for widget_enum {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <widget_enum>::from(i32::from_bytes(buf))
-    }
-}
+pub type widget_enum = u32;
+pub const widget_enum_WIDGET_A: widget_enum = 0;
+pub const widget_enum_WIDGET_B: widget_enum = 1;
+pub const widget_enum_WIDGET_C: widget_enum = 2;
 pub fn b_value_1() -> i32 {
-    let w: Value<widget_enum> = Rc::new(RefCell::new(widget_enum::WIDGET_C));
+    let w: Value<widget_enum> = Rc::new(RefCell::new(widget_enum_WIDGET_C));
     return ((*w.borrow()) as i32);
 }

--- a/tests/multi-file/cross_tu_tag_collision/out/unsafe/cross_tu_tag_collision.rs
+++ b/tests/multi-file/cross_tu_tag_collision/out/unsafe/cross_tu_tag_collision.rs
@@ -26,25 +26,11 @@ unsafe fn main_0() -> i32 {
     assert!(((((unsafe { b_value_1() }) == (2)) as i32) != 0));
     return 0;
 }
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum widget_enum {
-    #[default]
-    WIDGET_A = 0,
-    WIDGET_B = 1,
-    WIDGET_C = 2,
-}
-impl From<i32> for widget_enum {
-    fn from(n: i32) -> widget_enum {
-        match n {
-            0 => widget_enum::WIDGET_A,
-            1 => widget_enum::WIDGET_B,
-            2 => widget_enum::WIDGET_C,
-            _ => panic!("invalid widget_enum value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(widget_enum);
+pub type widget_enum = u32;
+pub const widget_enum_WIDGET_A: widget_enum = 0;
+pub const widget_enum_WIDGET_B: widget_enum = 1;
+pub const widget_enum_WIDGET_C: widget_enum = 2;
 pub unsafe fn b_value_1() -> i32 {
-    let mut w: widget_enum = widget_enum::WIDGET_C;
+    let mut w: widget_enum = widget_enum_WIDGET_C;
     return (w as i32);
 }

--- a/tests/ub/enum_out_of_range_cast.cpp
+++ b/tests/ub/enum_out_of_range_cast.cpp
@@ -1,4 +1,4 @@
-// panic-ub
+// nondet-result
 
 enum Color { RED, GREEN, BLUE };
 

--- a/tests/ub/enum_out_of_range_increment.c
+++ b/tests/ub/enum_out_of_range_increment.c
@@ -1,4 +1,4 @@
-// panic-ub
+// nondet-result
 
 enum color { RED, GREEN, BLUE };
 

--- a/tests/ub/out/refcount/enum_out_of_range_cast.rs
+++ b/tests/ub/out/refcount/enum_out_of_range_cast.rs
@@ -6,39 +6,17 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Color {
-    #[default]
-    RED = 0,
-    GREEN = 1,
-    BLUE = 2,
-}
-impl From<i32> for Color {
-    fn from(n: i32) -> Color {
-        match n {
-            0 => Color::RED,
-            1 => Color::GREEN,
-            2 => Color::BLUE,
-            _ => panic!("invalid Color value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Color);
-impl ByteRepr for Color {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <Color>::from(i32::from_bytes(buf))
-    }
-}
+pub type Color = u32;
+pub const Color_RED: Color = 0;
+pub const Color_GREEN: Color = 1;
+pub const Color_BLUE: Color = 2;
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
     let n: Value<i32> = Rc::new(RefCell::new(3));
-    let c: Value<Color> = Rc::new(RefCell::new(Color::from((*n.borrow()))));
-    return if (((*c.borrow()) as i32) == (Color::BLUE as i32)) {
+    let c: Value<Color> = Rc::new(RefCell::new(((*n.borrow()) as Color)));
+    return if (((*c.borrow()) as i32) == (Color_BLUE as i32)) {
         0
     } else {
         1

--- a/tests/ub/out/refcount/enum_out_of_range_increment.rs
+++ b/tests/ub/out/refcount/enum_out_of_range_increment.rs
@@ -6,39 +6,17 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum color {
-    #[default]
-    RED = 0,
-    GREEN = 1,
-    BLUE = 2,
-}
-impl From<i32> for color {
-    fn from(n: i32) -> color {
-        match n {
-            0 => color::RED,
-            1 => color::GREEN,
-            2 => color::BLUE,
-            _ => panic!("invalid color value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(color);
-impl ByteRepr for color {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <color>::from(i32::from_bytes(buf))
-    }
-}
+pub type color = u32;
+pub const color_RED: color = 0;
+pub const color_GREEN: color = 1;
+pub const color_BLUE: color = 2;
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    let c: Value<color> = Rc::new(RefCell::new(color::BLUE));
+    let c: Value<color> = Rc::new(RefCell::new(color_BLUE));
     (*c.borrow_mut()).postfix_inc();
-    return if (((((*c.borrow()) as u32) == ((color::RED as i32) as u32)) as i32) != 0) {
+    return if (((((*c.borrow()) as u32) == ((color_RED as i32) as u32)) as i32) != 0) {
         0
     } else {
         1

--- a/tests/ub/out/unsafe/enum_out_of_range_increment.rs
+++ b/tests/ub/out/unsafe/enum_out_of_range_increment.rs
@@ -6,33 +6,19 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum color {
-    #[default]
-    RED = 0,
-    GREEN = 1,
-    BLUE = 2,
-}
-impl From<i32> for color {
-    fn from(n: i32) -> color {
-        match n {
-            0 => color::RED,
-            1 => color::GREEN,
-            2 => color::BLUE,
-            _ => panic!("invalid color value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(color);
+pub type color = u32;
+pub const color_RED: color = 0;
+pub const color_GREEN: color = 1;
+pub const color_BLUE: color = 2;
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut c: color = color::BLUE;
+    let mut c: color = color_BLUE;
     c.postfix_inc();
-    return if ((((c as u32) == ((color::RED as i32) as u32)) as i32) != 0) {
+    return if ((((c as u32) == ((color_RED as i32) as u32)) as i32) != 0) {
         0
     } else {
         1

--- a/tests/unit/enum_comparisson_in_globals.cpp
+++ b/tests/unit/enum_comparisson_in_globals.cpp
@@ -1,9 +1,6 @@
 #include <cassert>
 
-enum E {
-  A,
-  B
-};
+enum E { A, B };
 
 int global = E::A != E::B;
 

--- a/tests/unit/enum_comparisson_in_globals.cpp
+++ b/tests/unit/enum_comparisson_in_globals.cpp
@@ -1,0 +1,13 @@
+#include <cassert>
+
+enum E {
+  A,
+  B
+};
+
+int global = E::A != E::B;
+
+int main() {
+  assert(global == 1);
+  return 0;
+}

--- a/tests/unit/enum_with_duplicated_values.cpp
+++ b/tests/unit/enum_with_duplicated_values.cpp
@@ -1,0 +1,16 @@
+#include <cassert>
+
+enum E {
+  A = 1 << 1,
+  B = 1 << 2,
+  C = A,
+  D = 1 << 2,
+};
+
+int main() {
+  assert(E::A == 1 << 1);
+  assert(E::B == 1 << 2);
+  assert(E::C == 1 << 1);
+  assert(E::D == 1 << 2);
+  return 0;
+}

--- a/tests/unit/out/refcount/anonymous_enum.rs
+++ b/tests/unit/out/refcount/anonymous_enum.rs
@@ -6,54 +6,12 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum anon_0 {
-    #[default]
-    FIRST_A = 0,
-    FIRST_B = 1,
-}
-impl From<i32> for anon_0 {
-    fn from(n: i32) -> anon_0 {
-        match n {
-            0 => anon_0::FIRST_A,
-            1 => anon_0::FIRST_B,
-            _ => panic!("invalid anon_0 value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(anon_0);
-impl ByteRepr for anon_0 {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <anon_0>::from(i32::from_bytes(buf))
-    }
-}
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum anon_1 {
-    #[default]
-    SECOND_A = 0,
-    SECOND_B = 1,
-}
-impl From<i32> for anon_1 {
-    fn from(n: i32) -> anon_1 {
-        match n {
-            0 => anon_1::SECOND_A,
-            1 => anon_1::SECOND_B,
-            _ => panic!("invalid anon_1 value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(anon_1);
-impl ByteRepr for anon_1 {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <anon_1>::from(i32::from_bytes(buf))
-    }
-}
+pub type anon_0 = u32;
+pub const anon_0_FIRST_A: anon_0 = 0;
+pub const anon_0_FIRST_B: anon_0 = 1;
+pub type anon_1 = u32;
+pub const anon_1_SECOND_A: anon_1 = 0;
+pub const anon_1_SECOND_B: anon_1 = 1;
 #[derive(Default)]
 pub struct S {
     pub a: Value<i32>,
@@ -79,54 +37,12 @@ impl ByteRepr for S {
         }
     }
 }
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum TdEnum {
-    #[default]
-    TD_A = 0,
-    TD_B = 1,
-}
-impl From<i32> for TdEnum {
-    fn from(n: i32) -> TdEnum {
-        match n {
-            0 => TdEnum::TD_A,
-            1 => TdEnum::TD_B,
-            _ => panic!("invalid TdEnum value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(TdEnum);
-impl ByteRepr for TdEnum {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <TdEnum>::from(i32::from_bytes(buf))
-    }
-}
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum anon_2 {
-    #[default]
-    FIELD_A = 0,
-    FIELD_B = 1,
-}
-impl From<i32> for anon_2 {
-    fn from(n: i32) -> anon_2 {
-        match n {
-            0 => anon_2::FIELD_A,
-            1 => anon_2::FIELD_B,
-            _ => panic!("invalid anon_2 value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(anon_2);
-impl ByteRepr for anon_2 {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <anon_2>::from(i32::from_bytes(buf))
-    }
-}
+pub type TdEnum = u32;
+pub const TdEnum_TD_A: TdEnum = 0;
+pub const TdEnum_TD_B: TdEnum = 1;
+pub type anon_2 = u32;
+pub const anon_2_FIELD_A: anon_2 = 0;
+pub const anon_2_FIELD_B: anon_2 = 1;
 #[derive(Default)]
 pub struct WithAnonField {
     pub a: Value<i32>,
@@ -160,41 +76,20 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    #[derive(Clone, Copy, PartialEq, Debug, Default)]
-    enum anon_3 {
-        #[default]
-        THIRD_A = 0,
-        THIRD_B = 1,
-    }
-    impl From<i32> for anon_3 {
-        fn from(n: i32) -> anon_3 {
-            match n {
-                0 => anon_3::THIRD_A,
-                1 => anon_3::THIRD_B,
-                _ => panic!("invalid anon_3 value: {}", n),
-            }
-        }
-    }
-    libcc2rs::impl_enum_inc_dec!(anon_3);
-    impl ByteRepr for anon_3 {
-        fn to_bytes(&self, buf: &mut [u8]) {
-            (*self as i32).to_bytes(buf);
-        }
-        fn from_bytes(buf: &[u8]) -> Self {
-            <anon_3>::from(i32::from_bytes(buf))
-        }
-    };
-    assert!(((anon_0::FIRST_A as i32) != (anon_0::FIRST_B as i32)));
-    assert!(((anon_1::SECOND_A as i32) != (anon_1::SECOND_B as i32)));
-    assert!(((anon_3::THIRD_A as i32) != (anon_3::THIRD_B as i32)));
-    let td: Value<TdEnum> = Rc::new(RefCell::new(TdEnum::TD_A));
-    assert!((((*td.borrow()) as i32) == (TdEnum::TD_A as i32)));
-    (*td.borrow_mut()) = TdEnum::TD_B;
-    assert!((((*td.borrow()) as i32) == (TdEnum::TD_B as i32)));
+    pub type anon_3 = u32;
+    pub const anon_3_THIRD_A: anon_3 = 0;
+    pub const anon_3_THIRD_B: anon_3 = 1;;
+    assert!(((anon_0_FIRST_A as i32) != (anon_0_FIRST_B as i32)));
+    assert!(((anon_1_SECOND_A as i32) != (anon_1_SECOND_B as i32)));
+    assert!(((anon_3_THIRD_A as i32) != (anon_3_THIRD_B as i32)));
+    let td: Value<TdEnum> = Rc::new(RefCell::new(TdEnum_TD_A));
+    assert!((((*td.borrow()) as i32) == (TdEnum_TD_A as i32)));
+    (*td.borrow_mut()) = TdEnum_TD_B;
+    assert!((((*td.borrow()) as i32) == (TdEnum_TD_B as i32)));
     let w: Value<WithAnonField> = Rc::new(RefCell::new(<WithAnonField>::default()));
-    (*(*w.borrow()).field.borrow_mut()) = anon_2::FIELD_A;
-    assert!((((*(*w.borrow()).field.borrow()) as i32) == (anon_2::FIELD_A as i32)));
-    (*(*w.borrow()).field.borrow_mut()) = anon_2::FIELD_B;
-    assert!((((*(*w.borrow()).field.borrow()) as i32) == (anon_2::FIELD_B as i32)));
+    (*(*w.borrow()).field.borrow_mut()) = anon_2_FIELD_A;
+    assert!((((*(*w.borrow()).field.borrow()) as i32) == (anon_2_FIELD_A as i32)));
+    (*(*w.borrow()).field.borrow_mut()) = anon_2_FIELD_B;
+    assert!((((*(*w.borrow()).field.borrow()) as i32) == (anon_2_FIELD_B as i32)));
     return 0;
 }

--- a/tests/unit/out/refcount/anonymous_enum_c.rs
+++ b/tests/unit/out/refcount/anonymous_enum_c.rs
@@ -6,54 +6,12 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum anon_0 {
-    #[default]
-    FIRST_A = 0,
-    FIRST_B = 1,
-}
-impl From<i32> for anon_0 {
-    fn from(n: i32) -> anon_0 {
-        match n {
-            0 => anon_0::FIRST_A,
-            1 => anon_0::FIRST_B,
-            _ => panic!("invalid anon_0 value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(anon_0);
-impl ByteRepr for anon_0 {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <anon_0>::from(i32::from_bytes(buf))
-    }
-}
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum anon_1 {
-    #[default]
-    SECOND_A = 0,
-    SECOND_B = 1,
-}
-impl From<i32> for anon_1 {
-    fn from(n: i32) -> anon_1 {
-        match n {
-            0 => anon_1::SECOND_A,
-            1 => anon_1::SECOND_B,
-            _ => panic!("invalid anon_1 value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(anon_1);
-impl ByteRepr for anon_1 {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <anon_1>::from(i32::from_bytes(buf))
-    }
-}
+pub type anon_0 = u32;
+pub const anon_0_FIRST_A: anon_0 = 0;
+pub const anon_0_FIRST_B: anon_0 = 1;
+pub type anon_1 = u32;
+pub const anon_1_SECOND_A: anon_1 = 0;
+pub const anon_1_SECOND_B: anon_1 = 1;
 #[derive(Default)]
 pub struct S {
     pub a: Value<i32>,
@@ -78,54 +36,12 @@ impl ByteRepr for S {
         }
     }
 }
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum TdEnum_enum {
-    #[default]
-    TD_A = 0,
-    TD_B = 1,
-}
-impl From<i32> for TdEnum_enum {
-    fn from(n: i32) -> TdEnum_enum {
-        match n {
-            0 => TdEnum_enum::TD_A,
-            1 => TdEnum_enum::TD_B,
-            _ => panic!("invalid TdEnum_enum value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(TdEnum_enum);
-impl ByteRepr for TdEnum_enum {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <TdEnum_enum>::from(i32::from_bytes(buf))
-    }
-}
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum anon_2 {
-    #[default]
-    FIELD_A = 0,
-    FIELD_B = 1,
-}
-impl From<i32> for anon_2 {
-    fn from(n: i32) -> anon_2 {
-        match n {
-            0 => anon_2::FIELD_A,
-            1 => anon_2::FIELD_B,
-            _ => panic!("invalid anon_2 value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(anon_2);
-impl ByteRepr for anon_2 {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <anon_2>::from(i32::from_bytes(buf))
-    }
-}
+pub type TdEnum_enum = u32;
+pub const TdEnum_enum_TD_A: TdEnum_enum = 0;
+pub const TdEnum_enum_TD_B: TdEnum_enum = 1;
+pub type anon_2 = u32;
+pub const anon_2_FIELD_A: anon_2 = 0;
+pub const anon_2_FIELD_B: anon_2 = 1;
 #[derive(Default)]
 pub struct WithAnonField {
     pub a: Value<i32>,
@@ -158,46 +74,25 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    #[derive(Clone, Copy, PartialEq, Debug, Default)]
-    enum anon_3 {
-        #[default]
-        THIRD_A = 0,
-        THIRD_B = 1,
-    }
-    impl From<i32> for anon_3 {
-        fn from(n: i32) -> anon_3 {
-            match n {
-                0 => anon_3::THIRD_A,
-                1 => anon_3::THIRD_B,
-                _ => panic!("invalid anon_3 value: {}", n),
-            }
-        }
-    }
-    libcc2rs::impl_enum_inc_dec!(anon_3);
-    impl ByteRepr for anon_3 {
-        fn to_bytes(&self, buf: &mut [u8]) {
-            (*self as i32).to_bytes(buf);
-        }
-        fn from_bytes(buf: &[u8]) -> Self {
-            <anon_3>::from(i32::from_bytes(buf))
-        }
-    };
-    assert!(((((anon_0::FIRST_A as i32) != (anon_0::FIRST_B as i32)) as i32) != 0));
-    assert!(((((anon_1::SECOND_A as i32) != (anon_1::SECOND_B as i32)) as i32) != 0));
-    assert!(((((anon_3::THIRD_A as i32) != (anon_3::THIRD_B as i32)) as i32) != 0));
-    let td: Value<TdEnum_enum> = Rc::new(RefCell::new(TdEnum_enum::TD_A));
-    assert!((((((*td.borrow()) as u32) == ((TdEnum_enum::TD_A as i32) as u32)) as i32) != 0));
-    (*td.borrow_mut()) = TdEnum_enum::TD_B;
-    assert!((((((*td.borrow()) as u32) == ((TdEnum_enum::TD_B as i32) as u32)) as i32) != 0));
+    pub type anon_3 = u32;
+    pub const anon_3_THIRD_A: anon_3 = 0;
+    pub const anon_3_THIRD_B: anon_3 = 1;;
+    assert!(((((anon_0_FIRST_A as i32) != (anon_0_FIRST_B as i32)) as i32) != 0));
+    assert!(((((anon_1_SECOND_A as i32) != (anon_1_SECOND_B as i32)) as i32) != 0));
+    assert!(((((anon_3_THIRD_A as i32) != (anon_3_THIRD_B as i32)) as i32) != 0));
+    let td: Value<TdEnum_enum> = Rc::new(RefCell::new(TdEnum_enum_TD_A));
+    assert!((((((*td.borrow()) as u32) == ((TdEnum_enum_TD_A as i32) as u32)) as i32) != 0));
+    (*td.borrow_mut()) = TdEnum_enum_TD_B;
+    assert!((((((*td.borrow()) as u32) == ((TdEnum_enum_TD_B as i32) as u32)) as i32) != 0));
     let w: Value<WithAnonField> = <Value<WithAnonField>>::default();
-    (*(*w.borrow()).field.borrow_mut()) = anon_2::FIELD_A;
+    (*(*w.borrow()).field.borrow_mut()) = anon_2_FIELD_A;
     assert!(
-        (((((*(*w.borrow()).field.borrow()) as u32) == ((anon_2::FIELD_A as i32) as u32)) as i32)
+        (((((*(*w.borrow()).field.borrow()) as u32) == ((anon_2_FIELD_A as i32) as u32)) as i32)
             != 0)
     );
-    (*(*w.borrow()).field.borrow_mut()) = anon_2::FIELD_B;
+    (*(*w.borrow()).field.borrow_mut()) = anon_2_FIELD_B;
     assert!(
-        (((((*(*w.borrow()).field.borrow()) as u32) == ((anon_2::FIELD_B as i32) as u32)) as i32)
+        (((((*(*w.borrow()).field.borrow()) as u32) == ((anon_2_FIELD_B as i32) as u32)) as i32)
             != 0)
     );
     return 0;

--- a/tests/unit/out/refcount/bool_condition_enum.rs
+++ b/tests/unit/out/refcount/bool_condition_enum.rs
@@ -6,53 +6,31 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Code {
-    #[default]
-    CODE_OK = 0,
-    CODE_ERR = 1,
-    CODE_FATAL = 2,
-}
-impl From<i32> for Code {
-    fn from(n: i32) -> Code {
-        match n {
-            0 => Code::CODE_OK,
-            1 => Code::CODE_ERR,
-            2 => Code::CODE_FATAL,
-            _ => panic!("invalid Code value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Code);
-impl ByteRepr for Code {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <Code>::from(i32::from_bytes(buf))
-    }
-}
+pub type Code = u32;
+pub const Code_CODE_OK: Code = 0;
+pub const Code_CODE_ERR: Code = 1;
+pub const Code_CODE_FATAL: Code = 2;
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    let code: Value<Code> = Rc::new(RefCell::new(Code::CODE_OK));
-    let err: Value<Code> = Rc::new(RefCell::new(Code::CODE_ERR));
-    if ((*code.borrow()) != Code::from(0)) {
+    let code: Value<Code> = Rc::new(RefCell::new(Code_CODE_OK));
+    let err: Value<Code> = Rc::new(RefCell::new(Code_CODE_ERR));
+    if ((*code.borrow()) != 0) {
         assert!(false);
     }
-    if !((*code.borrow()) != Code::from(0)) {
+    if !((*code.borrow()) != 0) {
         assert!(true);
     }
-    if ((*err.borrow()) != Code::from(0)) {
+    if ((*err.borrow()) != 0) {
         assert!(true);
     }
-    if !((*err.borrow()) != Code::from(0)) {
+    if !((*err.borrow()) != 0) {
         assert!(false);
     }
-    let t9: Value<i32> = Rc::new(RefCell::new((!((*code.borrow()) != Code::from(0)) as i32)));
+    let t9: Value<i32> = Rc::new(RefCell::new((!((*code.borrow()) != 0) as i32)));
     assert!(((*t9.borrow()) == 1));
-    let b4: Value<bool> = Rc::new(RefCell::new(((*code.borrow()) != Code::from(0))));
+    let b4: Value<bool> = Rc::new(RefCell::new(((*code.borrow()) != 0)));
     assert!(!(*b4.borrow()));
     return 0;
 }

--- a/tests/unit/out/refcount/bool_condition_enum_c.rs
+++ b/tests/unit/out/refcount/bool_condition_enum_c.rs
@@ -6,53 +6,31 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Code {
-    #[default]
-    CODE_OK = 0,
-    CODE_ERR = 1,
-    CODE_FATAL = 2,
-}
-impl From<i32> for Code {
-    fn from(n: i32) -> Code {
-        match n {
-            0 => Code::CODE_OK,
-            1 => Code::CODE_ERR,
-            2 => Code::CODE_FATAL,
-            _ => panic!("invalid Code value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Code);
-impl ByteRepr for Code {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <Code>::from(i32::from_bytes(buf))
-    }
-}
+pub type Code = u32;
+pub const Code_CODE_OK: Code = 0;
+pub const Code_CODE_ERR: Code = 1;
+pub const Code_CODE_FATAL: Code = 2;
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    let code: Value<Code> = Rc::new(RefCell::new(Code::CODE_OK));
-    let err: Value<Code> = Rc::new(RefCell::new(Code::CODE_ERR));
-    if ((*code.borrow()) != Code::from(0)) {
+    let code: Value<Code> = Rc::new(RefCell::new(Code_CODE_OK));
+    let err: Value<Code> = Rc::new(RefCell::new(Code_CODE_ERR));
+    if ((*code.borrow()) != 0) {
         assert!((0 != 0));
     }
-    if !((*code.borrow()) != Code::from(0)) {
+    if !((*code.borrow()) != 0) {
         assert!((1 != 0));
     }
-    if ((*err.borrow()) != Code::from(0)) {
+    if ((*err.borrow()) != 0) {
         assert!((1 != 0));
     }
-    if !((*err.borrow()) != Code::from(0)) {
+    if !((*err.borrow()) != 0) {
         assert!((0 != 0));
     }
-    let t9: Value<i32> = Rc::new(RefCell::new((!((*code.borrow()) != Code::from(0)) as i32)));
+    let t9: Value<i32> = Rc::new(RefCell::new((!((*code.borrow()) != 0) as i32)));
     assert!(((((*t9.borrow()) == 1) as i32) != 0));
-    let b4: Value<bool> = Rc::new(RefCell::new(((*code.borrow()) != Code::from(0))));
+    let b4: Value<bool> = Rc::new(RefCell::new(((*code.borrow()) != 0)));
     assert!(((!(*b4.borrow()) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/refcount/bool_condition_logical.rs
+++ b/tests/unit/out/refcount/bool_condition_logical.rs
@@ -6,32 +6,10 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Code {
-    #[default]
-    CODE_OK = 0,
-    CODE_ERR = 1,
-    CODE_FATAL = 2,
-}
-impl From<i32> for Code {
-    fn from(n: i32) -> Code {
-        match n {
-            0 => Code::CODE_OK,
-            1 => Code::CODE_ERR,
-            2 => Code::CODE_FATAL,
-            _ => panic!("invalid Code value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Code);
-impl ByteRepr for Code {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <Code>::from(i32::from_bytes(buf))
-    }
-}
+pub type Code = u32;
+pub const Code_CODE_OK: Code = 0;
+pub const Code_CODE_ERR: Code = 1;
+pub const Code_CODE_FATAL: Code = 2;
 thread_local!(
     pub static side_effect_0: Value<i32> = Rc::new(RefCell::new(0));
 );
@@ -56,7 +34,7 @@ fn main_0() -> i32 {
     let p: Value<Ptr<i32>> = Rc::new(RefCell::new((storage.as_pointer())));
     let np: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
     let u: Value<u32> = Rc::new(RefCell::new(4_u32));
-    let code: Value<Code> = Rc::new(RefCell::new(Code::CODE_OK));
+    let code: Value<Code> = Rc::new(RefCell::new(Code_CODE_OK));
     if ((*n.borrow()) != 0) && (!(*p.borrow()).is_null()) {
         assert!(true);
     }
@@ -70,7 +48,7 @@ fn main_0() -> i32 {
         assert!(false);
     }
     if ((((*n.borrow()) != 0) && ((*u.borrow()) != 0)) && (!(*p.borrow()).is_null()))
-        && (((*code.borrow()) as i32) == (Code::CODE_OK as i32))
+        && (((*code.borrow()) as i32) == (Code_CODE_OK as i32))
     {
         assert!(true);
     }

--- a/tests/unit/out/refcount/bool_condition_logical_c.rs
+++ b/tests/unit/out/refcount/bool_condition_logical_c.rs
@@ -6,32 +6,10 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Code {
-    #[default]
-    CODE_OK = 0,
-    CODE_ERR = 1,
-    CODE_FATAL = 2,
-}
-impl From<i32> for Code {
-    fn from(n: i32) -> Code {
-        match n {
-            0 => Code::CODE_OK,
-            1 => Code::CODE_ERR,
-            2 => Code::CODE_FATAL,
-            _ => panic!("invalid Code value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Code);
-impl ByteRepr for Code {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <Code>::from(i32::from_bytes(buf))
-    }
-}
+pub type Code = u32;
+pub const Code_CODE_OK: Code = 0;
+pub const Code_CODE_ERR: Code = 1;
+pub const Code_CODE_FATAL: Code = 2;
 thread_local!(
     pub static side_effect_0: Value<i32> = Rc::new(RefCell::new(0));
 );
@@ -56,7 +34,7 @@ fn main_0() -> i32 {
     let p: Value<Ptr<i32>> = Rc::new(RefCell::new((storage.as_pointer())));
     let np: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
     let u: Value<u32> = Rc::new(RefCell::new(4_u32));
-    let code: Value<Code> = Rc::new(RefCell::new(Code::CODE_OK));
+    let code: Value<Code> = Rc::new(RefCell::new(Code_CODE_OK));
     if (((((*n.borrow()) != 0) && (!(*p.borrow()).is_null())) as i32) != 0) {
         assert!((1 != 0));
     }
@@ -72,7 +50,7 @@ fn main_0() -> i32 {
     if (((((((((((*n.borrow()) != 0) && ((*u.borrow()) != 0)) as i32) != 0)
         && (!(*p.borrow()).is_null())) as i32)
         != 0)
-        && (((((*code.borrow()) as u32) == ((Code::CODE_OK as i32) as u32)) as i32) != 0))
+        && (((((*code.borrow()) as u32) == ((Code_CODE_OK as i32) as u32)) as i32) != 0))
         as i32)
         != 0)
     {

--- a/tests/unit/out/refcount/c_struct.rs
+++ b/tests/unit/out/refcount/c_struct.rs
@@ -90,32 +90,10 @@ impl ByteRepr for Node {
         }
     }
 }
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Color {
-    #[default]
-    RED = 0,
-    GREEN = 1,
-    BLUE = 2,
-}
-impl From<i32> for Color {
-    fn from(n: i32) -> Color {
-        match n {
-            0 => Color::RED,
-            1 => Color::GREEN,
-            2 => Color::BLUE,
-            _ => panic!("invalid Color value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Color);
-impl ByteRepr for Color {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <Color>::from(i32::from_bytes(buf))
-    }
-}
+pub type Color = u32;
+pub const Color_RED: Color = 0;
+pub const Color_GREEN: Color = 1;
+pub const Color_BLUE: Color = 2;
 #[derive(Default)]
 pub struct Inner {
     pub a: Value<i32>,
@@ -223,18 +201,17 @@ fn main_0() -> i32 {
             a: Rc::new(RefCell::new(5)),
             b: Rc::new(RefCell::new(6)),
         })),
-        color: Rc::new(RefCell::new(Color::GREEN)),
+        color: Rc::new(RefCell::new(Color_GREEN)),
         count: Rc::new(RefCell::new(42)),
     }));
     assert!(((((*(*(*c.borrow()).inner.borrow()).a.borrow()) == 5) as i32) != 0));
     assert!(((((*(*(*c.borrow()).inner.borrow()).b.borrow()) == 6) as i32) != 0));
     assert!(
-        (((((*(*c.borrow()).color.borrow()) as u32) == ((Color::GREEN as i32) as u32)) as i32)
-            != 0)
+        (((((*(*c.borrow()).color.borrow()) as u32) == ((Color_GREEN as i32) as u32)) as i32) != 0)
     );
     assert!(((((*(*c.borrow()).count.borrow()) == 42) as i32) != 0));
     let c2: Value<Container> = <Value<Container>>::default();
-    (*(*c2.borrow()).color.borrow_mut()) = Color::BLUE;
+    (*(*c2.borrow()).color.borrow_mut()) = Color_BLUE;
     assert!((((((*(*c2.borrow()).color.borrow()) as u32) == 2_u32) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/refcount/enum_comparisson_in_globals.rs
+++ b/tests/unit/out/refcount/enum_comparisson_in_globals.rs
@@ -1,0 +1,22 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub type E = u32;
+pub const E_A: E = 0;
+pub const E_B: E = 1;
+thread_local!(
+    pub static global_0: Value<i32> =
+        Rc::new(RefCell::new((((E_A as i32) != (E_B as i32)) as i32)));
+);
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(((*global_0.with(Value::clone).borrow()) == 1));
+    return 0;
+}

--- a/tests/unit/out/refcount/enum_default_in_static.rs
+++ b/tests/unit/out/refcount/enum_default_in_static.rs
@@ -6,32 +6,10 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Mode {
-    #[default]
-    MODE_NONE = 0,
-    MODE_ONE = 1,
-    MODE_TWO = 2,
-}
-impl From<i32> for Mode {
-    fn from(n: i32) -> Mode {
-        match n {
-            0 => Mode::MODE_NONE,
-            1 => Mode::MODE_ONE,
-            2 => Mode::MODE_TWO,
-            _ => panic!("invalid Mode value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Mode);
-impl ByteRepr for Mode {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <Mode>::from(i32::from_bytes(buf))
-    }
-}
+pub type Mode = u32;
+pub const Mode_MODE_NONE: Mode = 0;
+pub const Mode_MODE_ONE: Mode = 1;
+pub const Mode_MODE_TWO: Mode = 2;
 #[derive(Default)]
 pub struct Config {
     pub count: Value<i32>,
@@ -70,7 +48,7 @@ fn main_0() -> i32 {
     assert!(((((*(*config_0.with(Value::clone).borrow()).count.borrow()) == 0) as i32) != 0));
     assert!(
         (((((*(*config_0.with(Value::clone).borrow()).mode.borrow()) as u32)
-            == ((Mode::MODE_NONE as i32) as u32)) as i32)
+            == ((Mode_MODE_NONE as i32) as u32)) as i32)
             != 0)
     );
     return 0;

--- a/tests/unit/out/refcount/enum_increment.rs
+++ b/tests/unit/out/refcount/enum_increment.rs
@@ -6,57 +6,34 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum color {
-    #[default]
-    RED = 0,
-    GREEN = 1,
-    BLUE = 2,
-    COLOR_LAST = 3,
-}
-impl From<i32> for color {
-    fn from(n: i32) -> color {
-        match n {
-            0 => color::RED,
-            1 => color::GREEN,
-            2 => color::BLUE,
-            3 => color::COLOR_LAST,
-            _ => panic!("invalid color value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(color);
-impl ByteRepr for color {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <color>::from(i32::from_bytes(buf))
-    }
-}
+pub type color = u32;
+pub const color_RED: color = 0;
+pub const color_GREEN: color = 1;
+pub const color_BLUE: color = 2;
+pub const color_COLOR_LAST: color = 3;
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
     let count: Value<i32> = Rc::new(RefCell::new(0));
-    let c: Value<color> = Rc::new(RefCell::new(color::RED));
-    'loop_: while (((((*c.borrow()) as u32) < ((color::COLOR_LAST as i32) as u32)) as i32) != 0) {
+    let c: Value<color> = Rc::new(RefCell::new(color_RED));
+    'loop_: while (((((*c.borrow()) as u32) < ((color_COLOR_LAST as i32) as u32)) as i32) != 0) {
         (*count.borrow_mut()).postfix_inc();
         (*c.borrow_mut()).postfix_inc();
     }
     assert!(((((*count.borrow()) == 3) as i32) != 0));
-    let c: Value<color> = Rc::new(RefCell::new(color::RED));
+    let c: Value<color> = Rc::new(RefCell::new(color_RED));
     assert!(
-        (((((*c.borrow_mut()).postfix_inc() as u32) == ((color::RED as i32) as u32)) as i32) != 0)
+        (((((*c.borrow_mut()).postfix_inc() as u32) == ((color_RED as i32) as u32)) as i32) != 0)
     );
     assert!(
-        (((((*c.borrow_mut()).prefix_inc() as u32) == ((color::BLUE as i32) as u32)) as i32) != 0)
+        (((((*c.borrow_mut()).prefix_inc() as u32) == ((color_BLUE as i32) as u32)) as i32) != 0)
     );
     assert!(
-        (((((*c.borrow_mut()).postfix_dec() as u32) == ((color::BLUE as i32) as u32)) as i32) != 0)
+        (((((*c.borrow_mut()).postfix_dec() as u32) == ((color_BLUE as i32) as u32)) as i32) != 0)
     );
     assert!(
-        (((((*c.borrow_mut()).prefix_dec() as u32) == ((color::RED as i32) as u32)) as i32) != 0)
+        (((((*c.borrow_mut()).prefix_dec() as u32) == ((color_RED as i32) as u32)) as i32) != 0)
     );
     return 0;
 }

--- a/tests/unit/out/refcount/enum_int_interop.rs
+++ b/tests/unit/out/refcount/enum_int_interop.rs
@@ -6,86 +6,19 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Color {
-    #[default]
-    RED = 0,
-    GREEN = 1,
-    BLUE = 2,
-}
-impl From<i32> for Color {
-    fn from(n: i32) -> Color {
-        match n {
-            0 => Color::RED,
-            1 => Color::GREEN,
-            2 => Color::BLUE,
-            _ => panic!("invalid Color value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Color);
-impl ByteRepr for Color {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <Color>::from(i32::from_bytes(buf))
-    }
-}
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Option {
-    #[default]
-    OPT_NONE = 0,
-    OPT_A = 10,
-    OPT_B = 20,
-    OPT_C = 30,
-}
-impl From<i32> for Option {
-    fn from(n: i32) -> Option {
-        match n {
-            0 => Option::OPT_NONE,
-            10 => Option::OPT_A,
-            20 => Option::OPT_B,
-            30 => Option::OPT_C,
-            _ => panic!("invalid Option value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Option);
-impl ByteRepr for Option {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <Option>::from(i32::from_bytes(buf))
-    }
-}
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Tag {
-    #[default]
-    TAG_ZERO = 0,
-    TAG_ONE = 1,
-    TAG_TWO = 2,
-}
-impl From<i32> for Tag {
-    fn from(n: i32) -> Tag {
-        match n {
-            0 => Tag::TAG_ZERO,
-            1 => Tag::TAG_ONE,
-            2 => Tag::TAG_TWO,
-            _ => panic!("invalid Tag value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Tag);
-impl ByteRepr for Tag {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <Tag>::from(i32::from_bytes(buf))
-    }
-}
+pub type Color = u32;
+pub const Color_RED: Color = 0;
+pub const Color_GREEN: Color = 1;
+pub const Color_BLUE: Color = 2;
+pub type Option = u32;
+pub const Option_OPT_NONE: Option = 0;
+pub const Option_OPT_A: Option = 10;
+pub const Option_OPT_B: Option = 20;
+pub const Option_OPT_C: Option = 30;
+pub type Tag = u32;
+pub const Tag_TAG_ZERO: Tag = 0;
+pub const Tag_TAG_ONE: Tag = 1;
+pub const Tag_TAG_TWO: Tag = 2;
 #[derive(Default)]
 pub struct Entry {
     pub name: Value<Ptr<u8>>,
@@ -120,30 +53,30 @@ impl ByteRepr for Entry {
     }
 }
 thread_local!(
-    pub static global_color_0: Value<Color> = Rc::new(RefCell::new(Color::GREEN));
+    pub static global_color_0: Value<Color> = Rc::new(RefCell::new(Color_GREEN));
 );
 thread_local!(
-    pub static global_opt_1: Value<Option> = Rc::new(RefCell::new(Option::OPT_B));
+    pub static global_opt_1: Value<Option> = Rc::new(RefCell::new(Option_OPT_B));
 );
 thread_local!(
-    pub static global_tag_2: Value<Tag> = Rc::new(RefCell::new(Tag::TAG_TWO));
+    pub static global_tag_2: Value<Tag> = Rc::new(RefCell::new(Tag_TAG_TWO));
 );
 thread_local!(
     pub static entries_3: Value<Box<[Entry]>> = Rc::new(RefCell::new(Box::new([
         Entry {
             name: Rc::new(RefCell::new(Ptr::from_string_literal(b"first"))),
-            color: Rc::new(RefCell::new(Color::RED)),
-            opt: Rc::new(RefCell::new(Option::OPT_NONE)),
+            color: Rc::new(RefCell::new(Color_RED)),
+            opt: Rc::new(RefCell::new(Option_OPT_NONE)),
         },
         Entry {
             name: Rc::new(RefCell::new(Ptr::from_string_literal(b"second"))),
-            color: Rc::new(RefCell::new(Color::GREEN)),
-            opt: Rc::new(RefCell::new(Option::OPT_A)),
+            color: Rc::new(RefCell::new(Color_GREEN)),
+            opt: Rc::new(RefCell::new(Option_OPT_A)),
         },
         Entry {
             name: Rc::new(RefCell::new(Ptr::from_string_literal(b"third"))),
-            color: Rc::new(RefCell::new(Color::BLUE)),
-            opt: Rc::new(RefCell::new(Option::OPT_C)),
+            color: Rc::new(RefCell::new(Color_BLUE)),
+            opt: Rc::new(RefCell::new(Option_OPT_C)),
         },
     ])));
 );
@@ -156,16 +89,16 @@ pub fn classify_option_5(option: i32) -> i32 {
     'switch: {
         let __match_cond = (*option.borrow());
         match __match_cond {
-            __v if __v == (Option::OPT_NONE as i32) => {
+            __v if __v == (Option_OPT_NONE as i32) => {
                 return -1_i32;
             }
-            __v if __v == (Option::OPT_A as i32) => {
+            __v if __v == (Option_OPT_A as i32) => {
                 return 1;
             }
-            __v if __v == (Option::OPT_B as i32) => {
+            __v if __v == (Option_OPT_B as i32) => {
                 return 2;
             }
-            __v if __v == (Option::OPT_C as i32) => {
+            __v if __v == (Option_OPT_C as i32) => {
                 return 3;
             }
             _ => {
@@ -177,17 +110,17 @@ pub fn classify_option_5(option: i32) -> i32 {
 }
 pub fn make_color_6(n: i32) -> Color {
     let n: Value<i32> = Rc::new(RefCell::new(n));
-    return Color::from((*n.borrow()));
+    return ((*n.borrow()) as Color);
 }
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    let c: Value<Color> = Rc::new(RefCell::new(Color::RED));
-    assert!((((*c.borrow()) as i32) == (Color::RED as i32)));
+    let c: Value<Color> = Rc::new(RefCell::new(Color_RED));
+    assert!((((*c.borrow()) as i32) == (Color_RED as i32)));
     assert!((((*c.borrow()) as i32) == 0));
     assert!((((*c.borrow()) as i32) != 1));
-    if (((*c.borrow()) as i32) == (Color::GREEN as i32)) {
+    if (((*c.borrow()) as i32) == (Color_GREEN as i32)) {
         return 1;
     }
     'switch: {
@@ -211,39 +144,39 @@ fn main_0() -> i32 {
     assert!(((*x.borrow()) == 0));
     let y: Value<i32> = Rc::new(RefCell::new((((*c.borrow()) as i32) + 1)));
     assert!(((*y.borrow()) == 1));
-    (*c.borrow_mut()) = Color::from(2);
-    assert!((((*c.borrow()) as i32) == (Color::BLUE as i32)));
+    (*c.borrow_mut()) = ((2) as Color);
+    assert!((((*c.borrow()) as i32) == (Color_BLUE as i32)));
     assert!((((*c.borrow()) as i32) == 2));
     (*c.borrow_mut()) = ({ make_color_6(1) });
-    assert!((((*c.borrow()) as i32) == (Color::GREEN as i32)));
-    let cmp: Value<Color> = Rc::new(RefCell::new(Color::from((((*c.borrow()) as i32) + 1))));
-    assert!((((*cmp.borrow()) as i32) == (Color::BLUE as i32)));
-    let o: Value<Option> = Rc::new(RefCell::new(Option::OPT_A));
-    assert!((((*o.borrow()) as i32) == (Option::OPT_A as i32)));
+    assert!((((*c.borrow()) as i32) == (Color_GREEN as i32)));
+    let cmp: Value<Color> = Rc::new(RefCell::new(((((*c.borrow()) as i32) + 1) as Color)));
+    assert!((((*cmp.borrow()) as i32) == (Color_BLUE as i32)));
+    let o: Value<Option> = Rc::new(RefCell::new(Option_OPT_A));
+    assert!((((*o.borrow()) as i32) == (Option_OPT_A as i32)));
     assert!((((*o.borrow()) as i32) == 10));
     let oi: Value<i32> = Rc::new(RefCell::new(((*o.borrow()) as i32)));
     assert!(((*oi.borrow()) == 10));
-    (*o.borrow_mut()) = Option::from(20);
-    assert!((((*o.borrow()) as i32) == (Option::OPT_B as i32)));
+    (*o.borrow_mut()) = ((20) as Option);
+    assert!((((*o.borrow()) as i32) == (Option_OPT_B as i32)));
     let rc: Value<i32> = Rc::new(RefCell::new(
         ({ classify_option_5(((*o.borrow()) as i32)) }),
     ));
     assert!(((*rc.borrow()) == 2));
     (*rc.borrow_mut()) = ({ classify_option_5(20) });
     assert!(((*rc.borrow()) == 2));
-    (*rc.borrow_mut()) = ({ classify_option_5((Option::OPT_C as i32)) });
+    (*rc.borrow_mut()) = ({ classify_option_5((Option_OPT_C as i32)) });
     assert!(((*rc.borrow()) == 3));
-    let t: Value<Tag> = Rc::new(RefCell::new(Tag::TAG_ONE));
+    let t: Value<Tag> = Rc::new(RefCell::new(Tag_TAG_ONE));
     assert!((((*t.borrow()) as i32) == 1));
-    assert!((((*t.borrow()) as i32) == (Tag::TAG_ONE as i32)));
+    assert!((((*t.borrow()) as i32) == (Tag_TAG_ONE as i32)));
     let ti: Value<i32> = Rc::new(RefCell::new(((*t.borrow()) as i32)));
     assert!(((*ti.borrow()) == 1));
-    (*t.borrow_mut()) = Tag::from(2);
-    assert!((((*t.borrow()) as i32) == (Tag::TAG_TWO as i32)));
+    (*t.borrow_mut()) = ((2) as Tag);
+    assert!((((*t.borrow()) as i32) == (Tag_TAG_TWO as i32)));
     'switch: {
         let __match_cond = ((*t.borrow()) as i32);
         match __match_cond {
-            __v if __v == (Tag::TAG_ZERO as i32) => {
+            __v if __v == (Tag_TAG_ZERO as i32) => {
                 return 90;
             }
             __v if __v == 1 => {
@@ -256,47 +189,47 @@ fn main_0() -> i32 {
         }
     };
     let extra: Value<i32> = Rc::new(RefCell::new(
-        (((Color::RED as i32) + (Color::GREEN as i32)) + (Color::BLUE as i32)),
+        (((Color_RED as i32) + (Color_GREEN as i32)) + (Color_BLUE as i32)),
     ));
     assert!(((*extra.borrow()) == ((0 + 1) + 2)));
-    assert!((((*global_color_0.with(Value::clone).borrow()) as i32) == (Color::GREEN as i32)));
-    assert!((((*global_opt_1.with(Value::clone).borrow()) as i32) == (Option::OPT_B as i32)));
-    assert!((((*global_tag_2.with(Value::clone).borrow()) as i32) == (Tag::TAG_TWO as i32)));
+    assert!((((*global_color_0.with(Value::clone).borrow()) as i32) == (Color_GREEN as i32)));
+    assert!((((*global_opt_1.with(Value::clone).borrow()) as i32) == (Option_OPT_B as i32)));
+    assert!((((*global_tag_2.with(Value::clone).borrow()) as i32) == (Tag_TAG_TWO as i32)));
     assert!(
         (((*(*entries_3.with(Value::clone).borrow())[(0) as usize]
             .color
             .borrow()) as i32)
-            == (Color::RED as i32))
+            == (Color_RED as i32))
     );
     assert!(
         (((*(*entries_3.with(Value::clone).borrow())[(0) as usize]
             .opt
             .borrow()) as i32)
-            == (Option::OPT_NONE as i32))
+            == (Option_OPT_NONE as i32))
     );
     assert!(
         (((*(*entries_3.with(Value::clone).borrow())[(1) as usize]
             .color
             .borrow()) as i32)
-            == (Color::GREEN as i32))
+            == (Color_GREEN as i32))
     );
     assert!(
         (((*(*entries_3.with(Value::clone).borrow())[(1) as usize]
             .opt
             .borrow()) as i32)
-            == (Option::OPT_A as i32))
+            == (Option_OPT_A as i32))
     );
     assert!(
         (((*(*entries_3.with(Value::clone).borrow())[(2) as usize]
             .color
             .borrow()) as i32)
-            == (Color::BLUE as i32))
+            == (Color_BLUE as i32))
     );
     assert!(
         (((*(*entries_3.with(Value::clone).borrow())[(2) as usize]
             .opt
             .borrow()) as i32)
-            == (Option::OPT_C as i32))
+            == (Option_OPT_C as i32))
     );
     return 0;
 }

--- a/tests/unit/out/refcount/enum_int_interop_c.rs
+++ b/tests/unit/out/refcount/enum_int_interop_c.rs
@@ -6,86 +6,19 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Color {
-    #[default]
-    RED = 0,
-    GREEN = 1,
-    BLUE = 2,
-}
-impl From<i32> for Color {
-    fn from(n: i32) -> Color {
-        match n {
-            0 => Color::RED,
-            1 => Color::GREEN,
-            2 => Color::BLUE,
-            _ => panic!("invalid Color value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Color);
-impl ByteRepr for Color {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <Color>::from(i32::from_bytes(buf))
-    }
-}
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Option {
-    #[default]
-    OPT_NONE = 0,
-    OPT_A = 10,
-    OPT_B = 20,
-    OPT_C = 30,
-}
-impl From<i32> for Option {
-    fn from(n: i32) -> Option {
-        match n {
-            0 => Option::OPT_NONE,
-            10 => Option::OPT_A,
-            20 => Option::OPT_B,
-            30 => Option::OPT_C,
-            _ => panic!("invalid Option value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Option);
-impl ByteRepr for Option {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <Option>::from(i32::from_bytes(buf))
-    }
-}
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Tag_enum {
-    #[default]
-    TAG_ZERO = 0,
-    TAG_ONE = 1,
-    TAG_TWO = 2,
-}
-impl From<i32> for Tag_enum {
-    fn from(n: i32) -> Tag_enum {
-        match n {
-            0 => Tag_enum::TAG_ZERO,
-            1 => Tag_enum::TAG_ONE,
-            2 => Tag_enum::TAG_TWO,
-            _ => panic!("invalid Tag_enum value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Tag_enum);
-impl ByteRepr for Tag_enum {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <Tag_enum>::from(i32::from_bytes(buf))
-    }
-}
+pub type Color = u32;
+pub const Color_RED: Color = 0;
+pub const Color_GREEN: Color = 1;
+pub const Color_BLUE: Color = 2;
+pub type Option = u32;
+pub const Option_OPT_NONE: Option = 0;
+pub const Option_OPT_A: Option = 10;
+pub const Option_OPT_B: Option = 20;
+pub const Option_OPT_C: Option = 30;
+pub type Tag_enum = u32;
+pub const Tag_enum_TAG_ZERO: Tag_enum = 0;
+pub const Tag_enum_TAG_ONE: Tag_enum = 1;
+pub const Tag_enum_TAG_TWO: Tag_enum = 2;
 #[derive(Default)]
 pub struct Entry {
     pub name: Value<Ptr<u8>>,
@@ -119,30 +52,30 @@ impl ByteRepr for Entry {
     }
 }
 thread_local!(
-    pub static global_color_0: Value<Color> = Rc::new(RefCell::new(Color::GREEN));
+    pub static global_color_0: Value<Color> = Rc::new(RefCell::new(Color_GREEN));
 );
 thread_local!(
-    pub static global_opt_1: Value<Option> = Rc::new(RefCell::new(Option::OPT_B));
+    pub static global_opt_1: Value<Option> = Rc::new(RefCell::new(Option_OPT_B));
 );
 thread_local!(
-    pub static global_tag_2: Value<Tag_enum> = Rc::new(RefCell::new(Tag_enum::TAG_TWO));
+    pub static global_tag_2: Value<Tag_enum> = Rc::new(RefCell::new(Tag_enum_TAG_TWO));
 );
 thread_local!(
     pub static entries_3: Value<Box<[Entry]>> = Rc::new(RefCell::new(Box::new([
         Entry {
             name: Rc::new(RefCell::new(Ptr::from_string_literal(b"first"))),
-            color: Rc::new(RefCell::new(Color::RED)),
-            opt: Rc::new(RefCell::new(Option::OPT_NONE)),
+            color: Rc::new(RefCell::new(Color_RED)),
+            opt: Rc::new(RefCell::new(Option_OPT_NONE)),
         },
         Entry {
             name: Rc::new(RefCell::new(Ptr::from_string_literal(b"second"))),
-            color: Rc::new(RefCell::new(Color::GREEN)),
-            opt: Rc::new(RefCell::new(Option::OPT_A)),
+            color: Rc::new(RefCell::new(Color_GREEN)),
+            opt: Rc::new(RefCell::new(Option_OPT_A)),
         },
         Entry {
             name: Rc::new(RefCell::new(Ptr::from_string_literal(b"third"))),
-            color: Rc::new(RefCell::new(Color::BLUE)),
-            opt: Rc::new(RefCell::new(Option::OPT_C)),
+            color: Rc::new(RefCell::new(Color_BLUE)),
+            opt: Rc::new(RefCell::new(Option_OPT_C)),
         },
     ])));
 );
@@ -155,16 +88,16 @@ pub fn classify_option_5(option: i32) -> i32 {
     'switch: {
         let __match_cond = (*option.borrow());
         match __match_cond {
-            __v if __v == (Option::OPT_NONE as i32) => {
+            __v if __v == (Option_OPT_NONE as i32) => {
                 return -1_i32;
             }
-            __v if __v == (Option::OPT_A as i32) => {
+            __v if __v == (Option_OPT_A as i32) => {
                 return 1;
             }
-            __v if __v == (Option::OPT_B as i32) => {
+            __v if __v == (Option_OPT_B as i32) => {
                 return 2;
             }
-            __v if __v == (Option::OPT_C as i32) => {
+            __v if __v == (Option_OPT_C as i32) => {
                 return 3;
             }
             _ => {
@@ -176,17 +109,17 @@ pub fn classify_option_5(option: i32) -> i32 {
 }
 pub fn make_color_6(n: i32) -> Color {
     let n: Value<i32> = Rc::new(RefCell::new(n));
-    return Color::from((*n.borrow()));
+    return ((*n.borrow()) as Color);
 }
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    let c: Value<Color> = Rc::new(RefCell::new(Color::RED));
-    assert!((((((*c.borrow()) as u32) == ((Color::RED as i32) as u32)) as i32) != 0));
+    let c: Value<Color> = Rc::new(RefCell::new(Color_RED));
+    assert!((((((*c.borrow()) as u32) == ((Color_RED as i32) as u32)) as i32) != 0));
     assert!((((((*c.borrow()) as u32) == 0_u32) as i32) != 0));
     assert!((((((*c.borrow()) as u32) != 1_u32) as i32) != 0));
-    if (((((*c.borrow()) as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0) {
+    if (((((*c.borrow()) as u32) == ((Color_GREEN as i32) as u32)) as i32) != 0) {
         return 1;
     }
     'switch: {
@@ -212,41 +145,41 @@ fn main_0() -> i32 {
         ((((*c.borrow()) as u32).wrapping_add(1_u32)) as i32),
     ));
     assert!(((((*y.borrow()) == 1) as i32) != 0));
-    (*c.borrow_mut()) = Color::from(2);
-    assert!((((((*c.borrow()) as u32) == ((Color::BLUE as i32) as u32)) as i32) != 0));
+    (*c.borrow_mut()) = ((2) as Color);
+    assert!((((((*c.borrow()) as u32) == ((Color_BLUE as i32) as u32)) as i32) != 0));
     assert!((((((*c.borrow()) as u32) == 2_u32) as i32) != 0));
     (*c.borrow_mut()) = ({ make_color_6(1) });
-    assert!((((((*c.borrow()) as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0));
-    let cmp: Value<Color> = Rc::new(RefCell::new(Color::from(
-        (((*c.borrow()) as u32).wrapping_add(1_u32)) as i32,
-    )));
-    assert!((((((*cmp.borrow()) as u32) == ((Color::BLUE as i32) as u32)) as i32) != 0));
-    let o: Value<Option> = Rc::new(RefCell::new(Option::OPT_A));
-    assert!((((((*o.borrow()) as u32) == ((Option::OPT_A as i32) as u32)) as i32) != 0));
+    assert!((((((*c.borrow()) as u32) == ((Color_GREEN as i32) as u32)) as i32) != 0));
+    let cmp: Value<Color> = Rc::new(RefCell::new(
+        ((((*c.borrow()) as u32).wrapping_add(1_u32)) as Color),
+    ));
+    assert!((((((*cmp.borrow()) as u32) == ((Color_BLUE as i32) as u32)) as i32) != 0));
+    let o: Value<Option> = Rc::new(RefCell::new(Option_OPT_A));
+    assert!((((((*o.borrow()) as u32) == ((Option_OPT_A as i32) as u32)) as i32) != 0));
     assert!((((((*o.borrow()) as u32) == 10_u32) as i32) != 0));
     let oi: Value<i32> = Rc::new(RefCell::new(((*o.borrow()) as i32)));
     assert!(((((*oi.borrow()) == 10) as i32) != 0));
-    (*o.borrow_mut()) = Option::from(20);
-    assert!((((((*o.borrow()) as u32) == ((Option::OPT_B as i32) as u32)) as i32) != 0));
+    (*o.borrow_mut()) = ((20) as Option);
+    assert!((((((*o.borrow()) as u32) == ((Option_OPT_B as i32) as u32)) as i32) != 0));
     let rc: Value<i32> = Rc::new(RefCell::new(
         ({ classify_option_5(((*o.borrow()) as i32)) }),
     ));
     assert!(((((*rc.borrow()) == 2) as i32) != 0));
     (*rc.borrow_mut()) = ({ classify_option_5(20) });
     assert!(((((*rc.borrow()) == 2) as i32) != 0));
-    (*rc.borrow_mut()) = ({ classify_option_5((Option::OPT_C as i32)) });
+    (*rc.borrow_mut()) = ({ classify_option_5((Option_OPT_C as i32)) });
     assert!(((((*rc.borrow()) == 3) as i32) != 0));
-    let t: Value<Tag_enum> = Rc::new(RefCell::new(Tag_enum::TAG_ONE));
+    let t: Value<Tag_enum> = Rc::new(RefCell::new(Tag_enum_TAG_ONE));
     assert!((((((*t.borrow()) as u32) == 1_u32) as i32) != 0));
-    assert!((((((*t.borrow()) as u32) == ((Tag_enum::TAG_ONE as i32) as u32)) as i32) != 0));
+    assert!((((((*t.borrow()) as u32) == ((Tag_enum_TAG_ONE as i32) as u32)) as i32) != 0));
     let ti: Value<i32> = Rc::new(RefCell::new(((*t.borrow()) as i32)));
     assert!(((((*ti.borrow()) == 1) as i32) != 0));
-    (*t.borrow_mut()) = Tag_enum::from(2);
-    assert!((((((*t.borrow()) as u32) == ((Tag_enum::TAG_TWO as i32) as u32)) as i32) != 0));
+    (*t.borrow_mut()) = ((2) as Tag_enum);
+    assert!((((((*t.borrow()) as u32) == ((Tag_enum_TAG_TWO as i32) as u32)) as i32) != 0));
     'switch: {
         let __match_cond = ((*t.borrow()) as u32);
         match __match_cond {
-            __v if __v == ((Tag_enum::TAG_ZERO as i32) as u32) => {
+            __v if __v == ((Tag_enum_TAG_ZERO as i32) as u32) => {
                 return 90;
             }
             __v if __v == (1 as u32) => {
@@ -259,64 +192,64 @@ fn main_0() -> i32 {
         }
     };
     let extra: Value<i32> = Rc::new(RefCell::new(
-        (((Color::RED as i32) + (Color::GREEN as i32)) + (Color::BLUE as i32)),
+        (((Color_RED as i32) + (Color_GREEN as i32)) + (Color_BLUE as i32)),
     ));
     assert!(((((*extra.borrow()) == ((0 + 1) + 2)) as i32) != 0));
     assert!(
-        (((((*global_color_0.with(Value::clone).borrow()) as u32) == ((Color::GREEN as i32) as u32))
+        (((((*global_color_0.with(Value::clone).borrow()) as u32) == ((Color_GREEN as i32) as u32))
             as i32)
             != 0)
     );
     assert!(
-        (((((*global_opt_1.with(Value::clone).borrow()) as u32) == ((Option::OPT_B as i32) as u32))
+        (((((*global_opt_1.with(Value::clone).borrow()) as u32) == ((Option_OPT_B as i32) as u32))
             as i32)
             != 0)
     );
     assert!(
         (((((*global_tag_2.with(Value::clone).borrow()) as u32)
-            == ((Tag_enum::TAG_TWO as i32) as u32)) as i32)
+            == ((Tag_enum_TAG_TWO as i32) as u32)) as i32)
             != 0)
     );
     assert!(
         (((((*(*entries_3.with(Value::clone).borrow())[(0) as usize]
             .color
             .borrow()) as u32)
-            == ((Color::RED as i32) as u32)) as i32)
+            == ((Color_RED as i32) as u32)) as i32)
             != 0)
     );
     assert!(
         (((((*(*entries_3.with(Value::clone).borrow())[(0) as usize]
             .opt
             .borrow()) as u32)
-            == ((Option::OPT_NONE as i32) as u32)) as i32)
+            == ((Option_OPT_NONE as i32) as u32)) as i32)
             != 0)
     );
     assert!(
         (((((*(*entries_3.with(Value::clone).borrow())[(1) as usize]
             .color
             .borrow()) as u32)
-            == ((Color::GREEN as i32) as u32)) as i32)
+            == ((Color_GREEN as i32) as u32)) as i32)
             != 0)
     );
     assert!(
         (((((*(*entries_3.with(Value::clone).borrow())[(1) as usize]
             .opt
             .borrow()) as u32)
-            == ((Option::OPT_A as i32) as u32)) as i32)
+            == ((Option_OPT_A as i32) as u32)) as i32)
             != 0)
     );
     assert!(
         (((((*(*entries_3.with(Value::clone).borrow())[(2) as usize]
             .color
             .borrow()) as u32)
-            == ((Color::BLUE as i32) as u32)) as i32)
+            == ((Color_BLUE as i32) as u32)) as i32)
             != 0)
     );
     assert!(
         (((((*(*entries_3.with(Value::clone).borrow())[(2) as usize]
             .opt
             .borrow()) as u32)
-            == ((Option::OPT_C as i32) as u32)) as i32)
+            == ((Option_OPT_C as i32) as u32)) as i32)
             != 0)
     );
     let names: Value<Box<[Ptr<u8>]>> = Rc::new(RefCell::new(Box::new([
@@ -324,7 +257,7 @@ fn main_0() -> i32 {
         Ptr::from_string_literal(b"green"),
         Ptr::from_string_literal(b"blue"),
     ])));
-    let idx: Value<Color> = Rc::new(RefCell::new(Color::GREEN));
+    let idx: Value<Color> = Rc::new(RefCell::new(Color_GREEN));
     assert!(
         ((((((*names.borrow())[(*idx.borrow()) as usize]
             .offset((0) as isize)
@@ -336,7 +269,7 @@ fn main_0() -> i32 {
         (((((*(*entries_3.with(Value::clone).borrow())[(*idx.borrow()) as usize]
             .opt
             .borrow()) as u32)
-            == ((Option::OPT_A as i32) as u32)) as i32)
+            == ((Option_OPT_A as i32) as u32)) as i32)
             != 0)
     );
     assert!(
@@ -359,7 +292,7 @@ fn main_0() -> i32 {
     ));
     assert!(
         (((((*(*(*pe.borrow()).upgrade().deref()).opt.borrow()) as u32)
-            == ((Option::OPT_A as i32) as u32)) as i32)
+            == ((Option_OPT_A as i32) as u32)) as i32)
             != 0)
     );
     return 0;

--- a/tests/unit/out/refcount/enum_with_duplicated_values.rs
+++ b/tests/unit/out/refcount/enum_with_duplicated_values.rs
@@ -1,0 +1,23 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub type E = u32;
+pub const E_A: E = 2;
+pub const E_B: E = 4;
+pub const E_C: E = 2;
+pub const E_D: E = 4;
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!(((E_A as i32) == (1 << 1)));
+    assert!(((E_B as i32) == (1 << 2)));
+    assert!(((E_C as i32) == (1 << 1)));
+    assert!(((E_D as i32) == (1 << 2)));
+    return 0;
+}

--- a/tests/unit/out/refcount/switch_char.rs
+++ b/tests/unit/out/refcount/switch_char.rs
@@ -30,32 +30,10 @@ pub fn switch_char_0(c: u8) -> i32 {
     };
     panic!("ub: non-void function does not return a value")
 }
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Color {
-    #[default]
-    kRed = 0,
-    kGreen = 1,
-    kBlue = 2,
-}
-impl From<i32> for Color {
-    fn from(n: i32) -> Color {
-        match n {
-            0 => Color::kRed,
-            1 => Color::kGreen,
-            2 => Color::kBlue,
-            _ => panic!("invalid Color value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Color);
-impl ByteRepr for Color {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <Color>::from(i32::from_bytes(buf))
-    }
-}
+pub type Color = u32;
+pub const Color_kRed: Color = 0;
+pub const Color_kGreen: Color = 1;
+pub const Color_kBlue: Color = 2;
 pub fn main() {
     std::process::exit(main_0());
 }

--- a/tests/unit/out/refcount/switch_enum.rs
+++ b/tests/unit/out/refcount/switch_enum.rs
@@ -6,44 +6,22 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Color {
-    #[default]
-    kRed = 0,
-    kGreen = 1,
-    kBlue = 2,
-}
-impl From<i32> for Color {
-    fn from(n: i32) -> Color {
-        match n {
-            0 => Color::kRed,
-            1 => Color::kGreen,
-            2 => Color::kBlue,
-            _ => panic!("invalid Color value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Color);
-impl ByteRepr for Color {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <Color>::from(i32::from_bytes(buf))
-    }
-}
+pub type Color = u32;
+pub const Color_kRed: Color = 0;
+pub const Color_kGreen: Color = 1;
+pub const Color_kBlue: Color = 2;
 pub fn switch_enum_0(c: Color) -> i32 {
     let c: Value<Color> = Rc::new(RefCell::new(c));
     'switch: {
         let __match_cond = ((*c.borrow()) as i32);
         match __match_cond {
-            __v if __v == (Color::kRed as i32) => {
+            __v if __v == (Color_kRed as i32) => {
                 return 10;
             }
-            __v if __v == (Color::kGreen as i32) => {
+            __v if __v == (Color_kGreen as i32) => {
                 return 20;
             }
-            __v if __v == (Color::kBlue as i32) => {
+            __v if __v == (Color_kBlue as i32) => {
                 return 30;
             }
             _ => {}
@@ -55,8 +33,8 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    assert!((({ switch_enum_0(Color::kRed,) }) == 10));
-    assert!((({ switch_enum_0(Color::kGreen,) }) == 20));
-    assert!((({ switch_enum_0(Color::kBlue,) }) == 30));
+    assert!((({ switch_enum_0(Color_kRed,) }) == 10));
+    assert!((({ switch_enum_0(Color_kGreen,) }) == 20));
+    assert!((({ switch_enum_0(Color_kBlue,) }) == 30));
     return 0;
 }

--- a/tests/unit/out/refcount/tag_vs_identifier_collision.rs
+++ b/tests/unit/out/refcount/tag_vs_identifier_collision.rs
@@ -6,32 +6,10 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum widget_enum {
-    #[default]
-    MODE_IDLE = 0,
-    MODE_ACTIVE = 1,
-    MODE_DONE = 2,
-}
-impl From<i32> for widget_enum {
-    fn from(n: i32) -> widget_enum {
-        match n {
-            0 => widget_enum::MODE_IDLE,
-            1 => widget_enum::MODE_ACTIVE,
-            2 => widget_enum::MODE_DONE,
-            _ => panic!("invalid widget_enum value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(widget_enum);
-impl ByteRepr for widget_enum {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <widget_enum>::from(i32::from_bytes(buf))
-    }
-}
+pub type widget_enum = u32;
+pub const widget_enum_MODE_IDLE: widget_enum = 0;
+pub const widget_enum_MODE_ACTIVE: widget_enum = 1;
+pub const widget_enum_MODE_DONE: widget_enum = 2;
 #[derive(Default)]
 pub struct widget {
     pub id: Value<i32>,
@@ -164,30 +142,9 @@ impl ByteRepr for slot_union {
         }
     }
 }
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum slot {
-    #[default]
-    SLOT_A = 0,
-    SLOT_B = 1,
-}
-impl From<i32> for slot {
-    fn from(n: i32) -> slot {
-        match n {
-            0 => slot::SLOT_A,
-            1 => slot::SLOT_B,
-            _ => panic!("invalid slot value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(slot);
-impl ByteRepr for slot {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <slot>::from(i32::from_bytes(buf))
-    }
-}
+pub type slot = u32;
+pub const slot_SLOT_A: slot = 0;
+pub const slot_SLOT_B: slot = 1;
 #[derive(Default)]
 pub struct Inner {
     pub tag_field: Value<i32>,
@@ -263,7 +220,7 @@ impl ByteRepr for Inner_struct {
 pub fn is_active_0(w: Ptr<widget>) -> i32 {
     let w: Value<Ptr<widget>> = Rc::new(RefCell::new(w));
     return ((((*(*(*w.borrow()).upgrade().deref()).mode.borrow()) as u32)
-        == ((widget_enum::MODE_ACTIVE as i32) as u32)) as i32);
+        == ((widget_enum_MODE_ACTIVE as i32) as u32)) as i32);
 }
 pub fn main() {
     std::process::exit(main_0());
@@ -271,11 +228,11 @@ pub fn main() {
 fn main_0() -> i32 {
     let w: Value<widget> = <Value<widget>>::default();
     (*(*w.borrow()).id.borrow_mut()) = 7;
-    (*(*w.borrow()).mode.borrow_mut()) = widget_enum::MODE_ACTIVE;
+    (*(*w.borrow()).mode.borrow_mut()) = widget_enum_MODE_ACTIVE;
     assert!((({ is_active_0((w.as_pointer()),) }) != 0));
-    (*(*w.borrow()).mode.borrow_mut()) = widget_enum::MODE_DONE;
+    (*(*w.borrow()).mode.borrow_mut()) = widget_enum_MODE_DONE;
     assert!(
-        (((((*(*w.borrow()).mode.borrow()) as u32) == ((widget_enum::MODE_DONE as i32) as u32))
+        (((((*(*w.borrow()).mode.borrow()) as u32) == ((widget_enum_MODE_DONE as i32) as u32))
             as i32)
             != 0)
     );
@@ -289,8 +246,8 @@ fn main_0() -> i32 {
     let b: Value<slot_union> = <Value<slot_union>>::default();
     (*b.borrow_mut()).i().write(9);
     assert!((((((*b.borrow()).i().read()) == 9) as i32) != 0));
-    let e: Value<slot> = Rc::new(RefCell::new(slot::SLOT_B));
-    assert!((((((*e.borrow()) as u32) == ((slot::SLOT_B as i32) as u32)) as i32) != 0));
+    let e: Value<slot> = Rc::new(RefCell::new(slot_SLOT_B));
+    assert!((((((*e.borrow()) as u32) == ((slot_SLOT_B as i32) as u32)) as i32) != 0));
     let inner_tag: Value<Inner> = <Value<Inner>>::default();
     (*(*inner_tag.borrow()).tag_field.borrow_mut()) = 11;
     assert!(((((*(*inner_tag.borrow()).tag_field.borrow()) == 11) as i32) != 0));

--- a/tests/unit/out/refcount/union_tagged_many_arms.rs
+++ b/tests/unit/out/refcount/union_tagged_many_arms.rs
@@ -6,36 +6,12 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Tag_enum {
-    #[default]
-    T_NUM_S = 0,
-    T_NUM_U = 1,
-    T_TEXT = 2,
-    T_FLOAT = 3,
-    T_REF = 4,
-}
-impl From<i32> for Tag_enum {
-    fn from(n: i32) -> Tag_enum {
-        match n {
-            0 => Tag_enum::T_NUM_S,
-            1 => Tag_enum::T_NUM_U,
-            2 => Tag_enum::T_TEXT,
-            3 => Tag_enum::T_FLOAT,
-            4 => Tag_enum::T_REF,
-            _ => panic!("invalid Tag_enum value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Tag_enum);
-impl ByteRepr for Tag_enum {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <Tag_enum>::from(i32::from_bytes(buf))
-    }
-}
+pub type Tag_enum = u32;
+pub const Tag_enum_T_NUM_S: Tag_enum = 0;
+pub const Tag_enum_T_NUM_U: Tag_enum = 1;
+pub const Tag_enum_T_TEXT: Tag_enum = 2;
+pub const Tag_enum_T_FLOAT: Tag_enum = 3;
+pub const Tag_enum_T_REF: Tag_enum = 4;
 pub struct anon_0 {
     __bytes: Value<Box<[u8]>>,
 }
@@ -116,7 +92,7 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let a: Value<Slot> = <Value<Slot>>::default();
-    (*(*a.borrow()).tag.borrow_mut()) = Tag_enum::T_NUM_S;
+    (*(*a.borrow()).tag.borrow_mut()) = Tag_enum_T_NUM_S;
     (*(*a.borrow()).payload.borrow_mut())
         .signed_n()
         .write((-7_i32 as i64));
@@ -124,7 +100,7 @@ fn main_0() -> i32 {
         (((((*(*a.borrow()).payload.borrow()).signed_n().read()) == (-7_i32 as i64)) as i32) != 0)
     );
     let b: Value<Slot> = <Value<Slot>>::default();
-    (*(*b.borrow()).tag.borrow_mut()) = Tag_enum::T_NUM_U;
+    (*(*b.borrow()).tag.borrow_mut()) = Tag_enum_T_NUM_U;
     (*(*b.borrow()).payload.borrow_mut())
         .unsigned_n()
         .write(3735928559_u64);
@@ -132,7 +108,7 @@ fn main_0() -> i32 {
         (((((*(*b.borrow()).payload.borrow()).unsigned_n().read()) == 3735928559_u64) as i32) != 0)
     );
     let c: Value<Slot> = <Value<Slot>>::default();
-    (*(*c.borrow()).tag.borrow_mut()) = Tag_enum::T_TEXT;
+    (*(*c.borrow()).tag.borrow_mut()) = Tag_enum_T_TEXT;
     (*(*c.borrow()).payload.borrow_mut())
         .text()
         .write(Ptr::from_string_literal(b"hello"));
@@ -144,12 +120,12 @@ fn main_0() -> i32 {
             != 0)
     );
     let d: Value<Slot> = <Value<Slot>>::default();
-    (*(*d.borrow()).tag.borrow_mut()) = Tag_enum::T_FLOAT;
+    (*(*d.borrow()).tag.borrow_mut()) = Tag_enum_T_FLOAT;
     (*(*d.borrow()).payload.borrow_mut()).f().write(1.5E+0);
     assert!((((((*(*d.borrow()).payload.borrow()).f().read()) == 1.5E+0) as i32) != 0));
     let x: Value<i32> = Rc::new(RefCell::new(0));
     let e: Value<Slot> = <Value<Slot>>::default();
-    (*(*e.borrow()).tag.borrow_mut()) = Tag_enum::T_REF;
+    (*(*e.borrow()).tag.borrow_mut()) = Tag_enum_T_REF;
     (*(*e.borrow()).payload.borrow_mut())
         .handle()
         .write(((x.as_pointer()) as Ptr<i32>).to_any());

--- a/tests/unit/out/refcount/union_tagged_simple.rs
+++ b/tests/unit/out/refcount/union_tagged_simple.rs
@@ -6,30 +6,9 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Kind_enum {
-    #[default]
-    KIND_NONE = 0,
-    KIND_DONE = 1,
-}
-impl From<i32> for Kind_enum {
-    fn from(n: i32) -> Kind_enum {
-        match n {
-            0 => Kind_enum::KIND_NONE,
-            1 => Kind_enum::KIND_DONE,
-            _ => panic!("invalid Kind_enum value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Kind_enum);
-impl ByteRepr for Kind_enum {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <Kind_enum>::from(i32::from_bytes(buf))
-    }
-}
+pub type Kind_enum = u32;
+pub const Kind_enum_KIND_NONE: Kind_enum = 0;
+pub const Kind_enum_KIND_DONE: Kind_enum = 1;
 pub struct anon_0 {
     __bytes: Value<Box<[u8]>>,
 }
@@ -106,17 +85,17 @@ pub fn main() {
 fn main_0() -> i32 {
     let dummy: Value<i32> = Rc::new(RefCell::new(0));
     let m1: Value<Event> = <Value<Event>>::default();
-    (*(*m1.borrow()).kind.borrow_mut()) = Kind_enum::KIND_DONE;
+    (*(*m1.borrow()).kind.borrow_mut()) = Kind_enum_KIND_DONE;
     (*(*m1.borrow()).handle.borrow_mut()) = ((dummy.as_pointer()) as Ptr<i32>).to_any();
     (*(*m1.borrow()).payload.borrow_mut()).code().write(42);
     assert!(
-        (((((*(*m1.borrow()).kind.borrow()) as u32) == ((Kind_enum::KIND_DONE as i32) as u32))
+        (((((*(*m1.borrow()).kind.borrow()) as u32) == ((Kind_enum_KIND_DONE as i32) as u32))
             as i32)
             != 0)
     );
     assert!((((((*(*m1.borrow()).payload.borrow()).code().read()) == 42) as i32) != 0));
     let m2: Value<Event> = <Value<Event>>::default();
-    (*(*m2.borrow()).kind.borrow_mut()) = Kind_enum::KIND_NONE;
+    (*(*m2.borrow()).kind.borrow_mut()) = Kind_enum_KIND_NONE;
     (*(*m2.borrow()).handle.borrow_mut()) = ((dummy.as_pointer()) as Ptr<i32>).to_any();
     (*(*m2.borrow()).payload.borrow_mut())
         .obj()

--- a/tests/unit/out/refcount/union_tagged_struct_arms.rs
+++ b/tests/unit/out/refcount/union_tagged_struct_arms.rs
@@ -6,32 +6,10 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Choice_enum {
-    #[default]
-    C_LIST = 1,
-    C_LETTERS = 2,
-    C_INTEGERS = 3,
-}
-impl From<i32> for Choice_enum {
-    fn from(n: i32) -> Choice_enum {
-        match n {
-            1 => Choice_enum::C_LIST,
-            2 => Choice_enum::C_LETTERS,
-            3 => Choice_enum::C_INTEGERS,
-            _ => panic!("invalid Choice_enum value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Choice_enum);
-impl ByteRepr for Choice_enum {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <Choice_enum>::from(i32::from_bytes(buf))
-    }
-}
+pub type Choice_enum = u32;
+pub const Choice_enum_C_LIST: Choice_enum = 1;
+pub const Choice_enum_C_LETTERS: Choice_enum = 2;
+pub const Choice_enum_C_INTEGERS: Choice_enum = 3;
 #[derive(Default)]
 pub struct anon_1 {
     pub items: Value<Ptr<Ptr<u8>>>,
@@ -225,7 +203,7 @@ fn main_0() -> i32 {
         ])));
     );
     let p_list: Value<Branch> = <Value<Branch>>::default();
-    (*(*p_list.borrow()).choice.borrow_mut()) = Choice_enum::C_LIST;
+    (*(*p_list.borrow()).choice.borrow_mut()) = Choice_enum_C_LIST;
     (*(*p_list.borrow()).index.borrow_mut()) = 0;
     (*(*(*(*p_list.borrow()).v.borrow()).list().upgrade().deref())
         .items
@@ -255,7 +233,7 @@ fn main_0() -> i32 {
             != 0)
     );
     let p_letters: Value<Branch> = <Value<Branch>>::default();
-    (*(*p_letters.borrow()).choice.borrow_mut()) = Choice_enum::C_LETTERS;
+    (*(*p_letters.borrow()).choice.borrow_mut()) = Choice_enum_C_LETTERS;
     (*(*p_letters.borrow()).index.borrow_mut()) = 1;
     (*(*(*(*p_letters.borrow()).v.borrow())
         .letters()
@@ -298,7 +276,7 @@ fn main_0() -> i32 {
             != 0)
     );
     let p_integers: Value<Branch> = <Value<Branch>>::default();
-    (*(*p_integers.borrow()).choice.borrow_mut()) = Choice_enum::C_INTEGERS;
+    (*(*p_integers.borrow()).choice.borrow_mut()) = Choice_enum_C_INTEGERS;
     (*(*p_integers.borrow()).index.borrow_mut()) = 2;
     (*(*(*(*p_integers.borrow()).v.borrow())
         .integers()

--- a/tests/unit/out/refcount/union_void_ptr_sized_deref.rs
+++ b/tests/unit/out/refcount/union_void_ptr_sized_deref.rs
@@ -6,32 +6,10 @@ use std::io::prelude::*;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Width_enum {
-    #[default]
-    W_64 = 0,
-    W_32 = 1,
-    W_16 = 2,
-}
-impl From<i32> for Width_enum {
-    fn from(n: i32) -> Width_enum {
-        match n {
-            0 => Width_enum::W_64,
-            1 => Width_enum::W_32,
-            2 => Width_enum::W_16,
-            _ => panic!("invalid Width_enum value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Width_enum);
-impl ByteRepr for Width_enum {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <Width_enum>::from(i32::from_bytes(buf))
-    }
-}
+pub type Width_enum = u32;
+pub const Width_enum_W_64: Width_enum = 0;
+pub const Width_enum_W_32: Width_enum = 1;
+pub const Width_enum_W_16: Width_enum = 2;
 pub struct anon_0 {
     __bytes: Value<Box<[u8]>>,
 }
@@ -110,7 +88,7 @@ pub fn write_count_1(s: Ptr<Sink>, count: i64) {
     'switch: {
         let __match_cond = ((*(*(*s.borrow()).upgrade().deref()).width.borrow()) as u32);
         match __match_cond {
-            __v if __v == ((Width_enum::W_64 as i32) as u32) => {
+            __v if __v == ((Width_enum_W_64 as i32) as u32) => {
                 ((*(*(*s.borrow()).upgrade().deref()).out.borrow())
                     .handle()
                     .read())
@@ -118,7 +96,7 @@ pub fn write_count_1(s: Ptr<Sink>, count: i64) {
                 .write((*count.borrow()));
                 break 'switch;
             }
-            __v if __v == ((Width_enum::W_32 as i32) as u32) => {
+            __v if __v == ((Width_enum_W_32 as i32) as u32) => {
                 ((*(*(*s.borrow()).upgrade().deref()).out.borrow())
                     .handle()
                     .read())
@@ -126,7 +104,7 @@ pub fn write_count_1(s: Ptr<Sink>, count: i64) {
                 .write(((*count.borrow()) as i32));
                 break 'switch;
             }
-            __v if __v == ((Width_enum::W_16 as i32) as u32) => {
+            __v if __v == ((Width_enum_W_16 as i32) as u32) => {
                 ((*(*(*s.borrow()).upgrade().deref()).out.borrow())
                     .handle()
                     .read())
@@ -146,19 +124,19 @@ fn main_0() -> i32 {
     let buf32: Value<i32> = Rc::new(RefCell::new(0));
     let buf16: Value<i16> = Rc::new(RefCell::new(0_i16));
     let s: Value<Sink> = <Value<Sink>>::default();
-    (*(*s.borrow()).width.borrow_mut()) = Width_enum::W_64;
+    (*(*s.borrow()).width.borrow_mut()) = Width_enum_W_64;
     (*(*s.borrow()).out.borrow_mut())
         .handle()
         .write(((buf64.as_pointer()) as Ptr<i64>).to_any());
     ({ write_count_1((s.as_pointer()), 1234605616436508552_i64) });
     assert!(((((*buf64.borrow()) == 1234605616436508552_i64) as i32) != 0));
-    (*(*s.borrow()).width.borrow_mut()) = Width_enum::W_32;
+    (*(*s.borrow()).width.borrow_mut()) = Width_enum_W_32;
     (*(*s.borrow()).out.borrow_mut())
         .handle()
         .write(((buf32.as_pointer()) as Ptr<i32>).to_any());
     ({ write_count_1((s.as_pointer()), 305419896_i64) });
     assert!(((((*buf32.borrow()) == 305419896) as i32) != 0));
-    (*(*s.borrow()).width.borrow_mut()) = Width_enum::W_16;
+    (*(*s.borrow()).width.borrow_mut()) = Width_enum_W_16;
     (*(*s.borrow()).out.borrow_mut())
         .handle()
         .write(((buf16.as_pointer()) as Ptr<i16>).to_any());

--- a/tests/unit/out/refcount/va_arg_non_primitive_ptrs.rs
+++ b/tests/unit/out/refcount/va_arg_non_primitive_ptrs.rs
@@ -34,34 +34,11 @@ impl ByteRepr for node {
         }
     }
 }
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum opt {
-    #[default]
-    OPT_STRING_OUT = 0,
-    OPT_FILE = 1,
-    OPT_NODE = 2,
-    OPT_NODE_OUT = 3,
-}
-impl From<i32> for opt {
-    fn from(n: i32) -> opt {
-        match n {
-            0 => opt::OPT_STRING_OUT,
-            1 => opt::OPT_FILE,
-            2 => opt::OPT_NODE,
-            3 => opt::OPT_NODE_OUT,
-            _ => panic!("invalid opt value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(opt);
-impl ByteRepr for opt {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <opt>::from(i32::from_bytes(buf))
-    }
-}
+pub type opt = u32;
+pub const opt_OPT_STRING_OUT: opt = 0;
+pub const opt_OPT_FILE: opt = 1;
+pub const opt_OPT_NODE: opt = 2;
+pub const opt_OPT_NODE_OUT: opt = 3;
 pub fn dispatch_0(option: i32, __args: &[VaArg]) -> i32 {
     let option: Value<i32> = Rc::new(RefCell::new(option));
     let ap: Value<VaList> = Rc::new(RefCell::new(VaList::default()));
@@ -70,26 +47,26 @@ pub fn dispatch_0(option: i32, __args: &[VaArg]) -> i32 {
     'switch: {
         let __match_cond = (*option.borrow());
         match __match_cond {
-            __v if __v == (opt::OPT_STRING_OUT as i32) => {
+            __v if __v == (opt_OPT_STRING_OUT as i32) => {
                 let out: Value<Ptr<Ptr<u8>>> =
                     Rc::new(RefCell::new((*ap.borrow_mut()).arg::<Ptr<Ptr<u8>>>()));
                 (*out.borrow()).write(Ptr::from_string_literal(b"hello"));
                 (*result.borrow_mut()) = 1;
                 break 'switch;
             }
-            __v if __v == (opt::OPT_FILE as i32) => {
+            __v if __v == (opt_OPT_FILE as i32) => {
                 let f: Value<Ptr<CFile>> =
                     Rc::new(RefCell::new((*ap.borrow_mut()).arg::<Ptr<CFile>>()));
                 (*result.borrow_mut()) = ((!((*f.borrow()).is_null())) as i32);
                 break 'switch;
             }
-            __v if __v == (opt::OPT_NODE as i32) => {
+            __v if __v == (opt_OPT_NODE as i32) => {
                 let n: Value<Ptr<node>> =
                     Rc::new(RefCell::new((*ap.borrow_mut()).arg::<Ptr<node>>()));
                 (*result.borrow_mut()) = (*(*(*n.borrow()).upgrade().deref()).data.borrow());
                 break 'switch;
             }
-            __v if __v == (opt::OPT_NODE_OUT as i32) => {
+            __v if __v == (opt_OPT_NODE_OUT as i32) => {
                 let out: Value<Ptr<Ptr<node>>> =
                     Rc::new(RefCell::new((*ap.borrow_mut()).arg::<Ptr<Ptr<node>>>()));
                 (*out.borrow()).write(Ptr::<node>::null());
@@ -107,7 +84,7 @@ pub fn main() {
 fn main_0() -> i32 {
     let s: Value<Ptr<u8>> = Rc::new(RefCell::new(Ptr::<u8>::null()));
     assert!(
-        (((({ dispatch_0((opt::OPT_STRING_OUT as i32), &[(s.as_pointer()).into(),]) }) == 1)
+        (((({ dispatch_0((opt_OPT_STRING_OUT as i32), &[(s.as_pointer()).into(),]) }) == 1)
             as i32)
             != 0)
     );
@@ -115,7 +92,7 @@ fn main_0() -> i32 {
     assert!(
         (((({
             dispatch_0(
-                (opt::OPT_FILE as i32),
+                (opt_OPT_FILE as i32),
                 &[((libcc2rs::c_stdout()).clone()).into()],
             )
         }) == 1) as i32)
@@ -124,7 +101,7 @@ fn main_0() -> i32 {
     assert!(
         (((({
             dispatch_0(
-                (opt::OPT_FILE as i32),
+                (opt_OPT_FILE as i32),
                 &[((AnyPtr::default()).reinterpret_cast::<CFile>()).into()],
             )
         }) == 0) as i32)
@@ -135,12 +112,12 @@ fn main_0() -> i32 {
         next: Rc::new(RefCell::new(Ptr::<node>::null())),
     }));
     assert!(
-        (((({ dispatch_0((opt::OPT_NODE as i32), &[(head.as_pointer()).into(),]) }) == 42) as i32)
+        (((({ dispatch_0((opt_OPT_NODE as i32), &[(head.as_pointer()).into(),]) }) == 42) as i32)
             != 0)
     );
     let outp: Value<Ptr<node>> = Rc::new(RefCell::new((head.as_pointer())));
     assert!(
-        (((({ dispatch_0((opt::OPT_NODE_OUT as i32), &[(outp.as_pointer()).into(),]) }) == 2)
+        (((({ dispatch_0((opt_OPT_NODE_OUT as i32), &[(outp.as_pointer()).into(),]) }) == 2)
             as i32)
             != 0)
     );

--- a/tests/unit/out/refcount/va_arg_void_ptr.rs
+++ b/tests/unit/out/refcount/va_arg_void_ptr.rs
@@ -34,30 +34,9 @@ impl ByteRepr for registry {
         }
     }
 }
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum field {
-    #[default]
-    FIELD_SLOT = 0,
-    FIELD_LEVEL = 1,
-}
-impl From<i32> for field {
-    fn from(n: i32) -> field {
-        match n {
-            0 => field::FIELD_SLOT,
-            1 => field::FIELD_LEVEL,
-            _ => panic!("invalid field value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(field);
-impl ByteRepr for field {
-    fn to_bytes(&self, buf: &mut [u8]) {
-        (*self as i32).to_bytes(buf);
-    }
-    fn from_bytes(buf: &[u8]) -> Self {
-        <field>::from(i32::from_bytes(buf))
-    }
-}
+pub type field = u32;
+pub const field_FIELD_SLOT: field = 0;
+pub const field_FIELD_LEVEL: field = 1;
 pub fn registry_update_0(r: Ptr<registry>, field: field, __args: &[VaArg]) -> i32 {
     let r: Value<Ptr<registry>> = Rc::new(RefCell::new(r));
     let field: Value<field> = Rc::new(RefCell::new(field));
@@ -67,12 +46,12 @@ pub fn registry_update_0(r: Ptr<registry>, field: field, __args: &[VaArg]) -> i3
     'switch: {
         let __match_cond = ((*field.borrow()) as u32);
         match __match_cond {
-            __v if __v == ((field::FIELD_SLOT as i32) as u32) => {
+            __v if __v == ((field_FIELD_SLOT as i32) as u32) => {
                 (*(*(*r.borrow()).upgrade().deref()).slot.borrow_mut()) =
                     (*ap.borrow_mut()).arg::<AnyPtr>();
                 break 'switch;
             }
-            __v if __v == ((field::FIELD_LEVEL as i32) as u32) => {
+            __v if __v == ((field_FIELD_LEVEL as i32) as u32) => {
                 (*(*(*r.borrow()).upgrade().deref()).level.borrow_mut()) =
                     (*ap.borrow_mut()).arg::<i64>();
                 break 'switch;
@@ -98,14 +77,14 @@ fn main_0() -> i32 {
         (((({
             registry_update_0(
                 (r.as_pointer()),
-                field::FIELD_SLOT,
+                field_FIELD_SLOT,
                 &[(payload.as_pointer()).into()],
             )
         }) == 0) as i32)
             != 0)
     );
     assert!(
-        (((({ registry_update_0((r.as_pointer()), field::FIELD_LEVEL, &[(5_i64).into(),]) }) == 0)
+        (((({ registry_update_0((r.as_pointer()), field_FIELD_LEVEL, &[(5_i64).into(),]) }) == 0)
             as i32)
             != 0)
     );

--- a/tests/unit/out/unsafe/anonymous_enum.rs
+++ b/tests/unit/out/unsafe/anonymous_enum.rs
@@ -6,75 +6,23 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum anon_0 {
-    #[default]
-    FIRST_A = 0,
-    FIRST_B = 1,
-}
-impl From<i32> for anon_0 {
-    fn from(n: i32) -> anon_0 {
-        match n {
-            0 => anon_0::FIRST_A,
-            1 => anon_0::FIRST_B,
-            _ => panic!("invalid anon_0 value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(anon_0);
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum anon_1 {
-    #[default]
-    SECOND_A = 0,
-    SECOND_B = 1,
-}
-impl From<i32> for anon_1 {
-    fn from(n: i32) -> anon_1 {
-        match n {
-            0 => anon_1::SECOND_A,
-            1 => anon_1::SECOND_B,
-            _ => panic!("invalid anon_1 value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(anon_1);
+pub type anon_0 = u32;
+pub const anon_0_FIRST_A: anon_0 = 0;
+pub const anon_0_FIRST_B: anon_0 = 1;
+pub type anon_1 = u32;
+pub const anon_1_SECOND_A: anon_1 = 0;
+pub const anon_1_SECOND_B: anon_1 = 1;
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct S {
     pub a: i32,
 }
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum TdEnum {
-    #[default]
-    TD_A = 0,
-    TD_B = 1,
-}
-impl From<i32> for TdEnum {
-    fn from(n: i32) -> TdEnum {
-        match n {
-            0 => TdEnum::TD_A,
-            1 => TdEnum::TD_B,
-            _ => panic!("invalid TdEnum value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(TdEnum);
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum anon_2 {
-    #[default]
-    FIELD_A = 0,
-    FIELD_B = 1,
-}
-impl From<i32> for anon_2 {
-    fn from(n: i32) -> anon_2 {
-        match n {
-            0 => anon_2::FIELD_A,
-            1 => anon_2::FIELD_B,
-            _ => panic!("invalid anon_2 value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(anon_2);
+pub type TdEnum = u32;
+pub const TdEnum_TD_A: TdEnum = 0;
+pub const TdEnum_TD_B: TdEnum = 1;
+pub type anon_2 = u32;
+pub const anon_2_FIELD_A: anon_2 = 0;
+pub const anon_2_FIELD_B: anon_2 = 1;
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct WithAnonField {
@@ -87,33 +35,20 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    #[derive(Clone, Copy, PartialEq, Debug, Default)]
-    enum anon_3 {
-        #[default]
-        THIRD_A = 0,
-        THIRD_B = 1,
-    }
-    impl From<i32> for anon_3 {
-        fn from(n: i32) -> anon_3 {
-            match n {
-                0 => anon_3::THIRD_A,
-                1 => anon_3::THIRD_B,
-                _ => panic!("invalid anon_3 value: {}", n),
-            }
-        }
-    }
-    libcc2rs::impl_enum_inc_dec!(anon_3);
-    assert!(((anon_0::FIRST_A as i32) != (anon_0::FIRST_B as i32)));
-    assert!(((anon_1::SECOND_A as i32) != (anon_1::SECOND_B as i32)));
-    assert!(((anon_3::THIRD_A as i32) != (anon_3::THIRD_B as i32)));
-    let mut td: TdEnum = TdEnum::TD_A;
-    assert!(((td as i32) == (TdEnum::TD_A as i32)));
-    td = TdEnum::TD_B;
-    assert!(((td as i32) == (TdEnum::TD_B as i32)));
+    pub type anon_3 = u32;
+    pub const anon_3_THIRD_A: anon_3 = 0;
+    pub const anon_3_THIRD_B: anon_3 = 1;;
+    assert!(((anon_0_FIRST_A as i32) != (anon_0_FIRST_B as i32)));
+    assert!(((anon_1_SECOND_A as i32) != (anon_1_SECOND_B as i32)));
+    assert!(((anon_3_THIRD_A as i32) != (anon_3_THIRD_B as i32)));
+    let mut td: TdEnum = TdEnum_TD_A;
+    assert!(((td as i32) == (TdEnum_TD_A as i32)));
+    td = TdEnum_TD_B;
+    assert!(((td as i32) == (TdEnum_TD_B as i32)));
     let mut w: WithAnonField = <WithAnonField>::default();
-    w.field = anon_2::FIELD_A;
-    assert!(((w.field as i32) == (anon_2::FIELD_A as i32)));
-    w.field = anon_2::FIELD_B;
-    assert!(((w.field as i32) == (anon_2::FIELD_B as i32)));
+    w.field = anon_2_FIELD_A;
+    assert!(((w.field as i32) == (anon_2_FIELD_A as i32)));
+    w.field = anon_2_FIELD_B;
+    assert!(((w.field as i32) == (anon_2_FIELD_B as i32)));
     return 0;
 }

--- a/tests/unit/out/unsafe/anonymous_enum_c.rs
+++ b/tests/unit/out/unsafe/anonymous_enum_c.rs
@@ -6,75 +6,23 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum anon_0 {
-    #[default]
-    FIRST_A = 0,
-    FIRST_B = 1,
-}
-impl From<i32> for anon_0 {
-    fn from(n: i32) -> anon_0 {
-        match n {
-            0 => anon_0::FIRST_A,
-            1 => anon_0::FIRST_B,
-            _ => panic!("invalid anon_0 value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(anon_0);
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum anon_1 {
-    #[default]
-    SECOND_A = 0,
-    SECOND_B = 1,
-}
-impl From<i32> for anon_1 {
-    fn from(n: i32) -> anon_1 {
-        match n {
-            0 => anon_1::SECOND_A,
-            1 => anon_1::SECOND_B,
-            _ => panic!("invalid anon_1 value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(anon_1);
+pub type anon_0 = u32;
+pub const anon_0_FIRST_A: anon_0 = 0;
+pub const anon_0_FIRST_B: anon_0 = 1;
+pub type anon_1 = u32;
+pub const anon_1_SECOND_A: anon_1 = 0;
+pub const anon_1_SECOND_B: anon_1 = 1;
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct S {
     pub a: i32,
 }
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum TdEnum_enum {
-    #[default]
-    TD_A = 0,
-    TD_B = 1,
-}
-impl From<i32> for TdEnum_enum {
-    fn from(n: i32) -> TdEnum_enum {
-        match n {
-            0 => TdEnum_enum::TD_A,
-            1 => TdEnum_enum::TD_B,
-            _ => panic!("invalid TdEnum_enum value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(TdEnum_enum);
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum anon_2 {
-    #[default]
-    FIELD_A = 0,
-    FIELD_B = 1,
-}
-impl From<i32> for anon_2 {
-    fn from(n: i32) -> anon_2 {
-        match n {
-            0 => anon_2::FIELD_A,
-            1 => anon_2::FIELD_B,
-            _ => panic!("invalid anon_2 value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(anon_2);
+pub type TdEnum_enum = u32;
+pub const TdEnum_enum_TD_A: TdEnum_enum = 0;
+pub const TdEnum_enum_TD_B: TdEnum_enum = 1;
+pub type anon_2 = u32;
+pub const anon_2_FIELD_A: anon_2 = 0;
+pub const anon_2_FIELD_B: anon_2 = 1;
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct WithAnonField {
@@ -87,33 +35,20 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    #[derive(Clone, Copy, PartialEq, Debug, Default)]
-    enum anon_3 {
-        #[default]
-        THIRD_A = 0,
-        THIRD_B = 1,
-    }
-    impl From<i32> for anon_3 {
-        fn from(n: i32) -> anon_3 {
-            match n {
-                0 => anon_3::THIRD_A,
-                1 => anon_3::THIRD_B,
-                _ => panic!("invalid anon_3 value: {}", n),
-            }
-        }
-    }
-    libcc2rs::impl_enum_inc_dec!(anon_3);
-    assert!(((((anon_0::FIRST_A as i32) != (anon_0::FIRST_B as i32)) as i32) != 0));
-    assert!(((((anon_1::SECOND_A as i32) != (anon_1::SECOND_B as i32)) as i32) != 0));
-    assert!(((((anon_3::THIRD_A as i32) != (anon_3::THIRD_B as i32)) as i32) != 0));
-    let mut td: TdEnum_enum = TdEnum_enum::TD_A;
-    assert!(((((td as u32) == ((TdEnum_enum::TD_A as i32) as u32)) as i32) != 0));
-    td = TdEnum_enum::TD_B;
-    assert!(((((td as u32) == ((TdEnum_enum::TD_B as i32) as u32)) as i32) != 0));
+    pub type anon_3 = u32;
+    pub const anon_3_THIRD_A: anon_3 = 0;
+    pub const anon_3_THIRD_B: anon_3 = 1;;
+    assert!(((((anon_0_FIRST_A as i32) != (anon_0_FIRST_B as i32)) as i32) != 0));
+    assert!(((((anon_1_SECOND_A as i32) != (anon_1_SECOND_B as i32)) as i32) != 0));
+    assert!(((((anon_3_THIRD_A as i32) != (anon_3_THIRD_B as i32)) as i32) != 0));
+    let mut td: TdEnum_enum = TdEnum_enum_TD_A;
+    assert!(((((td as u32) == ((TdEnum_enum_TD_A as i32) as u32)) as i32) != 0));
+    td = TdEnum_enum_TD_B;
+    assert!(((((td as u32) == ((TdEnum_enum_TD_B as i32) as u32)) as i32) != 0));
     let mut w: WithAnonField = <WithAnonField>::default();
-    w.field = anon_2::FIELD_A;
-    assert!(((((w.field as u32) == ((anon_2::FIELD_A as i32) as u32)) as i32) != 0));
-    w.field = anon_2::FIELD_B;
-    assert!(((((w.field as u32) == ((anon_2::FIELD_B as i32) as u32)) as i32) != 0));
+    w.field = anon_2_FIELD_A;
+    assert!(((((w.field as u32) == ((anon_2_FIELD_A as i32) as u32)) as i32) != 0));
+    w.field = anon_2_FIELD_B;
+    assert!(((((w.field as u32) == ((anon_2_FIELD_B as i32) as u32)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/bool_condition_enum.rs
+++ b/tests/unit/out/unsafe/bool_condition_enum.rs
@@ -6,47 +6,33 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Code {
-    #[default]
-    CODE_OK = 0,
-    CODE_ERR = 1,
-    CODE_FATAL = 2,
-}
-impl From<i32> for Code {
-    fn from(n: i32) -> Code {
-        match n {
-            0 => Code::CODE_OK,
-            1 => Code::CODE_ERR,
-            2 => Code::CODE_FATAL,
-            _ => panic!("invalid Code value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Code);
+pub type Code = u32;
+pub const Code_CODE_OK: Code = 0;
+pub const Code_CODE_ERR: Code = 1;
+pub const Code_CODE_FATAL: Code = 2;
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut code: Code = Code::CODE_OK;
-    let mut err: Code = Code::CODE_ERR;
-    if (code != Code::from(0)) {
+    let mut code: Code = Code_CODE_OK;
+    let mut err: Code = Code_CODE_ERR;
+    if (code != 0) {
         assert!(false);
     }
-    if !(code != Code::from(0)) {
+    if !(code != 0) {
         assert!(true);
     }
-    if (err != Code::from(0)) {
+    if (err != 0) {
         assert!(true);
     }
-    if !(err != Code::from(0)) {
+    if !(err != 0) {
         assert!(false);
     }
-    let mut t9: i32 = (!(code != Code::from(0)) as i32);
+    let mut t9: i32 = (!(code != 0) as i32);
     assert!(((t9) == (1)));
-    let mut b4: bool = (code != Code::from(0));
+    let mut b4: bool = (code != 0);
     assert!(!b4);
     return 0;
 }

--- a/tests/unit/out/unsafe/bool_condition_enum_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_enum_c.rs
@@ -6,47 +6,33 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Code {
-    #[default]
-    CODE_OK = 0,
-    CODE_ERR = 1,
-    CODE_FATAL = 2,
-}
-impl From<i32> for Code {
-    fn from(n: i32) -> Code {
-        match n {
-            0 => Code::CODE_OK,
-            1 => Code::CODE_ERR,
-            2 => Code::CODE_FATAL,
-            _ => panic!("invalid Code value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Code);
+pub type Code = u32;
+pub const Code_CODE_OK: Code = 0;
+pub const Code_CODE_ERR: Code = 1;
+pub const Code_CODE_FATAL: Code = 2;
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut code: Code = Code::CODE_OK;
-    let mut err: Code = Code::CODE_ERR;
-    if (code != Code::from(0)) {
+    let mut code: Code = Code_CODE_OK;
+    let mut err: Code = Code_CODE_ERR;
+    if (code != 0) {
         assert!((0 != 0));
     }
-    if !(code != Code::from(0)) {
+    if !(code != 0) {
         assert!((1 != 0));
     }
-    if (err != Code::from(0)) {
+    if (err != 0) {
         assert!((1 != 0));
     }
-    if !(err != Code::from(0)) {
+    if !(err != 0) {
         assert!((0 != 0));
     }
-    let mut t9: i32 = (!(code != Code::from(0)) as i32);
+    let mut t9: i32 = (!(code != 0) as i32);
     assert!(((((t9) == (1)) as i32) != 0));
-    let mut b4: bool = (code != Code::from(0));
+    let mut b4: bool = (code != 0);
     assert!(((!b4 as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/bool_condition_logical.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical.rs
@@ -6,24 +6,10 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Code {
-    #[default]
-    CODE_OK = 0,
-    CODE_ERR = 1,
-    CODE_FATAL = 2,
-}
-impl From<i32> for Code {
-    fn from(n: i32) -> Code {
-        match n {
-            0 => Code::CODE_OK,
-            1 => Code::CODE_ERR,
-            2 => Code::CODE_FATAL,
-            _ => panic!("invalid Code value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Code);
+pub type Code = u32;
+pub const Code_CODE_OK: Code = 0;
+pub const Code_CODE_ERR: Code = 1;
+pub const Code_CODE_FATAL: Code = 2;
 pub static mut side_effect_0: i32 = unsafe { 0 };
 pub unsafe fn observe_1(mut v: i32) -> i32 {
     side_effect_0.prefix_inc();
@@ -47,7 +33,7 @@ unsafe fn main_0() -> i32 {
     let mut p: *mut i32 = (&mut storage as *mut i32);
     let mut np: *mut i32 = std::ptr::null_mut();
     let mut u: u32 = 4_u32;
-    let mut code: Code = Code::CODE_OK;
+    let mut code: Code = Code_CODE_OK;
     if (n != 0) && (!(p).is_null()) {
         assert!(true);
     }
@@ -60,7 +46,7 @@ unsafe fn main_0() -> i32 {
     if (zero != 0) || (!(np).is_null()) {
         assert!(false);
     }
-    if (((n != 0) && (u != 0)) && (!(p).is_null())) && ((code as i32) == (Code::CODE_OK as i32)) {
+    if (((n != 0) && (u != 0)) && (!(p).is_null())) && ((code as i32) == (Code_CODE_OK as i32)) {
         assert!(true);
     }
     side_effect_0 = 0;

--- a/tests/unit/out/unsafe/bool_condition_logical_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical_c.rs
@@ -6,24 +6,10 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Code {
-    #[default]
-    CODE_OK = 0,
-    CODE_ERR = 1,
-    CODE_FATAL = 2,
-}
-impl From<i32> for Code {
-    fn from(n: i32) -> Code {
-        match n {
-            0 => Code::CODE_OK,
-            1 => Code::CODE_ERR,
-            2 => Code::CODE_FATAL,
-            _ => panic!("invalid Code value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Code);
+pub type Code = u32;
+pub const Code_CODE_OK: Code = 0;
+pub const Code_CODE_ERR: Code = 1;
+pub const Code_CODE_FATAL: Code = 2;
 pub static mut side_effect_0: i32 = unsafe { 0 };
 pub unsafe fn observe_1(mut v: i32) -> i32 {
     side_effect_0.prefix_inc();
@@ -47,7 +33,7 @@ unsafe fn main_0() -> i32 {
     let mut p: *mut i32 = (&mut storage as *mut i32);
     let mut np: *mut i32 = std::ptr::null_mut();
     let mut u: u32 = 4_u32;
-    let mut code: Code = Code::CODE_OK;
+    let mut code: Code = Code_CODE_OK;
     if ((((n != 0) && (!(p).is_null())) as i32) != 0) {
         assert!((1 != 0));
     }
@@ -61,7 +47,7 @@ unsafe fn main_0() -> i32 {
         assert!((0 != 0));
     }
     if ((((((((((n != 0) && (u != 0)) as i32) != 0) && (!(p).is_null())) as i32) != 0)
-        && ((((code as u32) == ((Code::CODE_OK as i32) as u32)) as i32) != 0)) as i32)
+        && ((((code as u32) == ((Code_CODE_OK as i32) as u32)) as i32) != 0)) as i32)
         != 0)
     {
         assert!((1 != 0));

--- a/tests/unit/out/unsafe/c_struct.rs
+++ b/tests/unit/out/unsafe/c_struct.rs
@@ -24,24 +24,10 @@ pub struct Node {
     pub value: i32,
     pub next: *mut Node,
 }
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Color {
-    #[default]
-    RED = 0,
-    GREEN = 1,
-    BLUE = 2,
-}
-impl From<i32> for Color {
-    fn from(n: i32) -> Color {
-        match n {
-            0 => Color::RED,
-            1 => Color::GREEN,
-            2 => Color::BLUE,
-            _ => panic!("invalid Color value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Color);
+pub type Color = u32;
+pub const Color_RED: Color = 0;
+pub const Color_GREEN: Color = 1;
+pub const Color_BLUE: Color = 2;
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Inner {
@@ -86,15 +72,15 @@ unsafe fn main_0() -> i32 {
     assert!((((((*b.next).value) == (1)) as i32) != 0));
     let mut c: Container = Container {
         inner: Inner { a: 5, b: 6 },
-        color: Color::GREEN,
+        color: Color_GREEN,
         count: 42,
     };
     assert!(((((c.inner.a) == (5)) as i32) != 0));
     assert!(((((c.inner.b) == (6)) as i32) != 0));
-    assert!(((((c.color as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0));
+    assert!(((((c.color as u32) == ((Color_GREEN as i32) as u32)) as i32) != 0));
     assert!(((((c.count) == (42)) as i32) != 0));
     let mut c2: Container = <Container>::default();
-    c2.color = Color::BLUE;
+    c2.color = Color_BLUE;
     assert!(((((c2.color as u32) == (2_u32)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/enum_comparisson_in_globals.rs
+++ b/tests/unit/out/unsafe/enum_comparisson_in_globals.rs
@@ -6,21 +6,16 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-pub type Color = u32;
-pub const Color_RED: Color = 0;
-pub const Color_GREEN: Color = 1;
-pub const Color_BLUE: Color = 2;
+pub type E = u32;
+pub const E_A: E = 0;
+pub const E_B: E = 1;
+pub static mut global_0: i32 = unsafe { (((E_A as i32) != (E_B as i32)) as i32) };
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut n: i32 = 3;
-    let mut c: Color = ((n) as Color);
-    return if ((c as i32) == (Color_BLUE as i32)) {
-        0
-    } else {
-        1
-    };
+    assert!(((global_0) == (1)));
+    return 0;
 }

--- a/tests/unit/out/unsafe/enum_default_in_static.rs
+++ b/tests/unit/out/unsafe/enum_default_in_static.rs
@@ -6,24 +6,10 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Mode {
-    #[default]
-    MODE_NONE = 0,
-    MODE_ONE = 1,
-    MODE_TWO = 2,
-}
-impl From<i32> for Mode {
-    fn from(n: i32) -> Mode {
-        match n {
-            0 => Mode::MODE_NONE,
-            1 => Mode::MODE_ONE,
-            2 => Mode::MODE_TWO,
-            _ => panic!("invalid Mode value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Mode);
+pub type Mode = u32;
+pub const Mode_MODE_NONE: Mode = 0;
+pub const Mode_MODE_ONE: Mode = 1;
+pub const Mode_MODE_TWO: Mode = 2;
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Config {
@@ -33,7 +19,7 @@ pub struct Config {
 pub static mut config_0: Config = unsafe {
     Config {
         count: 0_i32,
-        mode: Mode::MODE_NONE,
+        mode: Mode_MODE_NONE,
     }
 };
 pub fn main() {
@@ -43,6 +29,6 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     assert!(((((config_0.count) == (0)) as i32) != 0));
-    assert!(((((config_0.mode as u32) == ((Mode::MODE_NONE as i32) as u32)) as i32) != 0));
+    assert!(((((config_0.mode as u32) == ((Mode_MODE_NONE as i32) as u32)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/enum_increment.rs
+++ b/tests/unit/out/unsafe/enum_increment.rs
@@ -6,26 +6,11 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum color {
-    #[default]
-    RED = 0,
-    GREEN = 1,
-    BLUE = 2,
-    COLOR_LAST = 3,
-}
-impl From<i32> for color {
-    fn from(n: i32) -> color {
-        match n {
-            0 => color::RED,
-            1 => color::GREEN,
-            2 => color::BLUE,
-            3 => color::COLOR_LAST,
-            _ => panic!("invalid color value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(color);
+pub type color = u32;
+pub const color_RED: color = 0;
+pub const color_GREEN: color = 1;
+pub const color_BLUE: color = 2;
+pub const color_COLOR_LAST: color = 3;
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
@@ -33,16 +18,16 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut count: i32 = 0;
-    let mut c: color = color::RED;
-    'loop_: while ((((c as u32) < ((color::COLOR_LAST as i32) as u32)) as i32) != 0) {
+    let mut c: color = color_RED;
+    'loop_: while ((((c as u32) < ((color_COLOR_LAST as i32) as u32)) as i32) != 0) {
         count.postfix_inc();
         c.postfix_inc();
     }
     assert!(((((count) == (3)) as i32) != 0));
-    let mut c: color = color::RED;
-    assert!(((((c.postfix_inc() as u32) == ((color::RED as i32) as u32)) as i32) != 0));
-    assert!(((((c.prefix_inc() as u32) == ((color::BLUE as i32) as u32)) as i32) != 0));
-    assert!(((((c.postfix_dec() as u32) == ((color::BLUE as i32) as u32)) as i32) != 0));
-    assert!(((((c.prefix_dec() as u32) == ((color::RED as i32) as u32)) as i32) != 0));
+    let mut c: color = color_RED;
+    assert!(((((c.postfix_inc() as u32) == ((color_RED as i32) as u32)) as i32) != 0));
+    assert!(((((c.prefix_inc() as u32) == ((color_BLUE as i32) as u32)) as i32) != 0));
+    assert!(((((c.postfix_dec() as u32) == ((color_BLUE as i32) as u32)) as i32) != 0));
+    assert!(((((c.prefix_dec() as u32) == ((color_RED as i32) as u32)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/enum_int_interop.rs
+++ b/tests/unit/out/unsafe/enum_int_interop.rs
@@ -6,62 +6,19 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Color {
-    #[default]
-    RED = 0,
-    GREEN = 1,
-    BLUE = 2,
-}
-impl From<i32> for Color {
-    fn from(n: i32) -> Color {
-        match n {
-            0 => Color::RED,
-            1 => Color::GREEN,
-            2 => Color::BLUE,
-            _ => panic!("invalid Color value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Color);
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Option {
-    #[default]
-    OPT_NONE = 0,
-    OPT_A = 10,
-    OPT_B = 20,
-    OPT_C = 30,
-}
-impl From<i32> for Option {
-    fn from(n: i32) -> Option {
-        match n {
-            0 => Option::OPT_NONE,
-            10 => Option::OPT_A,
-            20 => Option::OPT_B,
-            30 => Option::OPT_C,
-            _ => panic!("invalid Option value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Option);
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Tag {
-    #[default]
-    TAG_ZERO = 0,
-    TAG_ONE = 1,
-    TAG_TWO = 2,
-}
-impl From<i32> for Tag {
-    fn from(n: i32) -> Tag {
-        match n {
-            0 => Tag::TAG_ZERO,
-            1 => Tag::TAG_ONE,
-            2 => Tag::TAG_TWO,
-            _ => panic!("invalid Tag value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Tag);
+pub type Color = u32;
+pub const Color_RED: Color = 0;
+pub const Color_GREEN: Color = 1;
+pub const Color_BLUE: Color = 2;
+pub type Option = u32;
+pub const Option_OPT_NONE: Option = 0;
+pub const Option_OPT_A: Option = 10;
+pub const Option_OPT_B: Option = 20;
+pub const Option_OPT_C: Option = 30;
+pub type Tag = u32;
+pub const Tag_TAG_ZERO: Tag = 0;
+pub const Tag_TAG_ONE: Tag = 1;
+pub const Tag_TAG_TWO: Tag = 2;
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Entry {
@@ -69,25 +26,25 @@ pub struct Entry {
     pub color: Color,
     pub opt: Option,
 }
-pub static mut global_color_0: Color = unsafe { Color::GREEN };
-pub static mut global_opt_1: Option = unsafe { Option::OPT_B };
-pub static mut global_tag_2: Tag = unsafe { Tag::TAG_TWO };
+pub static mut global_color_0: Color = unsafe { Color_GREEN };
+pub static mut global_opt_1: Option = unsafe { Option_OPT_B };
+pub static mut global_tag_2: Tag = unsafe { Tag_TAG_TWO };
 pub static mut entries_3: [Entry; 3] = unsafe {
     [
         Entry {
             name: c"first".as_ptr(),
-            color: Color::RED,
-            opt: Option::OPT_NONE,
+            color: Color_RED,
+            opt: Option_OPT_NONE,
         },
         Entry {
             name: c"second".as_ptr(),
-            color: Color::GREEN,
-            opt: Option::OPT_A,
+            color: Color_GREEN,
+            opt: Option_OPT_A,
         },
         Entry {
             name: c"third".as_ptr(),
-            color: Color::BLUE,
-            opt: Option::OPT_C,
+            color: Color_BLUE,
+            opt: Option_OPT_C,
         },
     ]
 };
@@ -98,16 +55,16 @@ pub unsafe fn classify_option_5(mut option: i32) -> i32 {
     'switch: {
         let __match_cond = option;
         match __match_cond {
-            __v if __v == (Option::OPT_NONE as i32) => {
+            __v if __v == (Option_OPT_NONE as i32) => {
                 return -1_i32;
             }
-            __v if __v == (Option::OPT_A as i32) => {
+            __v if __v == (Option_OPT_A as i32) => {
                 return 1;
             }
-            __v if __v == (Option::OPT_B as i32) => {
+            __v if __v == (Option_OPT_B as i32) => {
                 return 2;
             }
-            __v if __v == (Option::OPT_C as i32) => {
+            __v if __v == (Option_OPT_C as i32) => {
                 return 3;
             }
             _ => {
@@ -118,7 +75,7 @@ pub unsafe fn classify_option_5(mut option: i32) -> i32 {
     panic!("ub: non-void function does not return a value")
 }
 pub unsafe fn make_color_6(mut n: i32) -> Color {
-    return Color::from(n);
+    return ((n) as Color);
 }
 pub fn main() {
     unsafe {
@@ -126,11 +83,11 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut c: Color = Color::RED;
-    assert!(((c as i32) == (Color::RED as i32)));
+    let mut c: Color = Color_RED;
+    assert!(((c as i32) == (Color_RED as i32)));
     assert!(((c as i32) == (0)));
     assert!(((c as i32) != (1)));
-    if ((c as i32) == (Color::GREEN as i32)) {
+    if ((c as i32) == (Color_GREEN as i32)) {
         return 1;
     }
     'switch: {
@@ -154,37 +111,37 @@ unsafe fn main_0() -> i32 {
     assert!(((x) == (0)));
     let mut y: i32 = ((c as i32) + (1));
     assert!(((y) == (1)));
-    c = Color::from(2);
-    assert!(((c as i32) == (Color::BLUE as i32)));
+    c = ((2) as Color);
+    assert!(((c as i32) == (Color_BLUE as i32)));
     assert!(((c as i32) == (2)));
     c = (unsafe { make_color_6(1) });
-    assert!(((c as i32) == (Color::GREEN as i32)));
-    let mut cmp: Color = Color::from(((c as i32) + (1)));
-    assert!(((cmp as i32) == (Color::BLUE as i32)));
-    let mut o: Option = Option::OPT_A;
-    assert!(((o as i32) == (Option::OPT_A as i32)));
+    assert!(((c as i32) == (Color_GREEN as i32)));
+    let mut cmp: Color = (((c as i32) + (1)) as Color);
+    assert!(((cmp as i32) == (Color_BLUE as i32)));
+    let mut o: Option = Option_OPT_A;
+    assert!(((o as i32) == (Option_OPT_A as i32)));
     assert!(((o as i32) == (10)));
     let mut oi: i32 = (o as i32);
     assert!(((oi) == (10)));
-    o = Option::from(20);
-    assert!(((o as i32) == (Option::OPT_B as i32)));
+    o = ((20) as Option);
+    assert!(((o as i32) == (Option_OPT_B as i32)));
     let mut rc: i32 = (unsafe { classify_option_5((o as i32)) });
     assert!(((rc) == (2)));
     rc = (unsafe { classify_option_5(20) });
     assert!(((rc) == (2)));
-    rc = (unsafe { classify_option_5((Option::OPT_C as i32)) });
+    rc = (unsafe { classify_option_5((Option_OPT_C as i32)) });
     assert!(((rc) == (3)));
-    let mut t: Tag = Tag::TAG_ONE;
+    let mut t: Tag = Tag_TAG_ONE;
     assert!(((t as i32) == (1)));
-    assert!(((t as i32) == (Tag::TAG_ONE as i32)));
+    assert!(((t as i32) == (Tag_TAG_ONE as i32)));
     let mut ti: i32 = (t as i32);
     assert!(((ti) == (1)));
-    t = Tag::from(2);
-    assert!(((t as i32) == (Tag::TAG_TWO as i32)));
+    t = ((2) as Tag);
+    assert!(((t as i32) == (Tag_TAG_TWO as i32)));
     'switch: {
         let __match_cond = (t as i32);
         match __match_cond {
-            __v if __v == (Tag::TAG_ZERO as i32) => {
+            __v if __v == (Tag_TAG_ZERO as i32) => {
                 return 90;
             }
             __v if __v == 1 => {
@@ -196,16 +153,16 @@ unsafe fn main_0() -> i32 {
             _ => {}
         }
     };
-    let mut extra: i32 = (((Color::RED as i32) + (Color::GREEN as i32)) + (Color::BLUE as i32));
+    let mut extra: i32 = (((Color_RED as i32) + (Color_GREEN as i32)) + (Color_BLUE as i32));
     assert!(((extra) == (((0) + (1)) + (2))));
-    assert!(((global_color_0 as i32) == (Color::GREEN as i32)));
-    assert!(((global_opt_1 as i32) == (Option::OPT_B as i32)));
-    assert!(((global_tag_2 as i32) == (Tag::TAG_TWO as i32)));
-    assert!(((entries_3[(0) as usize].color as i32) == (Color::RED as i32)));
-    assert!(((entries_3[(0) as usize].opt as i32) == (Option::OPT_NONE as i32)));
-    assert!(((entries_3[(1) as usize].color as i32) == (Color::GREEN as i32)));
-    assert!(((entries_3[(1) as usize].opt as i32) == (Option::OPT_A as i32)));
-    assert!(((entries_3[(2) as usize].color as i32) == (Color::BLUE as i32)));
-    assert!(((entries_3[(2) as usize].opt as i32) == (Option::OPT_C as i32)));
+    assert!(((global_color_0 as i32) == (Color_GREEN as i32)));
+    assert!(((global_opt_1 as i32) == (Option_OPT_B as i32)));
+    assert!(((global_tag_2 as i32) == (Tag_TAG_TWO as i32)));
+    assert!(((entries_3[(0) as usize].color as i32) == (Color_RED as i32)));
+    assert!(((entries_3[(0) as usize].opt as i32) == (Option_OPT_NONE as i32)));
+    assert!(((entries_3[(1) as usize].color as i32) == (Color_GREEN as i32)));
+    assert!(((entries_3[(1) as usize].opt as i32) == (Option_OPT_A as i32)));
+    assert!(((entries_3[(2) as usize].color as i32) == (Color_BLUE as i32)));
+    assert!(((entries_3[(2) as usize].opt as i32) == (Option_OPT_C as i32)));
     return 0;
 }

--- a/tests/unit/out/unsafe/enum_int_interop_c.rs
+++ b/tests/unit/out/unsafe/enum_int_interop_c.rs
@@ -6,62 +6,19 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Color {
-    #[default]
-    RED = 0,
-    GREEN = 1,
-    BLUE = 2,
-}
-impl From<i32> for Color {
-    fn from(n: i32) -> Color {
-        match n {
-            0 => Color::RED,
-            1 => Color::GREEN,
-            2 => Color::BLUE,
-            _ => panic!("invalid Color value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Color);
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Option {
-    #[default]
-    OPT_NONE = 0,
-    OPT_A = 10,
-    OPT_B = 20,
-    OPT_C = 30,
-}
-impl From<i32> for Option {
-    fn from(n: i32) -> Option {
-        match n {
-            0 => Option::OPT_NONE,
-            10 => Option::OPT_A,
-            20 => Option::OPT_B,
-            30 => Option::OPT_C,
-            _ => panic!("invalid Option value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Option);
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Tag_enum {
-    #[default]
-    TAG_ZERO = 0,
-    TAG_ONE = 1,
-    TAG_TWO = 2,
-}
-impl From<i32> for Tag_enum {
-    fn from(n: i32) -> Tag_enum {
-        match n {
-            0 => Tag_enum::TAG_ZERO,
-            1 => Tag_enum::TAG_ONE,
-            2 => Tag_enum::TAG_TWO,
-            _ => panic!("invalid Tag_enum value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Tag_enum);
+pub type Color = u32;
+pub const Color_RED: Color = 0;
+pub const Color_GREEN: Color = 1;
+pub const Color_BLUE: Color = 2;
+pub type Option = u32;
+pub const Option_OPT_NONE: Option = 0;
+pub const Option_OPT_A: Option = 10;
+pub const Option_OPT_B: Option = 20;
+pub const Option_OPT_C: Option = 30;
+pub type Tag_enum = u32;
+pub const Tag_enum_TAG_ZERO: Tag_enum = 0;
+pub const Tag_enum_TAG_ONE: Tag_enum = 1;
+pub const Tag_enum_TAG_TWO: Tag_enum = 2;
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Entry {
@@ -69,25 +26,25 @@ pub struct Entry {
     pub color: Color,
     pub opt: Option,
 }
-pub static mut global_color_0: Color = unsafe { Color::GREEN };
-pub static mut global_opt_1: Option = unsafe { Option::OPT_B };
-pub static mut global_tag_2: Tag_enum = unsafe { Tag_enum::TAG_TWO };
+pub static mut global_color_0: Color = unsafe { Color_GREEN };
+pub static mut global_opt_1: Option = unsafe { Option_OPT_B };
+pub static mut global_tag_2: Tag_enum = unsafe { Tag_enum_TAG_TWO };
 pub static mut entries_3: [Entry; 3] = unsafe {
     [
         Entry {
             name: (c"first".as_ptr().cast_mut()).cast_const(),
-            color: Color::RED,
-            opt: Option::OPT_NONE,
+            color: Color_RED,
+            opt: Option_OPT_NONE,
         },
         Entry {
             name: (c"second".as_ptr().cast_mut()).cast_const(),
-            color: Color::GREEN,
-            opt: Option::OPT_A,
+            color: Color_GREEN,
+            opt: Option_OPT_A,
         },
         Entry {
             name: (c"third".as_ptr().cast_mut()).cast_const(),
-            color: Color::BLUE,
-            opt: Option::OPT_C,
+            color: Color_BLUE,
+            opt: Option_OPT_C,
         },
     ]
 };
@@ -98,16 +55,16 @@ pub unsafe fn classify_option_5(mut option: i32) -> i32 {
     'switch: {
         let __match_cond = option;
         match __match_cond {
-            __v if __v == (Option::OPT_NONE as i32) => {
+            __v if __v == (Option_OPT_NONE as i32) => {
                 return -1_i32;
             }
-            __v if __v == (Option::OPT_A as i32) => {
+            __v if __v == (Option_OPT_A as i32) => {
                 return 1;
             }
-            __v if __v == (Option::OPT_B as i32) => {
+            __v if __v == (Option_OPT_B as i32) => {
                 return 2;
             }
-            __v if __v == (Option::OPT_C as i32) => {
+            __v if __v == (Option_OPT_C as i32) => {
                 return 3;
             }
             _ => {
@@ -118,7 +75,7 @@ pub unsafe fn classify_option_5(mut option: i32) -> i32 {
     panic!("ub: non-void function does not return a value")
 }
 pub unsafe fn make_color_6(mut n: i32) -> Color {
-    return Color::from(n);
+    return ((n) as Color);
 }
 pub fn main() {
     unsafe {
@@ -126,11 +83,11 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut c: Color = Color::RED;
-    assert!(((((c as u32) == ((Color::RED as i32) as u32)) as i32) != 0));
+    let mut c: Color = Color_RED;
+    assert!(((((c as u32) == ((Color_RED as i32) as u32)) as i32) != 0));
     assert!(((((c as u32) == (0_u32)) as i32) != 0));
     assert!(((((c as u32) != (1_u32)) as i32) != 0));
-    if ((((c as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0) {
+    if ((((c as u32) == ((Color_GREEN as i32) as u32)) as i32) != 0) {
         return 1;
     }
     'switch: {
@@ -154,37 +111,37 @@ unsafe fn main_0() -> i32 {
     assert!(((((x) == (0)) as i32) != 0));
     let mut y: i32 = (((c as u32).wrapping_add(1_u32)) as i32);
     assert!(((((y) == (1)) as i32) != 0));
-    c = Color::from(2);
-    assert!(((((c as u32) == ((Color::BLUE as i32) as u32)) as i32) != 0));
+    c = ((2) as Color);
+    assert!(((((c as u32) == ((Color_BLUE as i32) as u32)) as i32) != 0));
     assert!(((((c as u32) == (2_u32)) as i32) != 0));
     c = (unsafe { make_color_6(1) });
-    assert!(((((c as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0));
-    let mut cmp: Color = Color::from(((c as u32).wrapping_add(1_u32)) as i32);
-    assert!(((((cmp as u32) == ((Color::BLUE as i32) as u32)) as i32) != 0));
-    let mut o: Option = Option::OPT_A;
-    assert!(((((o as u32) == ((Option::OPT_A as i32) as u32)) as i32) != 0));
+    assert!(((((c as u32) == ((Color_GREEN as i32) as u32)) as i32) != 0));
+    let mut cmp: Color = (((c as u32).wrapping_add(1_u32)) as Color);
+    assert!(((((cmp as u32) == ((Color_BLUE as i32) as u32)) as i32) != 0));
+    let mut o: Option = Option_OPT_A;
+    assert!(((((o as u32) == ((Option_OPT_A as i32) as u32)) as i32) != 0));
     assert!(((((o as u32) == (10_u32)) as i32) != 0));
     let mut oi: i32 = (o as i32);
     assert!(((((oi) == (10)) as i32) != 0));
-    o = Option::from(20);
-    assert!(((((o as u32) == ((Option::OPT_B as i32) as u32)) as i32) != 0));
+    o = ((20) as Option);
+    assert!(((((o as u32) == ((Option_OPT_B as i32) as u32)) as i32) != 0));
     let mut rc: i32 = (unsafe { classify_option_5((o as i32)) });
     assert!(((((rc) == (2)) as i32) != 0));
     rc = (unsafe { classify_option_5(20) });
     assert!(((((rc) == (2)) as i32) != 0));
-    rc = (unsafe { classify_option_5((Option::OPT_C as i32)) });
+    rc = (unsafe { classify_option_5((Option_OPT_C as i32)) });
     assert!(((((rc) == (3)) as i32) != 0));
-    let mut t: Tag_enum = Tag_enum::TAG_ONE;
+    let mut t: Tag_enum = Tag_enum_TAG_ONE;
     assert!(((((t as u32) == (1_u32)) as i32) != 0));
-    assert!(((((t as u32) == ((Tag_enum::TAG_ONE as i32) as u32)) as i32) != 0));
+    assert!(((((t as u32) == ((Tag_enum_TAG_ONE as i32) as u32)) as i32) != 0));
     let mut ti: i32 = (t as i32);
     assert!(((((ti) == (1)) as i32) != 0));
-    t = Tag_enum::from(2);
-    assert!(((((t as u32) == ((Tag_enum::TAG_TWO as i32) as u32)) as i32) != 0));
+    t = ((2) as Tag_enum);
+    assert!(((((t as u32) == ((Tag_enum_TAG_TWO as i32) as u32)) as i32) != 0));
     'switch: {
         let __match_cond = (t as u32);
         match __match_cond {
-            __v if __v == ((Tag_enum::TAG_ZERO as i32) as u32) => {
+            __v if __v == ((Tag_enum_TAG_ZERO as i32) as u32) => {
                 return 90;
             }
             __v if __v == (1 as u32) => {
@@ -196,41 +153,40 @@ unsafe fn main_0() -> i32 {
             _ => {}
         }
     };
-    let mut extra: i32 = (((Color::RED as i32) + (Color::GREEN as i32)) + (Color::BLUE as i32));
+    let mut extra: i32 = (((Color_RED as i32) + (Color_GREEN as i32)) + (Color_BLUE as i32));
     assert!(((((extra) == (((0) + (1)) + (2))) as i32) != 0));
-    assert!(((((global_color_0 as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0));
-    assert!(((((global_opt_1 as u32) == ((Option::OPT_B as i32) as u32)) as i32) != 0));
-    assert!(((((global_tag_2 as u32) == ((Tag_enum::TAG_TWO as i32) as u32)) as i32) != 0));
+    assert!(((((global_color_0 as u32) == ((Color_GREEN as i32) as u32)) as i32) != 0));
+    assert!(((((global_opt_1 as u32) == ((Option_OPT_B as i32) as u32)) as i32) != 0));
+    assert!(((((global_tag_2 as u32) == ((Tag_enum_TAG_TWO as i32) as u32)) as i32) != 0));
     assert!(
-        ((((entries_3[(0) as usize].color as u32) == ((Color::RED as i32) as u32)) as i32) != 0)
+        ((((entries_3[(0) as usize].color as u32) == ((Color_RED as i32) as u32)) as i32) != 0)
     );
     assert!(
-        ((((entries_3[(0) as usize].opt as u32) == ((Option::OPT_NONE as i32) as u32)) as i32)
-            != 0)
+        ((((entries_3[(0) as usize].opt as u32) == ((Option_OPT_NONE as i32) as u32)) as i32) != 0)
     );
     assert!(
-        ((((entries_3[(1) as usize].color as u32) == ((Color::GREEN as i32) as u32)) as i32) != 0)
+        ((((entries_3[(1) as usize].color as u32) == ((Color_GREEN as i32) as u32)) as i32) != 0)
     );
     assert!(
-        ((((entries_3[(1) as usize].opt as u32) == ((Option::OPT_A as i32) as u32)) as i32) != 0)
+        ((((entries_3[(1) as usize].opt as u32) == ((Option_OPT_A as i32) as u32)) as i32) != 0)
     );
     assert!(
-        ((((entries_3[(2) as usize].color as u32) == ((Color::BLUE as i32) as u32)) as i32) != 0)
+        ((((entries_3[(2) as usize].color as u32) == ((Color_BLUE as i32) as u32)) as i32) != 0)
     );
     assert!(
-        ((((entries_3[(2) as usize].opt as u32) == ((Option::OPT_C as i32) as u32)) as i32) != 0)
+        ((((entries_3[(2) as usize].opt as u32) == ((Option_OPT_C as i32) as u32)) as i32) != 0)
     );
     let mut names: [*const libc::c_char; 3] = [
         (c"red".as_ptr().cast_mut()).cast_const(),
         (c"green".as_ptr().cast_mut()).cast_const(),
         (c"blue".as_ptr().cast_mut()).cast_const(),
     ];
-    let mut idx: Color = Color::GREEN;
+    let mut idx: Color = Color_GREEN;
     assert!(
         (((((*names[(idx) as usize].offset((0) as isize)) as i32) == ('g' as i32)) as i32) != 0)
     );
     assert!(
-        ((((entries_3[(idx) as usize].opt as u32) == ((Option::OPT_A as i32) as u32)) as i32) != 0)
+        ((((entries_3[(idx) as usize].opt as u32) == ((Option_OPT_A as i32) as u32)) as i32) != 0)
     );
     assert!(
         (((((*names[(global_tag_2) as usize].offset((0) as isize)) as i32) == ('b' as i32))
@@ -240,6 +196,6 @@ unsafe fn main_0() -> i32 {
     let mut pp: *mut *const libc::c_char = (&mut names[(idx) as usize] as *mut *const libc::c_char);
     assert!((((((*(*pp).offset((0) as isize)) as i32) == ('g' as i32)) as i32) != 0));
     let mut pe: *mut Entry = (&mut entries_3[(idx) as usize] as *mut Entry);
-    assert!((((((*pe).opt as u32) == ((Option::OPT_A as i32) as u32)) as i32) != 0));
+    assert!((((((*pe).opt as u32) == ((Option_OPT_A as i32) as u32)) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/enum_with_duplicated_values.rs
+++ b/tests/unit/out/unsafe/enum_with_duplicated_values.rs
@@ -6,21 +6,20 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-pub type Color = u32;
-pub const Color_RED: Color = 0;
-pub const Color_GREEN: Color = 1;
-pub const Color_BLUE: Color = 2;
+pub type E = u32;
+pub const E_A: E = 2;
+pub const E_B: E = 4;
+pub const E_C: E = 2;
+pub const E_D: E = 4;
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut n: i32 = 3;
-    let mut c: Color = ((n) as Color);
-    return if ((c as i32) == (Color_BLUE as i32)) {
-        0
-    } else {
-        1
-    };
+    assert!(((E_A as i32) == ((1) << (1))));
+    assert!(((E_B as i32) == ((1) << (2))));
+    assert!(((E_C as i32) == ((1) << (1))));
+    assert!(((E_D as i32) == ((1) << (2))));
+    return 0;
 }

--- a/tests/unit/out/unsafe/switch_char.rs
+++ b/tests/unit/out/unsafe/switch_char.rs
@@ -29,24 +29,10 @@ pub unsafe fn switch_char_0(mut c: libc::c_char) -> i32 {
     };
     panic!("ub: non-void function does not return a value")
 }
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Color {
-    #[default]
-    kRed = 0,
-    kGreen = 1,
-    kBlue = 2,
-}
-impl From<i32> for Color {
-    fn from(n: i32) -> Color {
-        match n {
-            0 => Color::kRed,
-            1 => Color::kGreen,
-            2 => Color::kBlue,
-            _ => panic!("invalid Color value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Color);
+pub type Color = u32;
+pub const Color_kRed: Color = 0;
+pub const Color_kGreen: Color = 1;
+pub const Color_kBlue: Color = 2;
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);

--- a/tests/unit/out/unsafe/switch_enum.rs
+++ b/tests/unit/out/unsafe/switch_enum.rs
@@ -6,35 +6,21 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Color {
-    #[default]
-    kRed = 0,
-    kGreen = 1,
-    kBlue = 2,
-}
-impl From<i32> for Color {
-    fn from(n: i32) -> Color {
-        match n {
-            0 => Color::kRed,
-            1 => Color::kGreen,
-            2 => Color::kBlue,
-            _ => panic!("invalid Color value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Color);
+pub type Color = u32;
+pub const Color_kRed: Color = 0;
+pub const Color_kGreen: Color = 1;
+pub const Color_kBlue: Color = 2;
 pub unsafe fn switch_enum_0(mut c: Color) -> i32 {
     'switch: {
         let __match_cond = (c as i32);
         match __match_cond {
-            __v if __v == (Color::kRed as i32) => {
+            __v if __v == (Color_kRed as i32) => {
                 return 10;
             }
-            __v if __v == (Color::kGreen as i32) => {
+            __v if __v == (Color_kGreen as i32) => {
                 return 20;
             }
-            __v if __v == (Color::kBlue as i32) => {
+            __v if __v == (Color_kBlue as i32) => {
                 return 30;
             }
             _ => {}
@@ -48,8 +34,8 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    assert!(((unsafe { switch_enum_0(Color::kRed,) }) == (10)));
-    assert!(((unsafe { switch_enum_0(Color::kGreen,) }) == (20)));
-    assert!(((unsafe { switch_enum_0(Color::kBlue,) }) == (30)));
+    assert!(((unsafe { switch_enum_0(Color_kRed,) }) == (10)));
+    assert!(((unsafe { switch_enum_0(Color_kGreen,) }) == (20)));
+    assert!(((unsafe { switch_enum_0(Color_kBlue,) }) == (30)));
     return 0;
 }

--- a/tests/unit/out/unsafe/tag_vs_identifier_collision.rs
+++ b/tests/unit/out/unsafe/tag_vs_identifier_collision.rs
@@ -6,24 +6,10 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum widget_enum {
-    #[default]
-    MODE_IDLE = 0,
-    MODE_ACTIVE = 1,
-    MODE_DONE = 2,
-}
-impl From<i32> for widget_enum {
-    fn from(n: i32) -> widget_enum {
-        match n {
-            0 => widget_enum::MODE_IDLE,
-            1 => widget_enum::MODE_ACTIVE,
-            2 => widget_enum::MODE_DONE,
-            _ => panic!("invalid widget_enum value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(widget_enum);
+pub type widget_enum = u32;
+pub const widget_enum_MODE_IDLE: widget_enum = 0;
+pub const widget_enum_MODE_ACTIVE: widget_enum = 1;
+pub const widget_enum_MODE_DONE: widget_enum = 2;
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct widget {
@@ -58,22 +44,9 @@ impl Default for slot_union {
         unsafe { std::mem::zeroed() }
     }
 }
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum slot {
-    #[default]
-    SLOT_A = 0,
-    SLOT_B = 1,
-}
-impl From<i32> for slot {
-    fn from(n: i32) -> slot {
-        match n {
-            0 => slot::SLOT_A,
-            1 => slot::SLOT_B,
-            _ => panic!("invalid slot value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(slot);
+pub type slot = u32;
+pub const slot_SLOT_A: slot = 0;
+pub const slot_SLOT_B: slot = 1;
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct Inner {
@@ -90,7 +63,7 @@ pub struct Inner_struct {
     pub typedef_field: i32,
 }
 pub unsafe fn is_active_0(mut w: *mut widget) -> i32 {
-    return ((((*w).mode as u32) == ((widget_enum::MODE_ACTIVE as i32) as u32)) as i32);
+    return ((((*w).mode as u32) == ((widget_enum_MODE_ACTIVE as i32) as u32)) as i32);
 }
 pub fn main() {
     unsafe {
@@ -100,10 +73,10 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut w: widget = <widget>::default();
     w.id = 7;
-    w.mode = widget_enum::MODE_ACTIVE;
+    w.mode = widget_enum_MODE_ACTIVE;
     assert!(((unsafe { is_active_0((&mut w as *mut widget),) }) != 0));
-    w.mode = widget_enum::MODE_DONE;
-    assert!(((((w.mode as u32) == ((widget_enum::MODE_DONE as i32) as u32)) as i32) != 0));
+    w.mode = widget_enum_MODE_DONE;
+    assert!(((((w.mode as u32) == ((widget_enum_MODE_DONE as i32) as u32)) as i32) != 0));
     let mut p: point_struct = <point_struct>::default();
     p.x = 3;
     p.y = 4;
@@ -114,8 +87,8 @@ unsafe fn main_0() -> i32 {
     let mut b: slot_union = <slot_union>::default();
     b.i = 9;
     assert!(((((b.i) == (9)) as i32) != 0));
-    let mut e: slot = slot::SLOT_B;
-    assert!(((((e as u32) == ((slot::SLOT_B as i32) as u32)) as i32) != 0));
+    let mut e: slot = slot_SLOT_B;
+    assert!(((((e as u32) == ((slot_SLOT_B as i32) as u32)) as i32) != 0));
     let mut inner_tag: Inner = <Inner>::default();
     inner_tag.tag_field = 11;
     assert!(((((inner_tag.tag_field) == (11)) as i32) != 0));

--- a/tests/unit/out/unsafe/union_tagged_many_arms.rs
+++ b/tests/unit/out/unsafe/union_tagged_many_arms.rs
@@ -6,28 +6,12 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Tag_enum {
-    #[default]
-    T_NUM_S = 0,
-    T_NUM_U = 1,
-    T_TEXT = 2,
-    T_FLOAT = 3,
-    T_REF = 4,
-}
-impl From<i32> for Tag_enum {
-    fn from(n: i32) -> Tag_enum {
-        match n {
-            0 => Tag_enum::T_NUM_S,
-            1 => Tag_enum::T_NUM_U,
-            2 => Tag_enum::T_TEXT,
-            3 => Tag_enum::T_FLOAT,
-            4 => Tag_enum::T_REF,
-            _ => panic!("invalid Tag_enum value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Tag_enum);
+pub type Tag_enum = u32;
+pub const Tag_enum_T_NUM_S: Tag_enum = 0;
+pub const Tag_enum_T_NUM_U: Tag_enum = 1;
+pub const Tag_enum_T_TEXT: Tag_enum = 2;
+pub const Tag_enum_T_FLOAT: Tag_enum = 3;
+pub const Tag_enum_T_REF: Tag_enum = 4;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union anon_0 {
@@ -55,24 +39,24 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut a: Slot = <Slot>::default();
-    a.tag = Tag_enum::T_NUM_S;
+    a.tag = Tag_enum_T_NUM_S;
     a.payload.signed_n = (-7_i32 as i64);
     assert!(((((a.payload.signed_n) == (-7_i32 as i64)) as i32) != 0));
     let mut b: Slot = <Slot>::default();
-    b.tag = Tag_enum::T_NUM_U;
+    b.tag = Tag_enum_T_NUM_U;
     b.payload.unsigned_n = 3735928559_u64;
     assert!(((((b.payload.unsigned_n) == (3735928559_u64)) as i32) != 0));
     let mut c: Slot = <Slot>::default();
-    c.tag = Tag_enum::T_TEXT;
+    c.tag = Tag_enum_T_TEXT;
     c.payload.text = (c"hello".as_ptr().cast_mut()).cast_const();
     assert!((((((*c.payload.text.offset((0) as isize)) as i32) == ('h' as i32)) as i32) != 0));
     let mut d: Slot = <Slot>::default();
-    d.tag = Tag_enum::T_FLOAT;
+    d.tag = Tag_enum_T_FLOAT;
     d.payload.f = 1.5E+0;
     assert!(((((d.payload.f) == (1.5E+0)) as i32) != 0));
     let mut x: i32 = 0;
     let mut e: Slot = <Slot>::default();
-    e.tag = Tag_enum::T_REF;
+    e.tag = Tag_enum_T_REF;
     e.payload.handle = ((&mut x as *mut i32) as *mut i32 as *mut ::libc::c_void);
     assert!(
         ((((e.payload.handle) == ((&mut x as *mut i32) as *mut i32 as *mut ::libc::c_void))

--- a/tests/unit/out/unsafe/union_tagged_simple.rs
+++ b/tests/unit/out/unsafe/union_tagged_simple.rs
@@ -6,22 +6,9 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Kind_enum {
-    #[default]
-    KIND_NONE = 0,
-    KIND_DONE = 1,
-}
-impl From<i32> for Kind_enum {
-    fn from(n: i32) -> Kind_enum {
-        match n {
-            0 => Kind_enum::KIND_NONE,
-            1 => Kind_enum::KIND_DONE,
-            _ => panic!("invalid Kind_enum value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Kind_enum);
+pub type Kind_enum = u32;
+pub const Kind_enum_KIND_NONE: Kind_enum = 0;
+pub const Kind_enum_KIND_DONE: Kind_enum = 1;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union anon_0 {
@@ -48,13 +35,13 @@ pub fn main() {
 unsafe fn main_0() -> i32 {
     let mut dummy: i32 = 0;
     let mut m1: Event = <Event>::default();
-    m1.kind = Kind_enum::KIND_DONE;
+    m1.kind = Kind_enum_KIND_DONE;
     m1.handle = ((&mut dummy as *mut i32) as *mut i32 as *mut ::libc::c_void);
     m1.payload.code = 42;
-    assert!(((((m1.kind as u32) == ((Kind_enum::KIND_DONE as i32) as u32)) as i32) != 0));
+    assert!(((((m1.kind as u32) == ((Kind_enum_KIND_DONE as i32) as u32)) as i32) != 0));
     assert!(((((m1.payload.code) == (42)) as i32) != 0));
     let mut m2: Event = <Event>::default();
-    m2.kind = Kind_enum::KIND_NONE;
+    m2.kind = Kind_enum_KIND_NONE;
     m2.handle = ((&mut dummy as *mut i32) as *mut i32 as *mut ::libc::c_void);
     m2.payload.obj = ((&mut dummy as *mut i32) as *mut i32 as *mut ::libc::c_void);
     assert!(

--- a/tests/unit/out/unsafe/union_tagged_struct_arms.rs
+++ b/tests/unit/out/unsafe/union_tagged_struct_arms.rs
@@ -6,24 +6,10 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Choice_enum {
-    #[default]
-    C_LIST = 1,
-    C_LETTERS = 2,
-    C_INTEGERS = 3,
-}
-impl From<i32> for Choice_enum {
-    fn from(n: i32) -> Choice_enum {
-        match n {
-            1 => Choice_enum::C_LIST,
-            2 => Choice_enum::C_LETTERS,
-            3 => Choice_enum::C_INTEGERS,
-            _ => panic!("invalid Choice_enum value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Choice_enum);
+pub type Choice_enum = u32;
+pub const Choice_enum_C_LIST: Choice_enum = 1;
+pub const Choice_enum_C_LETTERS: Choice_enum = 2;
+pub const Choice_enum_C_INTEGERS: Choice_enum = 3;
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
 pub struct anon_1 {
@@ -81,7 +67,7 @@ unsafe fn main_0() -> i32 {
         ]
     };;
     let mut p_list: Branch = <Branch>::default();
-    p_list.choice = Choice_enum::C_LIST;
+    p_list.choice = Choice_enum_C_LIST;
     p_list.index = 0;
     p_list.v.list.items = items_4.as_mut_ptr();
     p_list.v.list.count = 3_i64;
@@ -93,7 +79,7 @@ unsafe fn main_0() -> i32 {
             != 0)
     );
     let mut p_letters: Branch = <Branch>::default();
-    p_letters.choice = Choice_enum::C_LETTERS;
+    p_letters.choice = Choice_enum_C_LETTERS;
     p_letters.index = 1;
     p_letters.v.letters.lo = ('a' as i32);
     p_letters.v.letters.hi = ('z' as i32);
@@ -101,7 +87,7 @@ unsafe fn main_0() -> i32 {
     p_letters.v.letters.step = 1_u8;
     assert!((((((p_letters.v.letters.hi) - (p_letters.v.letters.lo)) == (25)) as i32) != 0));
     let mut p_integers: Branch = <Branch>::default();
-    p_integers.choice = Choice_enum::C_INTEGERS;
+    p_integers.choice = Choice_enum_C_INTEGERS;
     p_integers.index = 2;
     p_integers.v.integers.lo = 1_i64;
     p_integers.v.integers.hi = 100_i64;

--- a/tests/unit/out/unsafe/union_void_ptr_sized_deref.rs
+++ b/tests/unit/out/unsafe/union_void_ptr_sized_deref.rs
@@ -6,24 +6,10 @@ use std::collections::BTreeMap;
 use std::io::{Read, Seek, Write};
 use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum Width_enum {
-    #[default]
-    W_64 = 0,
-    W_32 = 1,
-    W_16 = 2,
-}
-impl From<i32> for Width_enum {
-    fn from(n: i32) -> Width_enum {
-        match n {
-            0 => Width_enum::W_64,
-            1 => Width_enum::W_32,
-            2 => Width_enum::W_16,
-            _ => panic!("invalid Width_enum value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(Width_enum);
+pub type Width_enum = u32;
+pub const Width_enum_W_64: Width_enum = 0;
+pub const Width_enum_W_32: Width_enum = 1;
+pub const Width_enum_W_16: Width_enum = 2;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union anon_0 {
@@ -47,15 +33,15 @@ pub unsafe fn write_count_1(mut s: *mut Sink, mut count: i64) {
     'switch: {
         let __match_cond = ((*s).width as u32);
         match __match_cond {
-            __v if __v == ((Width_enum::W_64 as i32) as u32) => {
+            __v if __v == ((Width_enum_W_64 as i32) as u32) => {
                 (*((*s).out.handle as *mut i64)) = count;
                 break 'switch;
             }
-            __v if __v == ((Width_enum::W_32 as i32) as u32) => {
+            __v if __v == ((Width_enum_W_32 as i32) as u32) => {
                 (*((*s).out.handle as *mut i32)) = (count as i32);
                 break 'switch;
             }
-            __v if __v == ((Width_enum::W_16 as i32) as u32) => {
+            __v if __v == ((Width_enum_W_16 as i32) as u32) => {
                 (*((*s).out.handle as *mut i16)) = (count as i16);
                 break 'switch;
             }
@@ -73,15 +59,15 @@ unsafe fn main_0() -> i32 {
     let mut buf32: i32 = 0;
     let mut buf16: i16 = 0_i16;
     let mut s: Sink = <Sink>::default();
-    s.width = Width_enum::W_64;
+    s.width = Width_enum_W_64;
     s.out.handle = ((&mut buf64 as *mut i64) as *mut i64 as *mut ::libc::c_void);
     (unsafe { write_count_1((&mut s as *mut Sink), 1234605616436508552_i64) });
     assert!(((((buf64) == (1234605616436508552_i64)) as i32) != 0));
-    s.width = Width_enum::W_32;
+    s.width = Width_enum_W_32;
     s.out.handle = ((&mut buf32 as *mut i32) as *mut i32 as *mut ::libc::c_void);
     (unsafe { write_count_1((&mut s as *mut Sink), 305419896_i64) });
     assert!(((((buf32) == (305419896)) as i32) != 0));
-    s.width = Width_enum::W_16;
+    s.width = Width_enum_W_16;
     s.out.handle = ((&mut buf16 as *mut i16) as *mut i16 as *mut ::libc::c_void);
     (unsafe { write_count_1((&mut s as *mut Sink), 4660_i64) });
     assert!(((((buf16 as i32) == (4660)) as i32) != 0));

--- a/tests/unit/out/unsafe/va_arg_non_primitive_ptrs.rs
+++ b/tests/unit/out/unsafe/va_arg_non_primitive_ptrs.rs
@@ -12,26 +12,11 @@ pub struct node {
     pub data: i32,
     pub next: *mut node,
 }
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum opt {
-    #[default]
-    OPT_STRING_OUT = 0,
-    OPT_FILE = 1,
-    OPT_NODE = 2,
-    OPT_NODE_OUT = 3,
-}
-impl From<i32> for opt {
-    fn from(n: i32) -> opt {
-        match n {
-            0 => opt::OPT_STRING_OUT,
-            1 => opt::OPT_FILE,
-            2 => opt::OPT_NODE,
-            3 => opt::OPT_NODE_OUT,
-            _ => panic!("invalid opt value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(opt);
+pub type opt = u32;
+pub const opt_OPT_STRING_OUT: opt = 0;
+pub const opt_OPT_FILE: opt = 1;
+pub const opt_OPT_NODE: opt = 2;
+pub const opt_OPT_NODE_OUT: opt = 3;
 pub unsafe fn dispatch_0(mut option: i32, __args: &[VaArg]) -> i32 {
     let mut ap: VaList = VaList::default();
     ap = VaList::new(__args);
@@ -39,23 +24,23 @@ pub unsafe fn dispatch_0(mut option: i32, __args: &[VaArg]) -> i32 {
     'switch: {
         let __match_cond = option;
         match __match_cond {
-            __v if __v == (opt::OPT_STRING_OUT as i32) => {
+            __v if __v == (opt_OPT_STRING_OUT as i32) => {
                 let mut out: *mut *const libc::c_char = ap.arg::<*mut *const libc::c_char>();
                 (*out) = (c"hello".as_ptr().cast_mut()).cast_const();
                 result = 1;
                 break 'switch;
             }
-            __v if __v == (opt::OPT_FILE as i32) => {
+            __v if __v == (opt_OPT_FILE as i32) => {
                 let mut f: *mut ::libc::FILE = ap.arg::<*mut ::libc::FILE>();
                 result = ((!((f).is_null())) as i32);
                 break 'switch;
             }
-            __v if __v == (opt::OPT_NODE as i32) => {
+            __v if __v == (opt_OPT_NODE as i32) => {
                 let mut n: *mut node = ap.arg::<*mut node>();
                 result = (*n).data;
                 break 'switch;
             }
-            __v if __v == (opt::OPT_NODE_OUT as i32) => {
+            __v if __v == (opt_OPT_NODE_OUT as i32) => {
                 let mut out: *mut *mut node = ap.arg::<*mut *mut node>();
                 (*out) = std::ptr::null_mut();
                 result = 2;
@@ -76,7 +61,7 @@ unsafe fn main_0() -> i32 {
     assert!(
         ((((unsafe {
             dispatch_0(
-                (opt::OPT_STRING_OUT as i32),
+                (opt_OPT_STRING_OUT as i32),
                 &[(&mut s as *mut *const libc::c_char).into()],
             )
         }) == (1)) as i32)
@@ -85,17 +70,14 @@ unsafe fn main_0() -> i32 {
     assert!((((!((s).is_null())) as i32) != 0));
     assert!(
         ((((unsafe {
-            dispatch_0(
-                (opt::OPT_FILE as i32),
-                &[(libcc2rs::stdout_unsafe()).into()],
-            )
+            dispatch_0((opt_OPT_FILE as i32), &[(libcc2rs::stdout_unsafe()).into()])
         }) == (1)) as i32)
             != 0)
     );
     assert!(
         ((((unsafe {
             dispatch_0(
-                (opt::OPT_FILE as i32),
+                (opt_OPT_FILE as i32),
                 &[((0 as *mut ::libc::c_void) as *mut ::libc::FILE).into()],
             )
         }) == (0)) as i32)
@@ -106,7 +88,7 @@ unsafe fn main_0() -> i32 {
         next: std::ptr::null_mut(),
     };
     assert!(
-        ((((unsafe { dispatch_0((opt::OPT_NODE as i32), &[(&mut head as *mut node).into(),]) })
+        ((((unsafe { dispatch_0((opt_OPT_NODE as i32), &[(&mut head as *mut node).into(),]) })
             == (42)) as i32)
             != 0)
     );
@@ -114,7 +96,7 @@ unsafe fn main_0() -> i32 {
     assert!(
         ((((unsafe {
             dispatch_0(
-                (opt::OPT_NODE_OUT as i32),
+                (opt_OPT_NODE_OUT as i32),
                 &[(&mut outp as *mut *mut node).into()],
             )
         }) == (2)) as i32)

--- a/tests/unit/out/unsafe/va_arg_void_ptr.rs
+++ b/tests/unit/out/unsafe/va_arg_void_ptr.rs
@@ -12,22 +12,9 @@ pub struct registry {
     pub slot: *mut ::libc::c_void,
     pub level: i64,
 }
-#[derive(Clone, Copy, PartialEq, Debug, Default)]
-enum field {
-    #[default]
-    FIELD_SLOT = 0,
-    FIELD_LEVEL = 1,
-}
-impl From<i32> for field {
-    fn from(n: i32) -> field {
-        match n {
-            0 => field::FIELD_SLOT,
-            1 => field::FIELD_LEVEL,
-            _ => panic!("invalid field value: {}", n),
-        }
-    }
-}
-libcc2rs::impl_enum_inc_dec!(field);
+pub type field = u32;
+pub const field_FIELD_SLOT: field = 0;
+pub const field_FIELD_LEVEL: field = 1;
 pub unsafe fn registry_update_0(mut r: *mut registry, mut field: field, __args: &[VaArg]) -> i32 {
     let mut result: i32 = 0;
     let mut ap: VaList = VaList::default();
@@ -35,11 +22,11 @@ pub unsafe fn registry_update_0(mut r: *mut registry, mut field: field, __args: 
     'switch: {
         let __match_cond = (field as u32);
         match __match_cond {
-            __v if __v == ((field::FIELD_SLOT as i32) as u32) => {
+            __v if __v == ((field_FIELD_SLOT as i32) as u32) => {
                 (*r).slot = ap.arg::<*mut ::libc::c_void>();
                 break 'switch;
             }
-            __v if __v == ((field::FIELD_LEVEL as i32) as u32) => {
+            __v if __v == ((field_FIELD_LEVEL as i32) as u32) => {
                 (*r).level = ap.arg::<i64>();
                 break 'switch;
             }
@@ -66,7 +53,7 @@ unsafe fn main_0() -> i32 {
         ((((unsafe {
             registry_update_0(
                 (&mut r as *mut registry),
-                field::FIELD_SLOT,
+                field_FIELD_SLOT,
                 &[(&mut payload as *mut i32).into()],
             )
         }) == (0)) as i32)
@@ -76,7 +63,7 @@ unsafe fn main_0() -> i32 {
         ((((unsafe {
             registry_update_0(
                 (&mut r as *mut registry),
-                field::FIELD_LEVEL,
+                field_FIELD_LEVEL,
                 &[(5_i64).into()],
             )
         }) == (0)) as i32)


### PR DESCRIPTION
The previous translation, C++ enums -> Rust enums had two weak points:
* it did not allow enums that have equal variants, for example `enum E { A = 1, B = A }`
* operations on the enum could not be used in const context, for example: `int global = E::A != E::B`. `!=` for enums is not const so it cannot be used in const expressions like initializing a global variable

The new translation does C++ enums -> Rust integers and the name of the values becomes `E_A` instead of `E::A`.