### PR TITLE
Translate destructors in unsafe 

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -678,7 +678,7 @@ bool Converter::RecordDerivesCopy(const clang::RecordDecl *decl) const {
 
 bool Converter::RecordHasCopyableFields(const clang::RecordDecl *decl) {
   if (auto *cxx = clang::dyn_cast<clang::CXXRecordDecl>(decl);
-      cxx && RecordNeedsDestruction(cxx)) {
+      cxx && !cxx->hasTrivialDestructor()) {
     return false;
   }
   for (auto f : decl->fields()) {

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -677,6 +677,10 @@ bool Converter::RecordDerivesCopy(const clang::RecordDecl *decl) const {
 }
 
 bool Converter::RecordHasCopyableFields(const clang::RecordDecl *decl) {
+  if (auto *cxx = clang::dyn_cast<clang::CXXRecordDecl>(decl);
+      cxx && RecordNeedsDestruction(cxx)) {
+    return false;
+  }
   for (auto f : decl->fields()) {
     // Records that contain std::vector, std::array, std::string or anything
     // that is translated to Vec<>, do not derive Copy
@@ -3969,7 +3973,20 @@ void Converter::AddOrdTrait(const clang::CXXRecordDecl *decl) {
 
 void Converter::AddCloneTrait(const clang::RecordDecl *decl) {}
 
-void Converter::AddDropTrait(const clang::CXXRecordDecl *decl) {}
+void Converter::AddDropTrait(const clang::CXXRecordDecl *decl) {
+  auto *dtor = GetTranslatableDestructor(decl);
+  if (!dtor) {
+    return;
+  }
+  PushCurrFunction push_fn(*this, dtor);
+  StrCat(keyword::kImpl, "Drop for", GetRecordName(decl));
+  PushBrace impl_brace(*this);
+  StrCat("fn drop(&mut self)");
+  PushBrace fn_brace(*this);
+  StrCat(keyword_unsafe_);
+  PushBrace unsafe_brace(*this);
+  ConvertBodyStmts(dtor->getDefinition()->getBody());
+}
 
 void Converter::AddDefaultTraitForUnion(const clang::RecordDecl *decl) {
   StrCat(std::format("impl Default for {}", GetRecordName(decl)));

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -348,7 +348,7 @@ bool Converter::VisitFunctionDecl(clang::FunctionDecl *decl) {
     return false;
   }
   decl->dump(log());
-  curr_function_ = decl;
+  PushCurrFunction push_fn(*this, decl);
   std::string function_name;
   if (decl->isMain()) {
     function_name = "main_0";
@@ -935,7 +935,7 @@ bool Converter::VisitCXXMethodDecl(clang::CXXMethodDecl *decl) {
   if (!decl_ids_.insert(GetMethodID(decl)).second) {
     return false;
   }
-  curr_function_ = decl;
+  PushCurrFunction push_fn(*this, decl);
 
   if (decl->isOutOfLine() && !decl->overridden_methods().empty()) {
     return false;
@@ -995,7 +995,7 @@ bool Converter::VisitCXXConstructorDecl(clang::CXXConstructorDecl *decl) {
   if (decl->isOutOfLine() || decl->isImplicit()) {
     return false;
   }
-  curr_function_ = decl;
+  PushCurrFunction push_fn(*this, decl);
 
   if (decl->isCopyOrMoveConstructor()) {
     // FIXME: improve error handling
@@ -3283,11 +3283,9 @@ bool Converter::VisitLambdaExpr(clang::LambdaExpr *expr) {
   }
   StrCat("| {");
   EmitFunctionPreamble(expr->getLambdaClass()->getLambdaCallOperator());
-  // TODO: replace with a stack
-  auto old_function = curr_function_;
-  curr_function_ = expr->getLambdaClass()->getLambdaCallOperator();
+  PushCurrFunction push_fn(*this,
+                           expr->getLambdaClass()->getLambdaCallOperator());
   ConvertFunctionBody(curr_function_);
-  curr_function_ = old_function;
   StrCat('}');
   return false;
 }

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -854,6 +854,16 @@ protected:
 
   void dump_expr_kinds();
 
+  struct PushCurrFunction {
+    Converter &c;
+    clang::FunctionDecl *prev;
+    PushCurrFunction(Converter &c, clang::FunctionDecl *decl)
+        : c(c), prev(c.curr_function_) {
+      c.curr_function_ = decl;
+    }
+    ~PushCurrFunction() { c.curr_function_ = prev; }
+  };
+
   struct PushExprKind {
     Converter &c;
     PushExprKind(Converter &c, ExprKind k, const char *file = __builtin_FILE(),

--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -587,6 +587,43 @@ const char *GetOverloadedOperator(const clang::FunctionDecl *decl) {
   }
 }
 
+clang::CXXDestructorDecl *
+GetTranslatableDestructor(const clang::CXXRecordDecl *decl) {
+  if (!decl->hasDefinition() || !IsUserDefinedDecl(decl) ||
+      !decl->hasUserDeclaredDestructor()) {
+    return nullptr;
+  }
+  auto *dtor = decl->getDestructor();
+  if (!dtor || dtor->isImplicit() || !dtor->getDefinition() ||
+      dtor->getDefinition()->isDefaulted()) {
+    return nullptr;
+  }
+  return dtor;
+}
+
+bool TypeNeedsDestruction(clang::QualType type) {
+  if (type->isArrayType()) {
+    type = clang::QualType(type->getBaseElementTypeUnsafe(), 0);
+  }
+  auto *record = type->getAsCXXRecordDecl();
+  return record && RecordNeedsDestruction(record);
+}
+
+bool RecordNeedsDestruction(const clang::CXXRecordDecl *decl) {
+  if (!decl->hasDefinition() || !IsUserDefinedDecl(decl)) {
+    return false;
+  }
+  if (GetTranslatableDestructor(decl)) {
+    return true;
+  }
+  for (const auto *field : decl->fields()) {
+    if (TypeNeedsDestruction(field->getType())) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool IsOverloadedComparisonOperator(const clang::CXXMethodDecl *decl) {
   if (decl->isOverloadedOperator()) {
     switch (decl->getOverloadedOperator()) {

--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -589,39 +589,15 @@ const char *GetOverloadedOperator(const clang::FunctionDecl *decl) {
 
 clang::CXXDestructorDecl *
 GetTranslatableDestructor(const clang::CXXRecordDecl *decl) {
-  if (!decl->hasDefinition() || !IsUserDefinedDecl(decl) ||
-      !decl->hasUserDeclaredDestructor()) {
+  if (!IsUserDefinedDecl(decl)) {
     return nullptr;
   }
   auto *dtor = decl->getDestructor();
-  if (!dtor || dtor->isImplicit() || !dtor->getDefinition() ||
-      dtor->getDefinition()->isDefaulted()) {
+  if (!dtor || dtor->isImplicit()) {
     return nullptr;
   }
-  return dtor;
-}
-
-bool TypeNeedsDestruction(clang::QualType type) {
-  if (type->isArrayType()) {
-    type = clang::QualType(type->getBaseElementTypeUnsafe(), 0);
-  }
-  auto *record = type->getAsCXXRecordDecl();
-  return record && RecordNeedsDestruction(record);
-}
-
-bool RecordNeedsDestruction(const clang::CXXRecordDecl *decl) {
-  if (!decl->hasDefinition() || !IsUserDefinedDecl(decl)) {
-    return false;
-  }
-  if (GetTranslatableDestructor(decl)) {
-    return true;
-  }
-  for (const auto *field : decl->fields()) {
-    if (TypeNeedsDestruction(field->getType())) {
-      return true;
-    }
-  }
-  return false;
+  auto *definition = dtor->getDefinition();
+  return definition && !definition->isDefaulted() ? dtor : nullptr;
 }
 
 bool IsOverloadedComparisonOperator(const clang::CXXMethodDecl *decl) {

--- a/cpp2rust/converter/converter_lib.h
+++ b/cpp2rust/converter/converter_lib.h
@@ -122,10 +122,6 @@ bool IsOverloadedComparisonOperator(const clang::CXXMethodDecl *decl);
 clang::CXXDestructorDecl *
 GetTranslatableDestructor(const clang::CXXRecordDecl *decl);
 
-bool TypeNeedsDestruction(clang::QualType type);
-
-bool RecordNeedsDestruction(const clang::CXXRecordDecl *decl);
-
 clang::Expr *ToAddrOf(clang::ASTContext &ctx, clang::Expr *expr);
 
 std::vector<clang::CXXRecordDecl *>

--- a/cpp2rust/converter/converter_lib.h
+++ b/cpp2rust/converter/converter_lib.h
@@ -119,6 +119,13 @@ const char *GetOverloadedOperator(const clang::FunctionDecl *decl);
 
 bool IsOverloadedComparisonOperator(const clang::CXXMethodDecl *decl);
 
+clang::CXXDestructorDecl *
+GetTranslatableDestructor(const clang::CXXRecordDecl *decl);
+
+bool TypeNeedsDestruction(clang::QualType type);
+
+bool RecordNeedsDestruction(const clang::CXXRecordDecl *decl);
+
 clang::Expr *ToAddrOf(clang::ASTContext &ctx, clang::Expr *expr);
 
 std::vector<clang::CXXRecordDecl *>

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -586,7 +586,10 @@ void ConverterRefCount::AddDropTrait(const clang::CXXRecordDecl *decl) {
 
   StrCat(keyword::kImpl, "Drop for", record_name, '{');
   StrCat("fn drop(&mut self)");
-  ConvertBody(body);
+  {
+    PushCurrFunction push_fn(*this, dtor);
+    ConvertBody(body);
+  }
   StrCat('}');
 }
 

--- a/tests/unit/destructor.cpp
+++ b/tests/unit/destructor.cpp
@@ -39,22 +39,34 @@ struct Copied {
 };
 
 int main() {
-  { S s{}; }
+  {
+    S s{};
+  }
   assert(global == 1);
 
-  { S s{}; }
+  {
+    S s{};
+  }
   assert(global == 2);
 
-  { Defaulted d{}; }
+  {
+    Defaulted d{};
+  }
   assert(global == 3);
 
-  { Outer o{}; }
+  {
+    Outer o{};
+  }
   assert(global == 4);
 
-  { ArrayMember am{}; }
+  {
+    ArrayMember am{};
+  }
   assert(global == 7);
 
-  { EmptyBody e{}; }
+  {
+    EmptyBody e{};
+  }
   assert(global == 8);
 
   {

--- a/tests/unit/destructor.cpp
+++ b/tests/unit/destructor.cpp
@@ -3,9 +3,39 @@
 int global = 0;
 
 struct S {
-  ~S() {
-    global++;
-  }
+  ~S() { global++; }
+};
+
+struct Defaulted {
+  S s;
+  ~Defaulted() = default;
+};
+
+struct Middle {
+  S s;
+};
+
+struct Outer {
+  Middle m;
+};
+
+struct ArrayMember {
+  S items[3];
+};
+
+struct EmptyBody {
+  S s;
+  ~EmptyBody() {}
+};
+
+template <typename T> struct Templated {
+  T v;
+  ~Templated() { global += sizeof(T); }
+};
+
+struct Copied {
+  int v;
+  ~Copied() { global++; }
 };
 
 int main() {
@@ -14,6 +44,31 @@ int main() {
 
   { S s{}; }
   assert(global == 2);
+
+  { Defaulted d{}; }
+  assert(global == 3);
+
+  { Outer o{}; }
+  assert(global == 4);
+
+  { ArrayMember am{}; }
+  assert(global == 7);
+
+  { EmptyBody e{}; }
+  assert(global == 8);
+
+  {
+    Templated<char> tc{};
+    Templated<int> ti{};
+  }
+  assert(global == 13);
+
+  {
+    Copied a{5};
+    Copied b = a;
+    assert(b.v == 5);
+  }
+  assert(global == 15);
 
   return 0;
 }

--- a/tests/unit/destructor.cpp
+++ b/tests/unit/destructor.cpp
@@ -1,0 +1,19 @@
+#include <cassert>
+
+int global = 0;
+
+struct S {
+  ~S() {
+    global++;
+  }
+};
+
+int main() {
+  { S s{}; }
+  assert(global == 1);
+
+  { S s{}; }
+  assert(global == 2);
+
+  return 0;
+}

--- a/tests/unit/out/refcount/destructor.rs
+++ b/tests/unit/out/refcount/destructor.rs
@@ -1,0 +1,47 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+thread_local!(
+    pub static global_0: Value<i32> = Rc::new(RefCell::new(0));
+);
+#[derive(Default)]
+pub struct S {}
+impl Drop for S {
+    fn drop(&mut self) {
+        (*global_0.with(Value::clone).borrow_mut()).postfix_inc();
+    }
+}
+impl Clone for S {
+    fn clone(&self) -> Self {
+        let mut this = Self {};
+        this
+    }
+}
+impl ByteRepr for S {
+    fn byte_size() -> usize {
+        1
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {}
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {}
+    }
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    {
+        let s: Value<S> = Rc::new(RefCell::new(S {}));
+    }
+    assert!(((*global_0.with(Value::clone).borrow()) == 1));
+    {
+        let s: Value<S> = Rc::new(RefCell::new(S {}));
+    }
+    assert!(((*global_0.with(Value::clone).borrow()) == 2));
+    return 0;
+}

--- a/tests/unit/out/refcount/destructor.rs
+++ b/tests/unit/out/refcount/destructor.rs
@@ -31,6 +31,240 @@ impl ByteRepr for S {
         Self {}
     }
 }
+#[derive(Default)]
+pub struct Defaulted {
+    pub s: Value<S>,
+}
+impl Clone for Defaulted {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            s: Rc::new(RefCell::new((*self.s.borrow()).clone())),
+        };
+        this
+    }
+}
+impl ByteRepr for Defaulted {
+    fn byte_size() -> usize {
+        1
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.s.borrow()).to_bytes(&mut buf[0..1]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            s: Rc::new(RefCell::new(<S>::from_bytes(&buf[0..1]))),
+        }
+    }
+}
+#[derive(Default)]
+pub struct Middle {
+    pub s: Value<S>,
+}
+impl Clone for Middle {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            s: Rc::new(RefCell::new((*self.s.borrow()).clone())),
+        };
+        this
+    }
+}
+impl ByteRepr for Middle {
+    fn byte_size() -> usize {
+        1
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.s.borrow()).to_bytes(&mut buf[0..1]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            s: Rc::new(RefCell::new(<S>::from_bytes(&buf[0..1]))),
+        }
+    }
+}
+#[derive(Default)]
+pub struct Outer {
+    pub m: Value<Middle>,
+}
+impl Clone for Outer {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            m: Rc::new(RefCell::new((*self.m.borrow()).clone())),
+        };
+        this
+    }
+}
+impl ByteRepr for Outer {
+    fn byte_size() -> usize {
+        1
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.m.borrow()).to_bytes(&mut buf[0..1]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            m: Rc::new(RefCell::new(<Middle>::from_bytes(&buf[0..1]))),
+        }
+    }
+}
+#[derive()]
+pub struct ArrayMember {
+    pub items: Value<Box<[S]>>,
+}
+impl Clone for ArrayMember {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            items: Rc::new(RefCell::new((*self.items.borrow()).clone())),
+        };
+        this
+    }
+}
+impl Default for ArrayMember {
+    fn default() -> Self {
+        ArrayMember {
+            items: Rc::new(RefCell::new(
+                (0..3).map(|_| <S>::default()).collect::<Box<[S]>>(),
+            )),
+        }
+    }
+}
+impl ByteRepr for ArrayMember {
+    fn byte_size() -> usize {
+        3
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.items.borrow()).to_bytes(&mut buf[0..3]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            items: Rc::new(RefCell::new(<Box<[S]>>::from_bytes(&buf[0..3]))),
+        }
+    }
+}
+#[derive(Default)]
+pub struct EmptyBody {
+    pub s: Value<S>,
+}
+impl Clone for EmptyBody {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            s: Rc::new(RefCell::new((*self.s.borrow()).clone())),
+        };
+        this
+    }
+}
+impl ByteRepr for EmptyBody {
+    fn byte_size() -> usize {
+        1
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.s.borrow()).to_bytes(&mut buf[0..1]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            s: Rc::new(RefCell::new(<S>::from_bytes(&buf[0..1]))),
+        }
+    }
+}
+#[derive(Default)]
+pub struct Templated_char_ {
+    pub v: Value<u8>,
+}
+impl Drop for Templated_char_ {
+    fn drop(&mut self) {
+        {
+            let rhs_0 = (((*global_0.with(Value::clone).borrow()) as usize)
+                .wrapping_add((::std::mem::size_of::<u8>() as usize)))
+                as i32;
+            (*global_0.with(Value::clone).borrow_mut()) = rhs_0
+        };
+    }
+}
+impl Clone for Templated_char_ {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            v: Rc::new(RefCell::new((*self.v.borrow()))),
+        };
+        this
+    }
+}
+impl ByteRepr for Templated_char_ {
+    fn byte_size() -> usize {
+        1
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.v.borrow()).to_bytes(&mut buf[0..1]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            v: Rc::new(RefCell::new(<u8>::from_bytes(&buf[0..1]))),
+        }
+    }
+}
+#[derive(Default)]
+pub struct Templated_int_ {
+    pub v: Value<i32>,
+}
+impl Drop for Templated_int_ {
+    fn drop(&mut self) {
+        {
+            let rhs_0 = (((*global_0.with(Value::clone).borrow()) as usize)
+                .wrapping_add((::std::mem::size_of::<i32>() as usize)))
+                as i32;
+            (*global_0.with(Value::clone).borrow_mut()) = rhs_0
+        };
+    }
+}
+impl Clone for Templated_int_ {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            v: Rc::new(RefCell::new((*self.v.borrow()))),
+        };
+        this
+    }
+}
+impl ByteRepr for Templated_int_ {
+    fn byte_size() -> usize {
+        4
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.v.borrow()).to_bytes(&mut buf[0..4]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            v: Rc::new(RefCell::new(<i32>::from_bytes(&buf[0..4]))),
+        }
+    }
+}
+#[derive(Default)]
+pub struct Copied {
+    pub v: Value<i32>,
+}
+impl Drop for Copied {
+    fn drop(&mut self) {
+        (*global_0.with(Value::clone).borrow_mut()).postfix_inc();
+    }
+}
+impl Clone for Copied {
+    fn clone(&self) -> Self {
+        let mut this = Self {
+            v: Rc::new(RefCell::new((*self.v.borrow()))),
+        };
+        this
+    }
+}
+impl ByteRepr for Copied {
+    fn byte_size() -> usize {
+        4
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.v.borrow()).to_bytes(&mut buf[0..4]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            v: Rc::new(RefCell::new(<i32>::from_bytes(&buf[0..4]))),
+        }
+    }
+}
 pub fn main() {
     std::process::exit(main_0());
 }
@@ -43,5 +277,48 @@ fn main_0() -> i32 {
         let s: Value<S> = Rc::new(RefCell::new(S {}));
     }
     assert!(((*global_0.with(Value::clone).borrow()) == 2));
+    {
+        let d: Value<Defaulted> = Rc::new(RefCell::new(Defaulted {
+            s: Rc::new(RefCell::new(S {})),
+        }));
+    }
+    assert!(((*global_0.with(Value::clone).borrow()) == 3));
+    {
+        let o: Value<Outer> = Rc::new(RefCell::new(Outer {
+            m: Rc::new(RefCell::new(Middle {
+                s: Rc::new(RefCell::new(S {})),
+            })),
+        }));
+    }
+    assert!(((*global_0.with(Value::clone).borrow()) == 4));
+    {
+        let am: Value<ArrayMember> = Rc::new(RefCell::new(ArrayMember {
+            items: Rc::new(RefCell::new(Box::new([S {}, S {}, S {}]))),
+        }));
+    }
+    assert!(((*global_0.with(Value::clone).borrow()) == 7));
+    {
+        let e: Value<EmptyBody> = Rc::new(RefCell::new(EmptyBody {
+            s: Rc::new(RefCell::new(S {})),
+        }));
+    }
+    assert!(((*global_0.with(Value::clone).borrow()) == 8));
+    {
+        let tc: Value<Templated_char_> = Rc::new(RefCell::new(Templated_char_ {
+            v: Rc::new(RefCell::new(<u8>::default())),
+        }));
+        let ti: Value<Templated_int_> = Rc::new(RefCell::new(Templated_int_ {
+            v: Rc::new(RefCell::new(<i32>::default())),
+        }));
+    }
+    assert!(((*global_0.with(Value::clone).borrow()) == 13));
+    {
+        let a: Value<Copied> = Rc::new(RefCell::new(Copied {
+            v: Rc::new(RefCell::new(5)),
+        }));
+        let b: Value<Copied> = Rc::new(RefCell::new((*a.borrow()).clone()));
+        assert!(((*(*b.borrow()).v.borrow()) == 5));
+    }
+    assert!(((*global_0.with(Value::clone).borrow()) == 15));
     return 0;
 }

--- a/tests/unit/out/unsafe/destructor.rs
+++ b/tests/unit/out/unsafe/destructor.rs
@@ -17,6 +17,82 @@ impl Drop for S {
         }
     }
 }
+#[repr(C)]
+#[derive(Clone, Default)]
+pub struct Defaulted {
+    pub s: S,
+}
+#[repr(C)]
+#[derive(Clone, Default)]
+pub struct Middle {
+    pub s: S,
+}
+#[repr(C)]
+#[derive(Clone, Default)]
+pub struct Outer {
+    pub m: Middle,
+}
+#[repr(C)]
+#[derive(Clone)]
+pub struct ArrayMember {
+    pub items: [S; 3],
+}
+impl Default for ArrayMember {
+    fn default() -> Self {
+        ArrayMember {
+            items: std::array::from_fn::<_, 3, _>(|_| <S>::default()),
+        }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Default)]
+pub struct EmptyBody {
+    pub s: S,
+}
+impl Drop for EmptyBody {
+    fn drop(&mut self) {
+        unsafe {}
+    }
+}
+#[repr(C)]
+#[derive(Clone, Default)]
+pub struct Templated_char_ {
+    pub v: libc::c_char,
+}
+impl Drop for Templated_char_ {
+    fn drop(&mut self) {
+        unsafe {
+            global_0 = ((global_0 as usize)
+                .wrapping_add((::std::mem::size_of::<libc::c_char>() as usize)))
+                as i32;
+        }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Default)]
+pub struct Templated_int_ {
+    pub v: i32,
+}
+impl Drop for Templated_int_ {
+    fn drop(&mut self) {
+        unsafe {
+            global_0 =
+                ((global_0 as usize).wrapping_add((::std::mem::size_of::<i32>() as usize))) as i32;
+        }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Default)]
+pub struct Copied {
+    pub v: i32,
+}
+impl Drop for Copied {
+    fn drop(&mut self) {
+        unsafe {
+            global_0.postfix_inc();
+        }
+    }
+}
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
@@ -31,5 +107,38 @@ unsafe fn main_0() -> i32 {
         let mut s: S = S {};
     }
     assert!(((global_0) == (2)));
+    {
+        let mut d: Defaulted = Defaulted { s: S {} };
+    }
+    assert!(((global_0) == (3)));
+    {
+        let mut o: Outer = Outer {
+            m: Middle { s: S {} },
+        };
+    }
+    assert!(((global_0) == (4)));
+    {
+        let mut am: ArrayMember = ArrayMember {
+            items: [S {}, S {}, S {}],
+        };
+    }
+    assert!(((global_0) == (7)));
+    {
+        let mut e: EmptyBody = EmptyBody { s: S {} };
+    }
+    assert!(((global_0) == (8)));
+    {
+        let mut tc: Templated_char_ = Templated_char_ {
+            v: (0 as libc::c_char),
+        };
+        let mut ti: Templated_int_ = Templated_int_ { v: 0_i32 };
+    }
+    assert!(((global_0) == (13)));
+    {
+        let mut a: Copied = Copied { v: 5 };
+        let mut b: Copied = a.clone();
+        assert!(((b.v) == (5)));
+    }
+    assert!(((global_0) == (15)));
     return 0;
 }

--- a/tests/unit/out/unsafe/destructor.rs
+++ b/tests/unit/out/unsafe/destructor.rs
@@ -1,0 +1,35 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub static mut global_0: i32 = unsafe { 0 };
+#[repr(C)]
+#[derive(Clone, Default)]
+pub struct S {}
+impl Drop for S {
+    fn drop(&mut self) {
+        unsafe {
+            global_0.postfix_inc();
+        }
+    }
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    {
+        let mut s: S = S {};
+    }
+    assert!(((global_0) == (1)));
+    {
+        let mut s: S = S {};
+    }
+    assert!(((global_0) == (2)));
+    return 0;
+}


### PR DESCRIPTION
Fixes #310 

Furthermore, droppable types don't implement copy.