### PR TITLE
Use borrow instead of clone in void cast

### DIFF
--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -1341,11 +1341,10 @@ bool ConverterRefCount::VisitFunctionPointerCast(
 
 bool ConverterRefCount::VisitExplicitCastExpr(clang::ExplicitCastExpr *expr) {
   if (expr->getTypeAsWritten()->isVoidType()) {
+    StrCat(token::kRef);
+    PushParen paren(*this);
     PushExprKind push(*this, ExprKind::Void);
     Convert(expr->getSubExpr());
-    if (!TypeIsCopyable(expr->getSubExpr()->getType()) && !isFresh()) {
-      StrCat(".clone()");
-    }
     return false;
   }
   if (expr->getCastKind() == clang::CK_NullToPointer) {

--- a/tests/multi-file/extern_functions/out/refcount/extern_functions.rs
+++ b/tests/multi-file/extern_functions/out/refcount/extern_functions.rs
@@ -24,8 +24,8 @@ pub fn unrelated3_3() -> i32 {
 }
 pub fn helper_0(x: i32) -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(x));
-    ({ unrelated1_1() });
-    ({ unrelated2_2() });
-    ({ unrelated3_3() });
+    &({ unrelated1_1() });
+    &({ unrelated2_2() });
+    &({ unrelated3_3() });
     return ((*x.borrow()) + 1);
 }

--- a/tests/multi-file/header_function/out/refcount/header_function.rs
+++ b/tests/multi-file/header_function/out/refcount/header_function.rs
@@ -24,8 +24,8 @@ pub fn unrelated3_3() -> i32 {
 }
 pub fn helper_0(x: i32) -> i32 {
     let x: Value<i32> = Rc::new(RefCell::new(x));
-    ({ unrelated1_1() });
-    ({ unrelated2_2() });
-    ({ unrelated3_3() });
+    &({ unrelated1_1() });
+    &({ unrelated2_2() });
+    &({ unrelated3_3() });
     return ((*x.borrow()) + 1);
 }

--- a/tests/multi-file/opaque_forward_decl/out/refcount/opaque_forward_decl.rs
+++ b/tests/multi-file/opaque_forward_decl/out/refcount/opaque_forward_decl.rs
@@ -49,6 +49,6 @@ fn main_0() -> i32 {
 }
 pub fn touch_0(c: Ptr<container>) {
     let c: Value<Ptr<container>> = Rc::new(RefCell::new(c));
-    (*(*(*c.borrow()).upgrade().deref()).p.borrow()).clone();
+    &(*(*(*c.borrow()).upgrade().deref()).p.borrow());
 }
 pub struct opaque;

--- a/tests/unit/out/refcount/opaque_forward_decl.rs
+++ b/tests/unit/out/refcount/opaque_forward_decl.rs
@@ -42,7 +42,7 @@ fn main_0() -> i32 {
         p: Rc::new(RefCell::new(Ptr::<opaque>::null())),
         x: Rc::new(RefCell::new(42)),
     }));
-    (*(*c.borrow()).p.borrow()).clone();
+    &(*(*c.borrow()).p.borrow());
     return ((*(*c.borrow()).x.borrow()) - 42);
 }
 pub struct opaque;

--- a/tests/unit/out/refcount/reinterpret_cast_oob_read.rs
+++ b/tests/unit/out/refcount/reinterpret_cast_oob_read.rs
@@ -15,6 +15,6 @@ fn main_0() -> i32 {
     let x: Value<u8> = Rc::new(RefCell::new(
         ((*bytes.borrow()).offset((4) as isize).read()),
     ));
-    (*x.borrow_mut());
+    &(*x.borrow_mut());
     return 0;
 }

--- a/tests/unit/out/refcount/reinterpret_cast_undersize.rs
+++ b/tests/unit/out/refcount/reinterpret_cast_undersize.rs
@@ -13,6 +13,6 @@ fn main_0() -> i32 {
     let b: Value<u8> = Rc::new(RefCell::new(66_u8));
     let p: Value<Ptr<u32>> = Rc::new(RefCell::new((b.as_pointer()).reinterpret_cast::<u32>()));
     let val: Value<u32> = Rc::new(RefCell::new(((*p.borrow()).read())));
-    (*val.borrow_mut());
+    &(*val.borrow_mut());
     return 0;
 }

--- a/tests/unit/out/refcount/user_defined_same_as_libc.rs
+++ b/tests/unit/out/refcount/user_defined_same_as_libc.rs
@@ -9,8 +9,8 @@ use std::rc::{Rc, Weak};
 pub fn fopen_0(path: Ptr<u8>, mode: Ptr<u8>) -> Ptr<CFile> {
     let path: Value<Ptr<u8>> = Rc::new(RefCell::new(path));
     let mode: Value<Ptr<u8>> = Rc::new(RefCell::new(mode));
-    (*path.borrow()).clone();
-    (*mode.borrow()).clone();
+    &(*path.borrow());
+    &(*mode.borrow());
     return Ptr::null();
 }
 pub fn main() {

--- a/tests/unit/out/refcount/va_arg_fn_ptr.rs
+++ b/tests/unit/out/refcount/va_arg_fn_ptr.rs
@@ -46,9 +46,9 @@ pub fn not_supported_5(ctx: AnyPtr, fn_: FnPtr<fn(i32) -> i32>, extra: AnyPtr) -
     let ctx: Value<AnyPtr> = Rc::new(RefCell::new(ctx));
     let fn_: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(fn_));
     let extra: Value<AnyPtr> = Rc::new(RefCell::new(extra));
-    (*ctx.borrow()).clone();
-    (*fn_.borrow()).clone();
-    (*extra.borrow()).clone();
+    &(*ctx.borrow());
+    &(*fn_.borrow());
+    &(*extra.borrow());
     return -3_i32;
 }
 pub fn main() {

--- a/tests/unit/out/refcount/va_arg_printf.rs
+++ b/tests/unit/out/refcount/va_arg_printf.rs
@@ -9,7 +9,7 @@ use std::rc::{Rc, Weak};
 pub fn logf_impl_0(fmt: Ptr<u8>, ap: VaList) -> i32 {
     let fmt: Value<Ptr<u8>> = Rc::new(RefCell::new(fmt));
     let ap: Value<VaList> = Rc::new(RefCell::new(ap));
-    (*fmt.borrow()).clone();
+    &(*fmt.borrow());
     return {
         let _lhs = (*ap.borrow_mut()).arg::<i32>();
         _lhs + (*ap.borrow_mut()).arg::<i32>()

--- a/tests/unit/out/refcount/void_cast.rs
+++ b/tests/unit/out/refcount/void_cast.rs
@@ -8,7 +8,7 @@ use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 pub fn unused_param_0(x: i32) {
     let x: Value<i32> = Rc::new(RefCell::new(x));
-    (*x.borrow_mut());
+    &(*x.borrow_mut());
 }
 #[derive(Default)]
 pub struct NonTrivial {
@@ -36,11 +36,11 @@ impl ByteRepr for NonTrivial {
     }
 }
 pub fn unused_ref_param_1(x: Ptr<NonTrivial>) {
-    (*x.upgrade().deref()).clone();
+    &(*x.upgrade().deref());
 }
 pub fn unused_ptr_param_2(p: Ptr<NonTrivial>) {
     let p: Value<Ptr<NonTrivial>> = Rc::new(RefCell::new(p));
-    (*(*p.borrow()).upgrade().deref()).clone();
+    &(*(*p.borrow()).upgrade().deref());
 }
 thread_local!(
     pub static side_effect_counter_3: Value<i32> = Rc::new(RefCell::new(0));
@@ -74,68 +74,95 @@ impl ByteRepr for Holder {
         }
     }
 }
+#[derive(Default)]
+pub struct NonCopyable {
+    pub value: Value<Option<Value<i32>>>,
+}
+impl ByteRepr for NonCopyable {
+    fn byte_size() -> usize {
+        8
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.value.borrow()).to_bytes(&mut buf[0..8]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            value: Rc::new(RefCell::new(<Option<Value<i32>>>::from_bytes(&buf[0..8]))),
+        }
+    }
+}
+pub fn unused_noncopyable_param_5(x: Ptr<NonCopyable>) {
+    &(*x.upgrade().deref());
+}
 pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
     ({ unused_param_0(42) });
     let y: Value<i32> = Rc::new(RefCell::new(5));
-    (*y.borrow_mut());
+    &(*y.borrow_mut());
     let z: Value<i32> = Rc::new(RefCell::new({
-        (*y.borrow_mut());
+        &(*y.borrow_mut());
         7
     }));
     assert!(((*z.borrow()) == 7));
     let counter: Value<i32> = Rc::new(RefCell::new(0));
     let w: Value<i32> = Rc::new(RefCell::new({
-        (*counter.borrow_mut());
+        &(*counter.borrow_mut());
         (*counter.borrow_mut()) = 3;
         (*counter.borrow())
     }));
     assert!(((*w.borrow()) == 3));
     assert!(((*counter.borrow()) == 3));
-    ({ bump_and_return_4() });
+    &({ bump_and_return_4() });
     assert!(((*side_effect_counter_3.with(Value::clone).borrow()) == 1));
     let v: Value<i32> = Rc::new(RefCell::new({
-        ({ bump_and_return_4() });
+        &({ bump_and_return_4() });
         99
     }));
     assert!(((*side_effect_counter_3.with(Value::clone).borrow()) == 2));
     assert!(((*v.borrow()) == 99));
-    0;
-    (0);
-    (*y.borrow_mut());
-    (0);
-    (*y.borrow_mut());
+    &(0);
+    &(0);
+    &(*y.borrow_mut());
+    (&(0));
+    (&(*y.borrow_mut()));
     let err: Value<i32> = Rc::new(RefCell::new(0));
-    ((*err.borrow_mut()) = 42);
+    (&((*err.borrow_mut()) = 42));
     assert!(((*err.borrow()) == 42));
     let chosen: Value<i32> = Rc::new(RefCell::new({
-        ((*err.borrow_mut()) = 7);
+        &((*err.borrow_mut()) = 7);
         123
     }));
     assert!(((*err.borrow()) == 7));
     assert!(((*chosen.borrow()) == 123));
-    bump_and_return_4;
+    &(bump_and_return_4);
     assert!(((*side_effect_counter_3.with(Value::clone).borrow()) == 2));
-    (FnPtr::<fn() -> i32>::new(bump_and_return_4));
+    &(FnPtr::<fn() -> i32>::new(bump_and_return_4));
     assert!(((*side_effect_counter_3.with(Value::clone).borrow()) == 2));
-    ((FnPtr::<fn() -> i32>::new(bump_and_return_4)).cast::<fn() -> i32>(None));
+    &((FnPtr::<fn() -> i32>::new(bump_and_return_4)).cast::<fn() -> i32>(None));
     assert!(((*side_effect_counter_3.with(Value::clone).borrow()) == 2));
     let storage: Value<i32> = Rc::new(RefCell::new(11));
     let p: Value<Ptr<i32>> = Rc::new(RefCell::new((storage.as_pointer())));
-    ((*p.borrow()).read());
-    (*p.borrow_mut()).clone();
+    &((*p.borrow()).read());
+    &(*p.borrow_mut());
     let arr: Value<Box<[i32]>> = Rc::new(RefCell::new(Box::new([1, 2, 3])));
-    ((*arr.borrow_mut())[(1) as usize]);
+    &((*arr.borrow_mut())[(1) as usize]);
     let h: Value<Holder> = Rc::new(RefCell::new(Holder {
         field: Rc::new(RefCell::new(17)),
     }));
-    (*(*h.borrow()).field.borrow_mut());
+    &(*(*h.borrow()).field.borrow_mut());
     let hp: Value<Ptr<Holder>> = Rc::new(RefCell::new((h.as_pointer())));
-    (*(*(*hp.borrow()).upgrade().deref()).field.borrow_mut());
+    &(*(*(*hp.borrow()).upgrade().deref()).field.borrow_mut());
     let nt: Value<NonTrivial> = Rc::new(RefCell::new(<NonTrivial>::default()));
     ({ unused_ref_param_1(nt.as_pointer()) });
     ({ unused_ptr_param_2((nt.as_pointer())) });
+    let g: Value<NonCopyable> = Rc::new(RefCell::new(NonCopyable {
+        value: Rc::new(RefCell::new(Some(Rc::new(RefCell::new(9))))),
+    }));
+    (&(*g.borrow_mut()));
+    &(*g.borrow_mut());
+    ({ unused_noncopyable_param_5(g.as_pointer()) });
+    assert!(((*(*(*g.borrow()).value.borrow()).as_ref().unwrap().borrow()) == 9));
     return 0;
 }

--- a/tests/unit/out/unsafe/void_cast.rs
+++ b/tests/unit/out/unsafe/void_cast.rs
@@ -30,6 +30,14 @@ pub unsafe fn bump_and_return_4() -> i32 {
 pub struct Holder {
     pub field: i32,
 }
+#[repr(C)]
+#[derive(Default)]
+pub struct NonCopyable {
+    pub value: Option<Box<i32>>,
+}
+pub unsafe fn unused_noncopyable_param_5(x: *const NonCopyable) {
+    &(*x);
+}
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
@@ -95,5 +103,12 @@ unsafe fn main_0() -> i32 {
     let mut nt: NonTrivial = <NonTrivial>::default();
     (unsafe { unused_ref_param_1(&nt as *const NonTrivial) });
     (unsafe { unused_ptr_param_2((&mut nt as *mut NonTrivial).cast_const()) });
+    let mut g: NonCopyable = NonCopyable {
+        value: Some(Box::new(9)),
+    };
+    (&(g));
+    &(g);
+    (unsafe { unused_noncopyable_param_5(&g as *const NonCopyable) });
+    assert!(((*g.value.as_deref_mut().unwrap()) == (9)));
     return 0;
 }

--- a/tests/unit/void_cast.cpp
+++ b/tests/unit/void_cast.cpp
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <memory>
 #include <vector>
 
 void unused_param(int x) { (void)x; }
@@ -20,6 +21,12 @@ int bump_and_return() {
 struct Holder {
   int field;
 };
+
+struct NonCopyable {
+  std::unique_ptr<int> value;
+};
+
+void unused_noncopyable_param(const NonCopyable &x) { (void)x; }
 
 int main() {
   unused_param(42);
@@ -83,6 +90,12 @@ int main() {
   NonTrivial nt;
   unused_ref_param(nt);
   unused_ptr_param(&nt);
+
+  NonCopyable g{std::make_unique<int>(9)};
+  ((void)g);
+  (void)g;
+  unused_noncopyable_param(g);
+  assert(*g.value == 9);
 
   return 0;
 }


### PR DESCRIPTION
In a void cast we clone the argument and immediately drop it.

Not all types implement Clone. Instead, take a reference and immediately drop it. This works for types that don't implement Clone.