### PR TITLE
Translate scopes

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -435,25 +435,17 @@ void Converter::ConvertGotoBlock(clang::CompoundStmt *body) {
 }
 
 void Converter::ConvertFunctionBody(clang::FunctionDecl *decl) {
-  if (auto compound = clang::dyn_cast<clang::CompoundStmt>(decl->getBody())) {
-    if (CompoundHasTopLevelLabel(compound)) {
-      ConvertGotoBlock(compound);
-      if (!decl->getReturnType()->isVoidType()) {
-        StrCat(R"(panic!("ub: non-void function does not return a value"))");
-      }
-      return;
-    }
+  ConvertBodyStmts(decl->getBody());
+  if (decl->getReturnType()->isVoidType()) {
+    return;
   }
-
-  Convert(decl->getBody());
-  if (!decl->getReturnType()->isVoidType()) {
-    if (auto compound = clang::dyn_cast<clang::CompoundStmt>(decl->getBody())) {
-      if (!compound->body_empty()) {
-        if (!clang::isa<clang::ReturnStmt>(compound->body_back())) {
-          StrCat(R"(panic!("ub: non-void function does not return a value"))");
-        }
-      }
-    }
+  auto compound = clang::dyn_cast<clang::CompoundStmt>(decl->getBody());
+  if (!compound || compound->body_empty()) {
+    return;
+  }
+  if (CompoundHasTopLevelLabel(compound) ||
+      !clang::isa<clang::ReturnStmt>(compound->body_back())) {
+    StrCat(R"(panic!("ub: non-void function does not return a value"))");
   }
 }
 
@@ -1057,7 +1049,7 @@ void Converter::ConvertCXXConstructorBody(clang::CXXConstructorDecl *decl) {
   }
 
   StrCat(token::kSemiColon);
-  Convert(decl->getBody());
+  ConvertBodyStmts(decl->getBody());
   StrCat("this");
 }
 
@@ -1127,14 +1119,28 @@ bool Converter::Convert(clang::Stmt *stmt) {
   return exited_visit;
 }
 
-bool Converter::VisitCompoundStmt(clang::CompoundStmt *stmt) {
-  if (CompoundHasTopLevelLabel(stmt)) {
-    ConvertGotoBlock(stmt);
-    return false;
+void Converter::ConvertBody(clang::Stmt *body) {
+  PushBrace brace(*this);
+  ConvertBodyStmts(body);
+}
+
+void Converter::ConvertBodyStmts(clang::Stmt *body) {
+  auto *compound = clang::dyn_cast_or_null<clang::CompoundStmt>(body);
+  if (!compound) {
+    Convert(body);
+    return;
   }
-  for (auto *child : stmt->body()) {
+  if (CompoundHasTopLevelLabel(compound)) {
+    ConvertGotoBlock(compound);
+    return;
+  }
+  for (auto *child : compound->body()) {
     Convert(child);
   }
+}
+
+bool Converter::VisitCompoundStmt(clang::CompoundStmt *stmt) {
+  ConvertBody(stmt);
   return false;
 }
 
@@ -1172,17 +1178,13 @@ void Converter::ConvertCondition(clang::Expr *cond) {
 bool Converter::VisitIfStmt(clang::IfStmt *stmt) {
   StrCat(keyword::kIf);
   ConvertCondition(stmt->getCond());
-  {
-    PushBrace brace(*this);
-    Convert(stmt->getThen());
-  }
+  ConvertBody(stmt->getThen());
   if (stmt->hasElseStorage()) {
     StrCat(keyword::kElse);
     if (clang::isa<clang::IfStmt>(stmt->getElse())) {
       Convert(stmt->getElse());
     } else {
-      PushBrace brace(*this);
-      Convert(stmt->getElse());
+      ConvertBody(stmt->getElse());
     }
   }
   return false;
@@ -1193,12 +1195,9 @@ bool Converter::VisitWhileStmt(clang::WhileStmt *stmt) {
   StrCat("'loop_:");
   StrCat(keyword::kWhile);
   ConvertCondition(stmt->getCond());
-  {
-    PushBrace brace(*this);
-    curr_for_inc_.emplace_back(nullptr);
-    Convert(stmt->getBody());
-    curr_for_inc_.pop_back();
-  }
+  curr_for_inc_.emplace_back(nullptr);
+  ConvertBody(stmt->getBody());
+  curr_for_inc_.pop_back();
   return false;
 }
 
@@ -1216,7 +1215,7 @@ bool Converter::VisitDoStmt(clang::DoStmt *stmt) {
     PushBrace loop_brace(*this);
     StrCat(control_var, token::kAssign, keyword::kFalse, token::kSemiColon);
     curr_for_inc_.emplace_back(nullptr);
-    Convert(stmt->getBody());
+    ConvertBodyStmts(stmt->getBody());
     curr_for_inc_.pop_back();
   }
   return false;
@@ -1235,7 +1234,7 @@ bool Converter::VisitForStmt(clang::ForStmt *stmt) {
   {
     PushBrace brace(*this);
     curr_for_inc_.emplace_back(stmt->getInc());
-    Convert(stmt->getBody());
+    ConvertBodyStmts(stmt->getBody());
     curr_for_inc_.pop_back();
     Convert(stmt->getInc());
     StrCat(token::kSemiColon);
@@ -1273,7 +1272,7 @@ void Converter::ConvertForRangeBody(clang::CXXForRangeStmt *stmt,
   if (map_iter_decl)
     skip.emplace(*this, map_iter_decl);
   curr_for_inc_.emplace_back(nullptr);
-  Convert(stmt->getBody());
+  ConvertBodyStmts(stmt->getBody());
   curr_for_inc_.pop_back();
 }
 

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -86,6 +86,10 @@ public:
 
   void ConvertGotoBlock(clang::CompoundStmt *body);
 
+  void ConvertBody(clang::Stmt *body);
+
+  void ConvertBodyStmts(clang::Stmt *body);
+
   void EmitHoistedDecls(clang::CompoundStmt *body);
 
   virtual bool VisitFunctionTemplateDecl(clang::FunctionTemplateDecl *decl);

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -585,9 +585,8 @@ void ConverterRefCount::AddDropTrait(const clang::CXXRecordDecl *decl) {
   auto record_name = GetRecordName(decl);
 
   StrCat(keyword::kImpl, "Drop for", record_name, '{');
-  StrCat("fn drop(&mut self) {");
-  Convert(body);
-  StrCat('}');
+  StrCat("fn drop(&mut self)");
+  ConvertBody(body);
   StrCat('}');
 }
 

--- a/tests/unit/nested_block_scope.cpp
+++ b/tests/unit/nested_block_scope.cpp
@@ -1,0 +1,37 @@
+#include <assert.h>
+
+int main() {
+  int x = 1;
+  {
+    int x = 2;
+    assert(x == 2);
+    {
+      int x = 3;
+      assert(x == 3);
+    }
+    assert(x == 2);
+  }
+  assert(x == 1);
+
+  int sum = 0;
+  for (int i = 0; i < 3; i++) {
+    int y = i;
+    {
+      int y = 10;
+      sum += y;
+    }
+    sum += y;
+  }
+  assert(sum == 33);
+
+  if (x == 1) {
+    int x = 5;
+    {
+      int x = 6;
+      assert(x == 6);
+    }
+    assert(x == 5);
+  }
+  assert(x == 1);
+  return 0;
+}

--- a/tests/unit/out/refcount/nested_block_scope.rs
+++ b/tests/unit/out/refcount/nested_block_scope.rs
@@ -1,0 +1,46 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(1));
+    {
+        let x: Value<i32> = Rc::new(RefCell::new(2));
+        assert!(((*x.borrow()) == 2));
+        {
+            let x: Value<i32> = Rc::new(RefCell::new(3));
+            assert!(((*x.borrow()) == 3));
+        }
+        assert!(((*x.borrow()) == 2));
+    }
+    assert!(((*x.borrow()) == 1));
+    let sum: Value<i32> = Rc::new(RefCell::new(0));
+    let i: Value<i32> = Rc::new(RefCell::new(0));
+    'loop_: while ((*i.borrow()) < 3) {
+        let y: Value<i32> = Rc::new(RefCell::new((*i.borrow())));
+        {
+            let y: Value<i32> = Rc::new(RefCell::new(10));
+            (*sum.borrow_mut()) += (*y.borrow());
+        }
+        (*sum.borrow_mut()) += (*y.borrow());
+        (*i.borrow_mut()).postfix_inc();
+    }
+    assert!(((*sum.borrow()) == 33));
+    if ((*x.borrow()) == 1) {
+        let x: Value<i32> = Rc::new(RefCell::new(5));
+        {
+            let x: Value<i32> = Rc::new(RefCell::new(6));
+            assert!(((*x.borrow()) == 6));
+        }
+        assert!(((*x.borrow()) == 5));
+    }
+    assert!(((*x.borrow()) == 1));
+    return 0;
+}

--- a/tests/unit/out/refcount/pointer_add_assign.rs
+++ b/tests/unit/out/refcount/pointer_add_assign.rs
@@ -11,29 +11,45 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let arr: Value<Box<[u8]>> = Rc::new(RefCell::new(Box::new([1_u8, 2_u8, 3_u8])));
-    let p: Value<Ptr<u8>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<u8>).offset(0))));
-    (*p.borrow_mut()) += (1_u8 as i32);
-    assert!(((((*p.borrow()).read()) as i32) == 2));
-    let p: Value<Ptr<u8>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<u8>).offset(0))));
-    (*p.borrow_mut()) += (1_i8 as i32);
-    assert!(((((*p.borrow()).read()) as i32) == 2));
-    let p: Value<Ptr<u8>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<u8>).offset(0))));
-    (*p.borrow_mut()) += (1_u16 as i32);
-    assert!(((((*p.borrow()).read()) as i32) == 2));
-    let p: Value<Ptr<u8>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<u8>).offset(0))));
-    (*p.borrow_mut()) += (1_i16 as i32);
-    assert!(((((*p.borrow()).read()) as i32) == 2));
-    let p: Value<Ptr<u8>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<u8>).offset(0))));
-    (*p.borrow_mut()) += 1_u32;
-    assert!(((((*p.borrow()).read()) as i32) == 2));
-    let p: Value<Ptr<u8>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<u8>).offset(0))));
-    (*p.borrow_mut()) += (1 as i32);
-    assert!(((((*p.borrow()).read()) as i32) == 2));
-    let p: Value<Ptr<u8>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<u8>).offset(0))));
-    (*p.borrow_mut()) += 1_u64;
-    assert!(((((*p.borrow()).read()) as i32) == 2));
-    let p: Value<Ptr<u8>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<u8>).offset(0))));
-    (*p.borrow_mut()) += 1_i64;
-    assert!(((((*p.borrow()).read()) as i32) == 2));
+    {
+        let p: Value<Ptr<u8>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<u8>).offset(0))));
+        (*p.borrow_mut()) += (1_u8 as i32);
+        assert!(((((*p.borrow()).read()) as i32) == 2));
+    }
+    {
+        let p: Value<Ptr<u8>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<u8>).offset(0))));
+        (*p.borrow_mut()) += (1_i8 as i32);
+        assert!(((((*p.borrow()).read()) as i32) == 2));
+    }
+    {
+        let p: Value<Ptr<u8>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<u8>).offset(0))));
+        (*p.borrow_mut()) += (1_u16 as i32);
+        assert!(((((*p.borrow()).read()) as i32) == 2));
+    }
+    {
+        let p: Value<Ptr<u8>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<u8>).offset(0))));
+        (*p.borrow_mut()) += (1_i16 as i32);
+        assert!(((((*p.borrow()).read()) as i32) == 2));
+    }
+    {
+        let p: Value<Ptr<u8>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<u8>).offset(0))));
+        (*p.borrow_mut()) += 1_u32;
+        assert!(((((*p.borrow()).read()) as i32) == 2));
+    }
+    {
+        let p: Value<Ptr<u8>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<u8>).offset(0))));
+        (*p.borrow_mut()) += (1 as i32);
+        assert!(((((*p.borrow()).read()) as i32) == 2));
+    }
+    {
+        let p: Value<Ptr<u8>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<u8>).offset(0))));
+        (*p.borrow_mut()) += 1_u64;
+        assert!(((((*p.borrow()).read()) as i32) == 2));
+    }
+    {
+        let p: Value<Ptr<u8>> = Rc::new(RefCell::new(((arr.as_pointer() as Ptr<u8>).offset(0))));
+        (*p.borrow_mut()) += 1_i64;
+        assert!(((((*p.borrow()).read()) as i32) == 2));
+    }
     return 0;
 }

--- a/tests/unit/out/refcount/stdcopy_ostream.rs
+++ b/tests/unit/out/refcount/stdcopy_ostream.rs
@@ -17,18 +17,20 @@ fn main_0() -> i32 {
             .collect::<Vec<u8>>(),
     ));
     let file: Value<Box<[u8]>> = Rc::new(RefCell::new(Box::from(*b"test_stdcopy_ostream.txt\0")));
-    let ofs: Value<::std::fs::File> = Rc::new(RefCell::new(
-        ::std::fs::File::create((file.as_pointer() as Ptr<u8>).to_string())
-            .expect("Failed to open file"),
-    ));
     {
-        (*ofs.borrow_mut()).write_all(
-            (str.as_pointer() as Ptr<u8>)
-                .slice_until(&(str.as_pointer() as Ptr<u8>).to_last())
-                .as_slice(),
-        );
-        (*ofs.borrow_mut()).try_clone().unwrap()
-    };
+        let ofs: Value<::std::fs::File> = Rc::new(RefCell::new(
+            ::std::fs::File::create((file.as_pointer() as Ptr<u8>).to_string())
+                .expect("Failed to open file"),
+        ));
+        {
+            (*ofs.borrow_mut()).write_all(
+                (str.as_pointer() as Ptr<u8>)
+                    .slice_until(&(str.as_pointer() as Ptr<u8>).to_last())
+                    .as_slice(),
+            );
+            (*ofs.borrow_mut()).try_clone().unwrap()
+        };
+    }
     match nix::unistd::unlink((file.as_pointer() as Ptr<u8>).to_rust_string().as_str()) {
         Ok(()) => 0,
         Err(__e) => {

--- a/tests/unit/out/refcount/switch_fallthrough_into_block.rs
+++ b/tests/unit/out/refcount/switch_fallthrough_into_block.rs
@@ -14,9 +14,11 @@ pub fn fallthrough_into_block_0(x: i32) -> i32 {
             (*r.borrow_mut()) += 1;
         }
         __v if __v == 2 => {
-            let tmp: Value<i32> = Rc::new(RefCell::new(((*r.borrow()) * 10)));
-            (*r.borrow_mut()) = ((*tmp.borrow()) + 5);
-            break;
+            {
+                let tmp: Value<i32> = Rc::new(RefCell::new(((*r.borrow()) * 10)));
+                (*r.borrow_mut()) = ((*tmp.borrow()) + 5);
+                break;
+            }
         }
         _ => {
             (*r.borrow_mut()) = -1_i32;

--- a/tests/unit/out/unsafe/nested_block_scope.rs
+++ b/tests/unit/out/unsafe/nested_block_scope.rs
@@ -1,0 +1,48 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut x: i32 = 1;
+    {
+        let mut x: i32 = 2;
+        assert!(((x) == (2)));
+        {
+            let mut x: i32 = 3;
+            assert!(((x) == (3)));
+        }
+        assert!(((x) == (2)));
+    }
+    assert!(((x) == (1)));
+    let mut sum: i32 = 0;
+    let mut i: i32 = 0;
+    'loop_: while ((i) < (3)) {
+        let mut y: i32 = i;
+        {
+            let mut y: i32 = 10;
+            sum += y;
+        }
+        sum += y;
+        i.postfix_inc();
+    }
+    assert!(((sum) == (33)));
+    if ((x) == (1)) {
+        let mut x: i32 = 5;
+        {
+            let mut x: i32 = 6;
+            assert!(((x) == (6)));
+        }
+        assert!(((x) == (5)));
+    }
+    assert!(((x) == (1)));
+    return 0;
+}

--- a/tests/unit/out/unsafe/pointer_add_assign.rs
+++ b/tests/unit/out/unsafe/pointer_add_assign.rs
@@ -17,29 +17,45 @@ unsafe fn main_0() -> i32 {
         (2 as libc::c_char),
         (3 as libc::c_char),
     ];
-    let mut p: *mut libc::c_char = (&mut arr[(0) as usize] as *mut libc::c_char);
-    p = (p).wrapping_add((1_u8 as i32) as usize);
-    assert!((((*p) as i32) == (2)));
-    let mut p: *mut libc::c_char = (&mut arr[(0) as usize] as *mut libc::c_char);
-    p = (p).wrapping_add((1_i8 as i32) as usize);
-    assert!((((*p) as i32) == (2)));
-    let mut p: *mut libc::c_char = (&mut arr[(0) as usize] as *mut libc::c_char);
-    p = (p).wrapping_add((1_u16 as i32) as usize);
-    assert!((((*p) as i32) == (2)));
-    let mut p: *mut libc::c_char = (&mut arr[(0) as usize] as *mut libc::c_char);
-    p = (p).wrapping_add((1_i16 as i32) as usize);
-    assert!((((*p) as i32) == (2)));
-    let mut p: *mut libc::c_char = (&mut arr[(0) as usize] as *mut libc::c_char);
-    p = (p).wrapping_add((1_u32 as u32) as usize);
-    assert!((((*p) as i32) == (2)));
-    let mut p: *mut libc::c_char = (&mut arr[(0) as usize] as *mut libc::c_char);
-    p = (p).wrapping_add(((1 as i32) as i32) as usize);
-    assert!((((*p) as i32) == (2)));
-    let mut p: *mut libc::c_char = (&mut arr[(0) as usize] as *mut libc::c_char);
-    p = (p).wrapping_add((1_u64 as u64) as usize);
-    assert!((((*p) as i32) == (2)));
-    let mut p: *mut libc::c_char = (&mut arr[(0) as usize] as *mut libc::c_char);
-    p = (p).wrapping_add((1_i64 as i64) as usize);
-    assert!((((*p) as i32) == (2)));
+    {
+        let mut p: *mut libc::c_char = (&mut arr[(0) as usize] as *mut libc::c_char);
+        p = (p).wrapping_add((1_u8 as i32) as usize);
+        assert!((((*p) as i32) == (2)));
+    }
+    {
+        let mut p: *mut libc::c_char = (&mut arr[(0) as usize] as *mut libc::c_char);
+        p = (p).wrapping_add((1_i8 as i32) as usize);
+        assert!((((*p) as i32) == (2)));
+    }
+    {
+        let mut p: *mut libc::c_char = (&mut arr[(0) as usize] as *mut libc::c_char);
+        p = (p).wrapping_add((1_u16 as i32) as usize);
+        assert!((((*p) as i32) == (2)));
+    }
+    {
+        let mut p: *mut libc::c_char = (&mut arr[(0) as usize] as *mut libc::c_char);
+        p = (p).wrapping_add((1_i16 as i32) as usize);
+        assert!((((*p) as i32) == (2)));
+    }
+    {
+        let mut p: *mut libc::c_char = (&mut arr[(0) as usize] as *mut libc::c_char);
+        p = (p).wrapping_add((1_u32 as u32) as usize);
+        assert!((((*p) as i32) == (2)));
+    }
+    {
+        let mut p: *mut libc::c_char = (&mut arr[(0) as usize] as *mut libc::c_char);
+        p = (p).wrapping_add(((1 as i32) as i32) as usize);
+        assert!((((*p) as i32) == (2)));
+    }
+    {
+        let mut p: *mut libc::c_char = (&mut arr[(0) as usize] as *mut libc::c_char);
+        p = (p).wrapping_add((1_u64 as u64) as usize);
+        assert!((((*p) as i32) == (2)));
+    }
+    {
+        let mut p: *mut libc::c_char = (&mut arr[(0) as usize] as *mut libc::c_char);
+        p = (p).wrapping_add((1_i64 as i64) as usize);
+        assert!((((*p) as i32) == (2)));
+    }
     return 0;
 }

--- a/tests/unit/out/unsafe/stdcopy_ostream.rs
+++ b/tests/unit/out/unsafe/stdcopy_ostream.rs
@@ -17,16 +17,18 @@ unsafe fn main_0() -> i32 {
         std::slice::from_raw_parts(s, (0..).take_while(|&i| *s.add(i) != 0).count() + 1).to_vec()
     };
     let file: [libc::c_char; 25] = std::mem::transmute(*b"test_stdcopy_ostream.txt\0");
-    let mut ofs: ::std::fs::File =
-        ::std::fs::File::create(::std::ffi::CStr::from_ptr(file.as_ptr()).to_str().unwrap())
-            .unwrap();
     {
-        let __start = str.as_mut_ptr() as *const u8;
-        let __end = str.as_mut_ptr().add(str.len() - 1) as *const u8;
-        let __len = __end.offset_from(__start) as usize;
-        ofs.write_all(::std::slice::from_raw_parts(__start, __len));
-        ofs.try_clone().unwrap()
-    };
+        let mut ofs: ::std::fs::File =
+            ::std::fs::File::create(::std::ffi::CStr::from_ptr(file.as_ptr()).to_str().unwrap())
+                .unwrap();
+        {
+            let __start = str.as_mut_ptr() as *const u8;
+            let __end = str.as_mut_ptr().add(str.len() - 1) as *const u8;
+            let __len = __end.offset_from(__start) as usize;
+            ofs.write_all(::std::slice::from_raw_parts(__start, __len));
+            ofs.try_clone().unwrap()
+        };
+    }
     libc::unlink(file.as_ptr());
     return 0;
 }

--- a/tests/unit/out/unsafe/switch_fallthrough_into_block.rs
+++ b/tests/unit/out/unsafe/switch_fallthrough_into_block.rs
@@ -13,9 +13,11 @@ pub unsafe fn fallthrough_into_block_0(mut x: i32) -> i32 {
             r += 1;
         }
         __v if __v == 2 => {
-            let mut tmp: i32 = ((r) * (10));
-            r = ((tmp) + (5));
-            break;
+            {
+                let mut tmp: i32 = ((r) * (10));
+                r = ((tmp) + (5));
+                break;
+            }
         }
         _ => {
             r = -1_i32;


### PR DESCRIPTION
Each C++ scope:

```cpp
int foo() {
  int a;
  {
    int a;
  }
}
```

Becomes a proper Rust scope:

```rust
fn foo() {
  let a: i32;
  {
    let a: i32;
  }
}
```