### PR TITLE
Convert late instantiated methods on `Ptr<Self>` instead of `self`

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -855,6 +855,15 @@ void Converter::EmitRustStructOrUnion(clang::RecordDecl *decl) {
   AddByteReprTrait(decl);
 }
 
+void Converter::ConvertLateInstantiatedMethods(clang::CXXRecordDecl *decl) {
+  ConvertCXXMethodDecls(
+      decl, std::format("{} {}", keyword::kImpl, GetRecordName(decl)),
+      [](auto *method) {
+        return IsEmittableMethod(method) && method->hasBody() &&
+               !decl_ids_.contains(GetMethodID(method));
+      });
+}
+
 void Converter::ConvertCXXRecordMethods(clang::CXXRecordDecl *decl) {
   ConvertCXXMethodDecls(
       decl, std::format("{} {}", keyword::kImpl, GetRecordName(decl)),
@@ -941,12 +950,7 @@ bool Converter::VisitCXXRecordDecl(clang::CXXRecordDecl *decl) {
     if (!record_decls_.MarkDefined(GetRecordName(decl))) {
       // Other translation units may instantiate members this one did not.
       if (clang::isa<clang::ClassTemplateSpecializationDecl>(decl)) {
-        ConvertCXXMethodDecls(
-            decl, std::format("{} {}", keyword::kImpl, GetRecordName(decl)),
-            [](auto *method) {
-              return IsEmittableMethod(method) && method->hasBody() &&
-                     !decl_ids_.contains(GetMethodID(method));
-            });
+        ConvertLateInstantiatedMethods(decl);
       }
       return false;
     }

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -26,8 +26,7 @@ std::unordered_set<std::string> Converter::decl_ids_;
 std::unordered_set<std::string> Converter::globals_;
 std::unordered_set<std::string> Converter::abstract_structs_;
 Converter::RecordIndex Converter::record_decls_;
-std::map<Converter::DeferredImplHeader, Converter::DeferredImplBody>
-    Converter::deferred_impls_;
+std::map<std::string, Converter::MethodsOnPtr> Converter::methods_on_ptr_;
 
 void Converter::ConvertUniquePtrDeref(clang::CXXOperatorCallExpr *expr) {
   bool is_star = expr->getOperator() == clang::OverloadedOperatorKind::OO_Star;
@@ -58,12 +57,16 @@ use std::rc::Rc;
 )");
 }
 
-std::string Converter::EmitDeferredImpls() {
+std::string Converter::EmitMethodsOnPtr() {
   std::string out;
-  for (const auto &[header, body] : deferred_impls_) {
-    out += header;
+  for (const auto &[name, methods] : methods_on_ptr_) {
+    out += methods.trait_header;
     out += " {\n";
-    out += body;
+    out += methods.trait_body;
+    out += "}\n";
+    out += methods.impl_header;
+    out += " {\n";
+    out += methods.impl_body;
     out += "}\n";
   }
   return out;

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -54,7 +54,7 @@ public:
 
   static std::string EmitOpaqueRecords();
 
-  static std::string EmitDeferredImpls();
+  static std::string EmitMethodsOnPtr();
 
   virtual bool VisitBuiltinType(clang::BuiltinType *type);
 
@@ -847,9 +847,15 @@ protected:
     std::unordered_map<std::string, bool> entries_;
   };
   static RecordIndex record_decls_;
-  using DeferredImplHeader = std::string;
-  using DeferredImplBody = std::string;
-  static std::map<DeferredImplHeader, DeferredImplBody> deferred_impls_;
+  struct MethodsOnPtr {
+    std::string trait_header;
+    std::string trait_body;
+    std::string impl_header;
+    std::string impl_body;
+  };
+  // record name -> trait and impl for Ptr<record>, emitted after all
+  // translation units.
+  static std::map<std::string, MethodsOnPtr> methods_on_ptr_;
 
   enum class ExprKind : uint8_t {
     Callee,

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -133,6 +133,7 @@ public:
   std::string GetMethodName(const clang::CXXMethodDecl *decl);
   virtual std::string GetSelfMaybeWithMut(const clang::CXXMethodDecl *decl);
   virtual void ConvertCXXRecordMethods(clang::CXXRecordDecl *decl);
+  virtual void ConvertLateInstantiatedMethods(clang::CXXRecordDecl *decl);
   virtual std::string DestroyMembers(const clang::CXXRecordDecl *decl);
   virtual void EmitScopedDestructor(const clang::VarDecl *decl);
   void EmitDeallocation(clang::CXXDeleteExpr *expr,

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -2604,15 +2604,16 @@ ConverterRefCount::TraitName(const clang::CXXRecordDecl *decl) const {
   return GetRecordName(decl) + "Impl";
 }
 
-std::string
-ConverterRefCount::TraitHeader(const clang::CXXRecordDecl *decl) const {
-  return std::format("pub trait {}", TraitName(decl));
-}
-
-std::string
-ConverterRefCount::ImplHeader(const clang::CXXRecordDecl *decl) const {
-  return std::format("impl {} for Ptr<{}>", TraitName(decl),
-                     GetRecordName(decl));
+Converter::MethodsOnPtr &
+ConverterRefCount::MethodsOnPtrFor(const clang::CXXRecordDecl *decl) {
+  auto name = GetRecordName(decl);
+  auto [it, inserted] = methods_on_ptr_.try_emplace(name);
+  if (inserted) {
+    it->second.trait_header = std::format("pub trait {}", TraitName(decl));
+    it->second.impl_header =
+        std::format("impl {} for Ptr<{}>", TraitName(decl), name);
+  }
+  return it->second;
 }
 
 bool ConverterRefCount::ConvertOutOfLineMethod(clang::CXXMethodDecl *decl) {
@@ -2624,7 +2625,7 @@ bool ConverterRefCount::ConvertOutOfLineMethod(clang::CXXMethodDecl *decl) {
     PushMethodTarget push(*this, MethodTarget::PtrImpl);
     ConvertCXXMethodDecl(decl);
   }
-  deferred_impls_[ImplHeader(decl->getParent())] += std::move(buf).str();
+  MethodsOnPtrFor(decl->getParent()).impl_body += std::move(buf).str();
   return false;
 }
 
@@ -2637,7 +2638,7 @@ void ConverterRefCount::ConvertMethodOnPtr(clang::CXXMethodDecl *method) {
       PushMethodTarget push(*this, MethodTarget::TraitDecl);
       ConvertCXXMethodDecl(method);
     }
-    deferred_impls_[TraitHeader(record)] += std::move(buf).str();
+    MethodsOnPtrFor(record).trait_body += std::move(buf).str();
   }
   if (!method->isThisDeclarationADefinition()) {
     return;
@@ -2647,7 +2648,7 @@ void ConverterRefCount::ConvertMethodOnPtr(clang::CXXMethodDecl *method) {
     PushMethodTarget push(*this, MethodTarget::PtrImpl);
     VisitCXXMethodDecl(method);
   }
-  deferred_impls_[ImplHeader(record)] += std::move(buf).str();
+  MethodsOnPtrFor(record).impl_body += std::move(buf).str();
 }
 
 void ConverterRefCount::ConvertLateInstantiatedMethods(
@@ -2683,9 +2684,9 @@ void ConverterRefCount::ConvertCXXRecordMethods(clang::CXXRecordDecl *decl) {
   }
 
   if (!GetUserDefinedDestructor(decl) && HasFieldsNeedingDestruction(decl)) {
-    deferred_impls_[TraitHeader(decl)] +=
+    MethodsOnPtrFor(decl).trait_body +=
         std::format("fn {}(&self);\n", kDestructorName);
-    deferred_impls_[ImplHeader(decl)] += std::format(
+    MethodsOnPtrFor(decl).impl_body += std::format(
         "fn {}(&self) {{ {} }}\n", kDestructorName, DestroyMembers(decl));
   }
 }

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -2605,6 +2605,11 @@ ConverterRefCount::TraitName(const clang::CXXRecordDecl *decl) const {
 }
 
 std::string
+ConverterRefCount::TraitHeader(const clang::CXXRecordDecl *decl) const {
+  return std::format("pub trait {}", TraitName(decl));
+}
+
+std::string
 ConverterRefCount::ImplHeader(const clang::CXXRecordDecl *decl) const {
   return std::format("impl {} for Ptr<{}>", TraitName(decl),
                      GetRecordName(decl));
@@ -2623,6 +2628,45 @@ bool ConverterRefCount::ConvertOutOfLineMethod(clang::CXXMethodDecl *decl) {
   return false;
 }
 
+void ConverterRefCount::ConvertMethodOnPtr(clang::CXXMethodDecl *method) {
+  auto *record = method->getParent();
+  {
+    Buffer buf(*this);
+    {
+      PushCurrFunction push_fn(*this, method);
+      PushMethodTarget push(*this, MethodTarget::TraitDecl);
+      ConvertCXXMethodDecl(method);
+    }
+    deferred_impls_[TraitHeader(record)] += std::move(buf).str();
+  }
+  if (!method->isThisDeclarationADefinition()) {
+    return;
+  }
+  Buffer buf(*this);
+  {
+    PushMethodTarget push(*this, MethodTarget::PtrImpl);
+    VisitCXXMethodDecl(method);
+  }
+  deferred_impls_[ImplHeader(record)] += std::move(buf).str();
+}
+
+void ConverterRefCount::ConvertLateInstantiatedMethods(
+    clang::CXXRecordDecl *decl) {
+  Converter::ConvertCXXMethodDecls(
+      decl, std::format("{} {}", keyword::kImpl, GetRecordName(decl)),
+      [](auto *method) {
+        return IsEmittableMethod(method) && method->hasBody() &&
+               !IsMethodOnPtr(method) &&
+               !decl_ids_.contains(GetMethodID(method));
+      });
+  for (auto *method : decl->methods()) {
+    if (IsEmittableMethod(method) && method->hasBody() &&
+        IsMethodOnPtr(method) && !decl_ids_.contains(GetMethodID(method))) {
+      ConvertMethodOnPtr(method);
+    }
+  }
+}
+
 void ConverterRefCount::ConvertCXXRecordMethods(clang::CXXRecordDecl *decl) {
   auto struct_name = GetRecordName(decl);
 
@@ -2632,42 +2676,16 @@ void ConverterRefCount::ConvertCXXRecordMethods(clang::CXXRecordDecl *decl) {
                                  !IsMethodOnPtr(method);
                         });
 
-  bool synthesize_dtor =
-      !GetUserDefinedDestructor(decl) && HasFieldsNeedingDestruction(decl);
-  if (!synthesize_dtor &&
-      !std::ranges::any_of(decl->methods(), [](auto *method) {
-        return IsMethodOnPtr(method) && method->getDefinition();
-      })) {
-    return;
-  }
-
-  auto header = ImplHeader(decl);
-  StrCat(keyword::kPub, keyword::kTrait, TraitName(decl));
-  PushBrace trait_brace(*this);
-
   for (auto *method : decl->methods()) {
-    if (!IsMethodOnPtr(method) || !method->getDefinition()) {
-      continue;
+    if (IsMethodOnPtr(method) && method->getDefinition()) {
+      ConvertMethodOnPtr(method);
     }
-    {
-      PushCurrFunction push_fn(*this, method);
-      PushMethodTarget push(*this, MethodTarget::TraitDecl);
-      ConvertCXXMethodDecl(method);
-    }
-    if (!method->isThisDeclarationADefinition()) {
-      continue;
-    }
-    Buffer buf(*this);
-    {
-      PushMethodTarget push(*this, MethodTarget::PtrImpl);
-      VisitCXXMethodDecl(method);
-    }
-    deferred_impls_[header] += std::move(buf).str();
   }
 
-  if (synthesize_dtor) {
-    StrCat(std::format("fn {}(&self)", kDestructorName), token::kSemiColon);
-    deferred_impls_[header] += std::format(
+  if (!GetUserDefinedDestructor(decl) && HasFieldsNeedingDestruction(decl)) {
+    deferred_impls_[TraitHeader(decl)] +=
+        std::format("fn {}(&self);\n", kDestructorName);
+    deferred_impls_[ImplHeader(decl)] += std::format(
         "fn {}(&self) {{ {} }}\n", kDestructorName, DestroyMembers(decl));
   }
 }

--- a/cpp2rust/converter/models/converter_refcount.h
+++ b/cpp2rust/converter/models/converter_refcount.h
@@ -219,8 +219,7 @@ public:
 
 private:
   std::string TraitName(const clang::CXXRecordDecl *decl) const;
-  std::string TraitHeader(const clang::CXXRecordDecl *decl) const;
-  std::string ImplHeader(const clang::CXXRecordDecl *decl) const;
+  MethodsOnPtr &MethodsOnPtrFor(const clang::CXXRecordDecl *decl);
   std::string DestroyMembers(const clang::CXXRecordDecl *decl) override;
   void EmitScopedDestructor(const clang::VarDecl *decl) override;
 

--- a/cpp2rust/converter/models/converter_refcount.h
+++ b/cpp2rust/converter/models/converter_refcount.h
@@ -60,6 +60,10 @@ public:
 
   void ConvertCXXRecordMethods(clang::CXXRecordDecl *decl) override;
 
+  void ConvertLateInstantiatedMethods(clang::CXXRecordDecl *decl) override;
+
+  void ConvertMethodOnPtr(clang::CXXMethodDecl *method);
+
   bool VisitCXXThisExpr(clang::CXXThisExpr *expr) override;
 
   bool ThisIsRustPtr() const override;
@@ -215,6 +219,7 @@ public:
 
 private:
   std::string TraitName(const clang::CXXRecordDecl *decl) const;
+  std::string TraitHeader(const clang::CXXRecordDecl *decl) const;
   std::string ImplHeader(const clang::CXXRecordDecl *decl) const;
   std::string DestroyMembers(const clang::CXXRecordDecl *decl) override;
   void EmitScopedDestructor(const clang::VarDecl *decl) override;

--- a/cpp2rust/cpp2rust_lib.cpp
+++ b/cpp2rust/cpp2rust_lib.cpp
@@ -31,7 +31,7 @@ std::string TranspileSrc(std::string_view cc_code, Model model,
       cc_code, tool_args, std::filesystem::path(filename).filename().string(),
       filename.ends_with(".c") ? CLANG_C_COMPILER : CLANG_CXX_COMPILER);
   rs_code += Converter::EmitOpaqueRecords();
-  rs_code += Converter::EmitDeferredImpls();
+  rs_code += Converter::EmitMethodsOnPtr();
   return rs_code;
 }
 
@@ -72,7 +72,7 @@ std::string TranspileDir(std::string_view build_dir, Model model,
   FrontendActionFactory factory(rs_code, model, rules_dir);
   Tool.run(&factory);
   rs_code += Converter::EmitOpaqueRecords();
-  rs_code += Converter::EmitDeferredImpls();
+  rs_code += Converter::EmitMethodsOnPtr();
   return rs_code;
 }
 } // namespace cpp2rust

--- a/tests/multi-file/template_method_late_instantiation/CMakeLists.txt
+++ b/tests/multi-file/template_method_late_instantiation/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.16)
+project(template_method_late_instantiation LANGUAGES CXX)
+add_executable(app a.cpp b.cpp)

--- a/tests/multi-file/template_method_late_instantiation/a.cpp
+++ b/tests/multi-file/template_method_late_instantiation/a.cpp
@@ -1,0 +1,10 @@
+#include <assert.h>
+
+#include "s.h"
+
+int main() {
+  S<int> p;
+  p.set(3);
+  assert(f(&p) == 3);
+  return 0;
+}

--- a/tests/multi-file/template_method_late_instantiation/b.cpp
+++ b/tests/multi-file/template_method_late_instantiation/b.cpp
@@ -1,0 +1,3 @@
+#include "s.h"
+
+int f(S<int> *p) { return p->get(); }

--- a/tests/multi-file/template_method_late_instantiation/out/refcount/template_method_late_instantiation.rs
+++ b/tests/multi-file/template_method_late_instantiation/out/refcount/template_method_late_instantiation.rs
@@ -1,0 +1,60 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+#[derive(Default)]
+pub struct S_int_ {
+    pub x: Value<i32>,
+}
+impl Clone for S_int_ {
+    fn clone(&self) -> Self {
+        let __this: Value<S_int_> = Rc::new(RefCell::new(Self {
+            x: Rc::new(RefCell::new((*self.x.borrow()))),
+        }));
+        let this: Ptr<S_int_> = __this.as_pointer();
+        Rc::try_unwrap(__this).ok().unwrap().into_inner()
+    }
+}
+impl ByteRepr for S_int_ {
+    fn byte_size() -> usize {
+        4
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.x.borrow()).to_bytes(&mut buf[0..4]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            x: Rc::new(RefCell::new(<i32>::from_bytes(&buf[0..4]))),
+        }
+    }
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let p: Value<S_int_> = Rc::new(RefCell::new(<S_int_>::default()));
+    ({ S_int_Impl::set(&p.as_pointer(), 3) });
+    assert!((({ f_0((p.as_pointer()),) }) == 3));
+    return 0;
+}
+pub fn f_0(p: Ptr<S_int_>) -> i32 {
+    let p: Value<Ptr<S_int_>> = Rc::new(RefCell::new(p));
+    return ({ S_int_Impl::get(&(*p.borrow())) });
+}
+impl S_int_Impl for Ptr<S_int_> {
+    fn set(&self, v: i32) {
+        let v: Value<i32> = Rc::new(RefCell::new(v));
+        (*(*(*self).upgrade().deref()).x.borrow_mut()) = (*v.borrow());
+    }
+    fn get(&self) -> i32 {
+        return (*(*(*self).upgrade().deref()).x.borrow());
+    }
+}
+pub trait S_int_Impl {
+    fn set(&self, v: i32);
+    fn get(&self) -> i32;
+}

--- a/tests/multi-file/template_method_late_instantiation/out/refcount/template_method_late_instantiation.rs
+++ b/tests/multi-file/template_method_late_instantiation/out/refcount/template_method_late_instantiation.rs
@@ -45,6 +45,10 @@ pub fn f_0(p: Ptr<S_int_>) -> i32 {
     let p: Value<Ptr<S_int_>> = Rc::new(RefCell::new(p));
     return ({ S_int_Impl::get(&(*p.borrow())) });
 }
+pub trait S_int_Impl {
+    fn set(&self, v: i32);
+    fn get(&self) -> i32;
+}
 impl S_int_Impl for Ptr<S_int_> {
     fn set(&self, v: i32) {
         let v: Value<i32> = Rc::new(RefCell::new(v));
@@ -53,8 +57,4 @@ impl S_int_Impl for Ptr<S_int_> {
     fn get(&self) -> i32 {
         return (*(*(*self).upgrade().deref()).x.borrow());
     }
-}
-pub trait S_int_Impl {
-    fn set(&self, v: i32);
-    fn get(&self) -> i32;
 }

--- a/tests/multi-file/template_method_late_instantiation/out/unsafe/template_method_late_instantiation.rs
+++ b/tests/multi-file/template_method_late_instantiation/out/unsafe/template_method_late_instantiation.rs
@@ -1,0 +1,37 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct S_int_ {
+    pub x: i32,
+}
+impl S_int_ {
+    pub unsafe fn set(&mut self, mut v: i32) {
+        self.x = v;
+    }
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut p: S_int_ = <S_int_>::default();
+    (unsafe { S_int_::set(&mut p, 3) });
+    assert!(((unsafe { f_0((&mut p as *mut S_int_),) }) == (3)));
+    return 0;
+}
+impl S_int_ {
+    pub unsafe fn get(&mut self) -> i32 {
+        return self.x;
+    }
+}
+pub unsafe fn f_0(mut p: *mut S_int_) -> i32 {
+    return (unsafe { S_int_::get(&mut (*p)) });
+}

--- a/tests/multi-file/template_method_late_instantiation/s.h
+++ b/tests/multi-file/template_method_late_instantiation/s.h
@@ -1,0 +1,11 @@
+#pragma once
+
+template <typename T>
+struct S {
+  T x = 0;
+
+  void set(T v) { x = v; }
+  T get() { return x; }
+};
+
+int f(S<int> *p);

--- a/tests/unit/out/refcount/10_struct.rs
+++ b/tests/unit/out/refcount/10_struct.rs
@@ -76,6 +76,9 @@ fn main_0() -> i32 {
     }));
     return 0;
 }
+pub trait GraphImpl {
+    fn push(&self, src: u32, dst: u32);
+}
 impl GraphImpl for Ptr<Graph> {
     fn push(&self, src: u32, dst: u32) {
         let src: Value<u32> = Rc::new(RefCell::new(src));
@@ -105,7 +108,4 @@ impl GraphImpl for Ptr<Graph> {
             .offset((*dst.borrow()) as isize)
             .write(__rhs);
     }
-}
-pub trait GraphImpl {
-    fn push(&self, src: u32, dst: u32);
 }

--- a/tests/unit/out/refcount/10_struct.rs
+++ b/tests/unit/out/refcount/10_struct.rs
@@ -41,9 +41,6 @@ pub struct Graph {
     pub V: Value<u32>,
     pub adj: Value<Ptr<Ptr<GraphNode>>>,
 }
-pub trait GraphImpl {
-    fn push(&self, src: u32, dst: u32);
-}
 impl Clone for Graph {
     fn clone(&self) -> Self {
         let __this: Value<Graph> = Rc::new(RefCell::new(Self {
@@ -108,4 +105,7 @@ impl GraphImpl for Ptr<Graph> {
             .offset((*dst.borrow()) as isize)
             .write(__rhs);
     }
+}
+pub trait GraphImpl {
+    fn push(&self, src: u32, dst: u32);
 }

--- a/tests/unit/out/refcount/class.rs
+++ b/tests/unit/out/refcount/class.rs
@@ -11,14 +11,6 @@ pub struct Pair {
     pub first: Value<i32>,
     pub second: Value<i32>,
 }
-pub trait PairImpl {
-    fn NOP(&self);
-    fn GetFirst(&self) -> i32;
-    fn GetSecond(&self) -> i32;
-    fn Set(&self, field: Ptr<i32>, new_val: i32) -> i32;
-    fn SetFirst(&self, new_first: i32) -> i32;
-    fn SetSecond(&self, new_second: i32) -> i32;
-}
 impl Clone for Pair {
     fn clone(&self) -> Self {
         let __this: Value<Pair> = Rc::new(RefCell::new(Self {
@@ -48,9 +40,6 @@ impl ByteRepr for Pair {
 pub struct Route {
     pub path: Value<Pair>,
     pub cost: Value<f64>,
-}
-pub trait RouteImpl {
-    fn SetCost(&self, new_cost: f64) -> f64;
 }
 impl Clone for Route {
     fn clone(&self) -> Self {
@@ -168,4 +157,15 @@ impl RouteImpl for Ptr<Route> {
         (*(*(*self).upgrade().deref()).cost.borrow_mut()) = (*new_cost.borrow());
         return (*old_cost.borrow());
     }
+}
+pub trait PairImpl {
+    fn NOP(&self);
+    fn GetFirst(&self) -> i32;
+    fn GetSecond(&self) -> i32;
+    fn Set(&self, field: Ptr<i32>, new_val: i32) -> i32;
+    fn SetFirst(&self, new_first: i32) -> i32;
+    fn SetSecond(&self, new_second: i32) -> i32;
+}
+pub trait RouteImpl {
+    fn SetCost(&self, new_cost: f64) -> f64;
 }

--- a/tests/unit/out/refcount/class.rs
+++ b/tests/unit/out/refcount/class.rs
@@ -116,6 +116,14 @@ fn main_0() -> i32 {
     );
     return 0;
 }
+pub trait PairImpl {
+    fn NOP(&self);
+    fn GetFirst(&self) -> i32;
+    fn GetSecond(&self) -> i32;
+    fn Set(&self, field: Ptr<i32>, new_val: i32) -> i32;
+    fn SetFirst(&self, new_first: i32) -> i32;
+    fn SetSecond(&self, new_second: i32) -> i32;
+}
 impl PairImpl for Ptr<Pair> {
     fn NOP(&self) {}
     fn GetFirst(&self) -> i32 {
@@ -149,6 +157,9 @@ impl PairImpl for Ptr<Pair> {
             }));
     }
 }
+pub trait RouteImpl {
+    fn SetCost(&self, new_cost: f64) -> f64;
+}
 impl RouteImpl for Ptr<Route> {
     fn SetCost(&self, new_cost: f64) -> f64 {
         let new_cost: Value<f64> = Rc::new(RefCell::new(new_cost));
@@ -157,15 +168,4 @@ impl RouteImpl for Ptr<Route> {
         (*(*(*self).upgrade().deref()).cost.borrow_mut()) = (*new_cost.borrow());
         return (*old_cost.borrow());
     }
-}
-pub trait PairImpl {
-    fn NOP(&self);
-    fn GetFirst(&self) -> i32;
-    fn GetSecond(&self) -> i32;
-    fn Set(&self, field: Ptr<i32>, new_val: i32) -> i32;
-    fn SetFirst(&self, new_first: i32) -> i32;
-    fn SetSecond(&self, new_second: i32) -> i32;
-}
-pub trait RouteImpl {
-    fn SetCost(&self, new_cost: f64) -> f64;
 }

--- a/tests/unit/out/refcount/class_template_lazy_member.rs
+++ b/tests/unit/out/refcount/class_template_lazy_member.rs
@@ -100,20 +100,20 @@ fn main_0() -> i32 {
     assert!(((*({ Box_Point_Impl::get(&p.as_pointer(),) }).x.borrow()) == 4));
     return 0;
 }
+pub trait Box_Point_Impl {
+    fn get(&self) -> Point;
+}
 impl Box_Point_Impl for Ptr<Box_Point_> {
     fn get(&self) -> Point {
         return (*(*(*self).upgrade().deref()).val.borrow()).clone();
     }
+}
+pub trait Box_int_Impl {
+    fn twice(&self) -> i32;
 }
 impl Box_int_Impl for Ptr<Box_int_> {
     fn twice(&self) -> i32 {
         return ((*(*(*self).upgrade().deref()).val.borrow())
             + (*(*(*self).upgrade().deref()).val.borrow()));
     }
-}
-pub trait Box_Point_Impl {
-    fn get(&self) -> Point;
-}
-pub trait Box_int_Impl {
-    fn twice(&self) -> i32;
 }

--- a/tests/unit/out/refcount/class_template_lazy_member.rs
+++ b/tests/unit/out/refcount/class_template_lazy_member.rs
@@ -36,9 +36,6 @@ impl ByteRepr for Point {
 pub struct Box_int_ {
     pub val: Value<i32>,
 }
-pub trait Box_int_Impl {
-    fn twice(&self) -> i32;
-}
 impl Clone for Box_int_ {
     fn clone(&self) -> Self {
         let __this: Value<Box_int_> = Rc::new(RefCell::new(Self {
@@ -64,9 +61,6 @@ impl ByteRepr for Box_int_ {
 #[derive(Default)]
 pub struct Box_Point_ {
     pub val: Value<Point>,
-}
-pub trait Box_Point_Impl {
-    fn get(&self) -> Point;
 }
 impl Clone for Box_Point_ {
     fn clone(&self) -> Self {
@@ -116,4 +110,10 @@ impl Box_int_Impl for Ptr<Box_int_> {
         return ((*(*(*self).upgrade().deref()).val.borrow())
             + (*(*(*self).upgrade().deref()).val.borrow()));
     }
+}
+pub trait Box_Point_Impl {
+    fn get(&self) -> Point;
+}
+pub trait Box_int_Impl {
+    fn twice(&self) -> i32;
 }

--- a/tests/unit/out/refcount/class_templates.rs
+++ b/tests/unit/out/refcount/class_templates.rs
@@ -127,6 +127,13 @@ fn main_0() -> i32 {
     assert!(({ MyContainer_float_Impl::empty(&fmc.as_pointer(),) }));
     return 0;
 }
+pub trait MyContainer_char_Impl {
+    fn empty(&self) -> bool;
+    fn size(&self) -> usize;
+    fn back(&self) -> Ptr<u8>;
+    fn pop_back(&self);
+    fn push_back(&self, item: Ptr<u8>);
+}
 impl MyContainer_char_Impl for Ptr<MyContainer_char_> {
     fn empty(&self) -> bool {
         return (*(*(*self).upgrade().deref()).vec_.borrow()).is_empty();
@@ -147,6 +154,13 @@ impl MyContainer_char_Impl for Ptr<MyContainer_char_> {
             (*(*(*self).upgrade().deref()).vec_.borrow_mut()).push(a0_clone)
         };
     }
+}
+pub trait MyContainer_float_Impl {
+    fn empty(&self) -> bool;
+    fn size(&self) -> usize;
+    fn back(&self) -> Ptr<f32>;
+    fn pop_back(&self);
+    fn push_back(&self, item: Ptr<f32>);
 }
 impl MyContainer_float_Impl for Ptr<MyContainer_float_> {
     fn empty(&self) -> bool {
@@ -169,6 +183,13 @@ impl MyContainer_float_Impl for Ptr<MyContainer_float_> {
         };
     }
 }
+pub trait MyContainer_int_Impl {
+    fn empty(&self) -> bool;
+    fn size(&self) -> usize;
+    fn back(&self) -> Ptr<i32>;
+    fn pop_back(&self);
+    fn push_back(&self, item: Ptr<i32>);
+}
 impl MyContainer_int_Impl for Ptr<MyContainer_int_> {
     fn empty(&self) -> bool {
         return (*(*(*self).upgrade().deref()).vec_.borrow()).is_empty();
@@ -189,25 +210,4 @@ impl MyContainer_int_Impl for Ptr<MyContainer_int_> {
             (*(*(*self).upgrade().deref()).vec_.borrow_mut()).push(a0_clone)
         };
     }
-}
-pub trait MyContainer_char_Impl {
-    fn empty(&self) -> bool;
-    fn size(&self) -> usize;
-    fn back(&self) -> Ptr<u8>;
-    fn pop_back(&self);
-    fn push_back(&self, item: Ptr<u8>);
-}
-pub trait MyContainer_float_Impl {
-    fn empty(&self) -> bool;
-    fn size(&self) -> usize;
-    fn back(&self) -> Ptr<f32>;
-    fn pop_back(&self);
-    fn push_back(&self, item: Ptr<f32>);
-}
-pub trait MyContainer_int_Impl {
-    fn empty(&self) -> bool;
-    fn size(&self) -> usize;
-    fn back(&self) -> Ptr<i32>;
-    fn pop_back(&self);
-    fn push_back(&self, item: Ptr<i32>);
 }

--- a/tests/unit/out/refcount/class_templates.rs
+++ b/tests/unit/out/refcount/class_templates.rs
@@ -10,13 +10,6 @@ use std::rc::{Rc, Weak};
 pub struct MyContainer_int_ {
     vec_: Value<Vec<i32>>,
 }
-pub trait MyContainer_int_Impl {
-    fn empty(&self) -> bool;
-    fn size(&self) -> usize;
-    fn back(&self) -> Ptr<i32>;
-    fn pop_back(&self);
-    fn push_back(&self, item: Ptr<i32>);
-}
 impl Clone for MyContainer_int_ {
     fn clone(&self) -> Self {
         let __this: Value<MyContainer_int_> = Rc::new(RefCell::new(Self {
@@ -43,13 +36,6 @@ impl ByteRepr for MyContainer_int_ {
 pub struct MyContainer_char_ {
     vec_: Value<Vec<u8>>,
 }
-pub trait MyContainer_char_Impl {
-    fn empty(&self) -> bool;
-    fn size(&self) -> usize;
-    fn back(&self) -> Ptr<u8>;
-    fn pop_back(&self);
-    fn push_back(&self, item: Ptr<u8>);
-}
 impl Clone for MyContainer_char_ {
     fn clone(&self) -> Self {
         let __this: Value<MyContainer_char_> = Rc::new(RefCell::new(Self {
@@ -75,13 +61,6 @@ impl ByteRepr for MyContainer_char_ {
 #[derive(Default)]
 pub struct MyContainer_float_ {
     vec_: Value<Vec<f32>>,
-}
-pub trait MyContainer_float_Impl {
-    fn empty(&self) -> bool;
-    fn size(&self) -> usize;
-    fn back(&self) -> Ptr<f32>;
-    fn pop_back(&self);
-    fn push_back(&self, item: Ptr<f32>);
 }
 impl Clone for MyContainer_float_ {
     fn clone(&self) -> Self {
@@ -210,4 +189,25 @@ impl MyContainer_int_Impl for Ptr<MyContainer_int_> {
             (*(*(*self).upgrade().deref()).vec_.borrow_mut()).push(a0_clone)
         };
     }
+}
+pub trait MyContainer_char_Impl {
+    fn empty(&self) -> bool;
+    fn size(&self) -> usize;
+    fn back(&self) -> Ptr<u8>;
+    fn pop_back(&self);
+    fn push_back(&self, item: Ptr<u8>);
+}
+pub trait MyContainer_float_Impl {
+    fn empty(&self) -> bool;
+    fn size(&self) -> usize;
+    fn back(&self) -> Ptr<f32>;
+    fn pop_back(&self);
+    fn push_back(&self, item: Ptr<f32>);
+}
+pub trait MyContainer_int_Impl {
+    fn empty(&self) -> bool;
+    fn size(&self) -> usize;
+    fn back(&self) -> Ptr<i32>;
+    fn pop_back(&self);
+    fn push_back(&self, item: Ptr<i32>);
 }

--- a/tests/unit/out/refcount/complex_function.rs
+++ b/tests/unit/out/refcount/complex_function.rs
@@ -47,9 +47,6 @@ impl ByteRepr for X1 {
 pub struct X2 {
     pub v: Ptr<X1>,
 }
-pub trait X2Impl {
-    fn get(&self) -> Ptr<X1>;
-}
 impl Clone for X2 {
     fn clone(&self) -> Self {
         let __this: Value<X2> = Rc::new(RefCell::new(Self {
@@ -63,9 +60,6 @@ impl ByteRepr for X2 {}
 #[derive(Default)]
 pub struct X3 {
     pub v: Value<Ptr<X2>>,
-}
-pub trait X3Impl {
-    fn get(&self) -> Ptr<X2>;
 }
 impl Clone for X3 {
     fn clone(&self) -> Self {
@@ -92,9 +86,6 @@ impl ByteRepr for X3 {
 #[derive(Default)]
 pub struct X4 {
     pub v: Value<X3>,
-}
-pub trait X4Impl {
-    fn get(&self) -> Ptr<X3>;
 }
 impl Clone for X4 {
     fn clone(&self) -> Self {
@@ -422,4 +413,13 @@ impl X4Impl for Ptr<X4> {
     fn get(&self) -> Ptr<X3> {
         return (*(*self).upgrade().deref()).v.as_pointer();
     }
+}
+pub trait X2Impl {
+    fn get(&self) -> Ptr<X1>;
+}
+pub trait X3Impl {
+    fn get(&self) -> Ptr<X2>;
+}
+pub trait X4Impl {
+    fn get(&self) -> Ptr<X3>;
 }

--- a/tests/unit/out/refcount/complex_function.rs
+++ b/tests/unit/out/refcount/complex_function.rs
@@ -399,27 +399,27 @@ fn main_0() -> i32 {
     );
     return 0;
 }
+pub trait X2Impl {
+    fn get(&self) -> Ptr<X1>;
+}
 impl X2Impl for Ptr<X2> {
     fn get(&self) -> Ptr<X1> {
         return ((*(*self).upgrade().deref()).v).clone();
     }
+}
+pub trait X3Impl {
+    fn get(&self) -> Ptr<X2>;
 }
 impl X3Impl for Ptr<X3> {
     fn get(&self) -> Ptr<X2> {
         return (*(*(*self).upgrade().deref()).v.borrow()).clone();
     }
 }
+pub trait X4Impl {
+    fn get(&self) -> Ptr<X3>;
+}
 impl X4Impl for Ptr<X4> {
     fn get(&self) -> Ptr<X3> {
         return (*(*self).upgrade().deref()).v.as_pointer();
     }
-}
-pub trait X2Impl {
-    fn get(&self) -> Ptr<X1>;
-}
-pub trait X3Impl {
-    fn get(&self) -> Ptr<X2>;
-}
-pub trait X4Impl {
-    fn get(&self) -> Ptr<X3>;
 }

--- a/tests/unit/out/refcount/constructor.rs
+++ b/tests/unit/out/refcount/constructor.rs
@@ -60,6 +60,11 @@ fn main_0() -> i32 {
     assert!(((*total_0.with(Value::clone).borrow()) == 18));
     return 0;
 }
+pub trait SImpl {
+    fn const_method(&self) -> i32;
+    fn mut_method(&self);
+    fn destructor(&self);
+}
 impl SImpl for Ptr<S> {
     fn const_method(&self) -> i32 {
         return ((*(*(*self).upgrade().deref()).v.borrow()) * 2);
@@ -71,9 +76,4 @@ impl SImpl for Ptr<S> {
         ({ SImpl::mut_method(self) });
         (*total_0.with(Value::clone).borrow_mut()) += ({ SImpl::const_method(self) });
     }
-}
-pub trait SImpl {
-    fn const_method(&self) -> i32;
-    fn mut_method(&self);
-    fn destructor(&self);
 }

--- a/tests/unit/out/refcount/constructor.rs
+++ b/tests/unit/out/refcount/constructor.rs
@@ -25,11 +25,6 @@ impl S {
         Rc::try_unwrap(__this).ok().unwrap().into_inner()
     }
 }
-pub trait SImpl {
-    fn const_method(&self) -> i32;
-    fn mut_method(&self);
-    fn destructor(&self);
-}
 impl Clone for S {
     fn clone(&self) -> Self {
         let __this: Value<S> = Rc::new(RefCell::new(Self {
@@ -76,4 +71,9 @@ impl SImpl for Ptr<S> {
         ({ SImpl::mut_method(self) });
         (*total_0.with(Value::clone).borrow_mut()) += ({ SImpl::const_method(self) });
     }
+}
+pub trait SImpl {
+    fn const_method(&self) -> i32;
+    fn mut_method(&self);
+    fn destructor(&self);
 }

--- a/tests/unit/out/refcount/destructor.rs
+++ b/tests/unit/out/refcount/destructor.rs
@@ -407,6 +407,9 @@ fn main_0() -> i32 {
     assert!(((*order_1.with(Value::clone).borrow())[(2) as usize] == 1));
     return 0;
 }
+pub trait ArrayMemberImpl {
+    fn destructor(&self);
+}
 impl ArrayMemberImpl for Ptr<ArrayMember> {
     fn destructor(&self) {
         {
@@ -417,25 +420,40 @@ impl ArrayMemberImpl for Ptr<ArrayMember> {
         }
     }
 }
+pub trait CopiedImpl {
+    fn destructor(&self);
+}
 impl CopiedImpl for Ptr<Copied> {
     fn destructor(&self) {
         (*global_0.with(Value::clone).borrow_mut()).postfix_inc();
     }
+}
+pub trait DefaultedImpl {
+    fn destructor(&self);
 }
 impl DefaultedImpl for Ptr<Defaulted> {
     fn destructor(&self) {
         (*self.upgrade().deref()).s.as_pointer().destructor();
     }
 }
+pub trait EmptyBodyImpl {
+    fn destructor(&self);
+}
 impl EmptyBodyImpl for Ptr<EmptyBody> {
     fn destructor(&self) {
         (*self.upgrade().deref()).s.as_pointer().destructor();
     }
 }
+pub trait MiddleImpl {
+    fn destructor(&self);
+}
 impl MiddleImpl for Ptr<Middle> {
     fn destructor(&self) {
         (*self.upgrade().deref()).s.as_pointer().destructor();
     }
+}
+pub trait OrderedImpl {
+    fn destructor(&self);
 }
 impl OrderedImpl for Ptr<Ordered> {
     fn destructor(&self) {
@@ -444,15 +462,24 @@ impl OrderedImpl for Ptr<Ordered> {
         (*self.upgrade().deref()).first.as_pointer().destructor();
     }
 }
+pub trait OuterImpl {
+    fn destructor(&self);
+}
 impl OuterImpl for Ptr<Outer> {
     fn destructor(&self) {
         (*self.upgrade().deref()).m.as_pointer().destructor();
     }
 }
+pub trait SImpl {
+    fn destructor(&self);
+}
 impl SImpl for Ptr<S> {
     fn destructor(&self) {
         (*global_0.with(Value::clone).borrow_mut()).postfix_inc();
     }
+}
+pub trait TaggedImpl {
+    fn destructor(&self);
 }
 impl TaggedImpl for Ptr<Tagged> {
     fn destructor(&self) {
@@ -460,6 +487,9 @@ impl TaggedImpl for Ptr<Tagged> {
             [((*order_count_2.with(Value::clone).borrow_mut()).postfix_inc()) as usize] =
             (*(*(*self).upgrade().deref()).tag.borrow());
     }
+}
+pub trait Templated_char_Impl {
+    fn destructor(&self);
 }
 impl Templated_char_Impl for Ptr<Templated_char_> {
     fn destructor(&self) {
@@ -471,6 +501,9 @@ impl Templated_char_Impl for Ptr<Templated_char_> {
         };
     }
 }
+pub trait Templated_int_Impl {
+    fn destructor(&self);
+}
 impl Templated_int_Impl for Ptr<Templated_int_> {
     fn destructor(&self) {
         {
@@ -480,37 +513,4 @@ impl Templated_int_Impl for Ptr<Templated_int_> {
             (*global_0.with(Value::clone).borrow_mut()) = rhs_0
         };
     }
-}
-pub trait ArrayMemberImpl {
-    fn destructor(&self);
-}
-pub trait CopiedImpl {
-    fn destructor(&self);
-}
-pub trait DefaultedImpl {
-    fn destructor(&self);
-}
-pub trait EmptyBodyImpl {
-    fn destructor(&self);
-}
-pub trait MiddleImpl {
-    fn destructor(&self);
-}
-pub trait OrderedImpl {
-    fn destructor(&self);
-}
-pub trait OuterImpl {
-    fn destructor(&self);
-}
-pub trait SImpl {
-    fn destructor(&self);
-}
-pub trait TaggedImpl {
-    fn destructor(&self);
-}
-pub trait Templated_char_Impl {
-    fn destructor(&self);
-}
-pub trait Templated_int_Impl {
-    fn destructor(&self);
 }

--- a/tests/unit/out/refcount/destructor.rs
+++ b/tests/unit/out/refcount/destructor.rs
@@ -11,9 +11,6 @@ thread_local!(
 );
 #[derive(Default)]
 pub struct S {}
-pub trait SImpl {
-    fn destructor(&self);
-}
 impl Clone for S {
     fn clone(&self) -> Self {
         let __this: Value<S> = Rc::new(RefCell::new(Self {}));
@@ -33,9 +30,6 @@ impl ByteRepr for S {
 #[derive(Default)]
 pub struct Defaulted {
     pub s: Value<S>,
-}
-pub trait DefaultedImpl {
-    fn destructor(&self);
 }
 impl Clone for Defaulted {
     fn clone(&self) -> Self {
@@ -63,9 +57,6 @@ impl ByteRepr for Defaulted {
 pub struct Middle {
     pub s: Value<S>,
 }
-pub trait MiddleImpl {
-    fn destructor(&self);
-}
 impl Clone for Middle {
     fn clone(&self) -> Self {
         let __this: Value<Middle> = Rc::new(RefCell::new(Self {
@@ -92,9 +83,6 @@ impl ByteRepr for Middle {
 pub struct Outer {
     pub m: Value<Middle>,
 }
-pub trait OuterImpl {
-    fn destructor(&self);
-}
 impl Clone for Outer {
     fn clone(&self) -> Self {
         let __this: Value<Outer> = Rc::new(RefCell::new(Self {
@@ -120,9 +108,6 @@ impl ByteRepr for Outer {
 #[derive()]
 pub struct ArrayMember {
     pub items: Value<Box<[S]>>,
-}
-pub trait ArrayMemberImpl {
-    fn destructor(&self);
 }
 impl Clone for ArrayMember {
     fn clone(&self) -> Self {
@@ -159,9 +144,6 @@ impl ByteRepr for ArrayMember {
 pub struct EmptyBody {
     pub s: Value<S>,
 }
-pub trait EmptyBodyImpl {
-    fn destructor(&self);
-}
 impl Clone for EmptyBody {
     fn clone(&self) -> Self {
         let __this: Value<EmptyBody> = Rc::new(RefCell::new(Self {
@@ -187,9 +169,6 @@ impl ByteRepr for EmptyBody {
 #[derive(Default)]
 pub struct Templated_char_ {
     pub v: Value<u8>,
-}
-pub trait Templated_char_Impl {
-    fn destructor(&self);
 }
 impl Clone for Templated_char_ {
     fn clone(&self) -> Self {
@@ -217,9 +196,6 @@ impl ByteRepr for Templated_char_ {
 pub struct Templated_int_ {
     pub v: Value<i32>,
 }
-pub trait Templated_int_Impl {
-    fn destructor(&self);
-}
 impl Clone for Templated_int_ {
     fn clone(&self) -> Self {
         let __this: Value<Templated_int_> = Rc::new(RefCell::new(Self {
@@ -245,9 +221,6 @@ impl ByteRepr for Templated_int_ {
 #[derive(Default)]
 pub struct Copied {
     pub v: Value<i32>,
-}
-pub trait CopiedImpl {
-    fn destructor(&self);
 }
 impl Clone for Copied {
     fn clone(&self) -> Self {
@@ -283,9 +256,6 @@ thread_local!(
 pub struct Tagged {
     pub tag: Value<i32>,
 }
-pub trait TaggedImpl {
-    fn destructor(&self);
-}
 impl Clone for Tagged {
     fn clone(&self) -> Self {
         let __this: Value<Tagged> = Rc::new(RefCell::new(Self {
@@ -315,9 +285,6 @@ pub struct Ordered {
     pub second: Value<Tagged>,
     pub dummy2: Value<i32>,
     pub third: Value<Tagged>,
-}
-pub trait OrderedImpl {
-    fn destructor(&self);
 }
 impl Clone for Ordered {
     fn clone(&self) -> Self {
@@ -513,4 +480,37 @@ impl Templated_int_Impl for Ptr<Templated_int_> {
             (*global_0.with(Value::clone).borrow_mut()) = rhs_0
         };
     }
+}
+pub trait ArrayMemberImpl {
+    fn destructor(&self);
+}
+pub trait CopiedImpl {
+    fn destructor(&self);
+}
+pub trait DefaultedImpl {
+    fn destructor(&self);
+}
+pub trait EmptyBodyImpl {
+    fn destructor(&self);
+}
+pub trait MiddleImpl {
+    fn destructor(&self);
+}
+pub trait OrderedImpl {
+    fn destructor(&self);
+}
+pub trait OuterImpl {
+    fn destructor(&self);
+}
+pub trait SImpl {
+    fn destructor(&self);
+}
+pub trait TaggedImpl {
+    fn destructor(&self);
+}
+pub trait Templated_char_Impl {
+    fn destructor(&self);
+}
+pub trait Templated_int_Impl {
+    fn destructor(&self);
 }

--- a/tests/unit/out/refcount/doubly_linked_list.rs
+++ b/tests/unit/out/refcount/doubly_linked_list.rs
@@ -12,10 +12,6 @@ pub struct Node {
     pub next: Value<Ptr<Node>>,
     pub prev: Value<Ptr<Node>>,
 }
-pub trait NodeImpl {
-    fn SetNext(&self, n: Ptr<Node>);
-    fn SetPrev(&self, p: Ptr<Node>);
-}
 impl Clone for Node {
     fn clone(&self) -> Self {
         let __this: Value<Node> = Rc::new(RefCell::new(Self {
@@ -444,4 +440,8 @@ impl NodeImpl for Ptr<Node> {
         let p: Value<Ptr<Node>> = Rc::new(RefCell::new(p));
         (*(*(*self).upgrade().deref()).prev.borrow_mut()) = (*p.borrow()).clone();
     }
+}
+pub trait NodeImpl {
+    fn SetNext(&self, n: Ptr<Node>);
+    fn SetPrev(&self, p: Ptr<Node>);
 }

--- a/tests/unit/out/refcount/doubly_linked_list.rs
+++ b/tests/unit/out/refcount/doubly_linked_list.rs
@@ -431,6 +431,10 @@ fn main_0() -> i32 {
     });
     return 0;
 }
+pub trait NodeImpl {
+    fn SetNext(&self, n: Ptr<Node>);
+    fn SetPrev(&self, p: Ptr<Node>);
+}
 impl NodeImpl for Ptr<Node> {
     fn SetNext(&self, n: Ptr<Node>) {
         let n: Value<Ptr<Node>> = Rc::new(RefCell::new(n));
@@ -440,8 +444,4 @@ impl NodeImpl for Ptr<Node> {
         let p: Value<Ptr<Node>> = Rc::new(RefCell::new(p));
         (*(*(*self).upgrade().deref()).prev.borrow_mut()) = (*p.borrow()).clone();
     }
-}
-pub trait NodeImpl {
-    fn SetNext(&self, n: Ptr<Node>);
-    fn SetPrev(&self, p: Ptr<Node>);
 }

--- a/tests/unit/out/refcount/exprs.rs
+++ b/tests/unit/out/refcount/exprs.rs
@@ -37,10 +37,6 @@ pub struct Y {
     pub x: Value<X>,
     pub p: Value<Ptr<X>>,
 }
-pub trait YImpl {
-    fn foo(&self) -> Ptr<X>;
-    fn ptr(&self) -> Ptr<X>;
-}
 impl Clone for Y {
     fn clone(&self) -> Self {
         let __this: Value<Y> = Rc::new(RefCell::new(Self {
@@ -141,4 +137,8 @@ impl YImpl for Ptr<Y> {
     fn ptr(&self) -> Ptr<X> {
         return ((*(*self).upgrade().deref()).x.as_pointer());
     }
+}
+pub trait YImpl {
+    fn foo(&self) -> Ptr<X>;
+    fn ptr(&self) -> Ptr<X>;
 }

--- a/tests/unit/out/refcount/exprs.rs
+++ b/tests/unit/out/refcount/exprs.rs
@@ -130,6 +130,10 @@ fn main_0() -> i32 {
     assert!(((*(*x.borrow()).x.borrow()) == 100));
     return 0;
 }
+pub trait YImpl {
+    fn foo(&self) -> Ptr<X>;
+    fn ptr(&self) -> Ptr<X>;
+}
 impl YImpl for Ptr<Y> {
     fn foo(&self) -> Ptr<X> {
         return (*(*self).upgrade().deref()).x.as_pointer();
@@ -137,8 +141,4 @@ impl YImpl for Ptr<Y> {
     fn ptr(&self) -> Ptr<X> {
         return ((*(*self).upgrade().deref()).x.as_pointer());
     }
-}
-pub trait YImpl {
-    fn foo(&self) -> Ptr<X>;
-    fn ptr(&self) -> Ptr<X>;
 }

--- a/tests/unit/out/refcount/function_overloading.rs
+++ b/tests/unit/out/refcount/function_overloading.rs
@@ -93,6 +93,14 @@ fn main_0() -> i32 {
     assert!(((*out.borrow()) == 13));
     return 0;
 }
+pub trait FooImpl {
+    fn foo_const(&self);
+    fn foo(&self);
+    fn method_i32(&self, x: i32);
+    fn method_i32_const(&self, x: i32);
+    fn method2_i32_i32_const(&self, x: i32, y: i32);
+    fn method2_f64_f64_const(&self, x: f64, y: f64);
+}
 impl FooImpl for Ptr<Foo> {
     fn foo_const(&self) {}
     fn foo(&self) {}
@@ -110,12 +118,4 @@ impl FooImpl for Ptr<Foo> {
         let x: Value<f64> = Rc::new(RefCell::new(x));
         let y: Value<f64> = Rc::new(RefCell::new(y));
     }
-}
-pub trait FooImpl {
-    fn foo_const(&self);
-    fn foo(&self);
-    fn method_i32(&self, x: i32);
-    fn method_i32_const(&self, x: i32);
-    fn method2_i32_i32_const(&self, x: i32, y: i32);
-    fn method2_f64_f64_const(&self, x: f64, y: f64);
 }

--- a/tests/unit/out/refcount/function_overloading.rs
+++ b/tests/unit/out/refcount/function_overloading.rs
@@ -38,14 +38,6 @@ pub fn bar_4(x: Ptr<i32>) -> i32 {
 }
 #[derive(Default)]
 pub struct Foo {}
-pub trait FooImpl {
-    fn foo_const(&self);
-    fn foo(&self);
-    fn method_i32(&self, x: i32);
-    fn method_i32_const(&self, x: i32);
-    fn method2_i32_i32_const(&self, x: i32, y: i32);
-    fn method2_f64_f64_const(&self, x: f64, y: f64);
-}
 impl Clone for Foo {
     fn clone(&self) -> Self {
         let __this: Value<Foo> = Rc::new(RefCell::new(Self {}));
@@ -118,4 +110,12 @@ impl FooImpl for Ptr<Foo> {
         let x: Value<f64> = Rc::new(RefCell::new(x));
         let y: Value<f64> = Rc::new(RefCell::new(y));
     }
+}
+pub trait FooImpl {
+    fn foo_const(&self);
+    fn foo(&self);
+    fn method_i32(&self, x: i32);
+    fn method_i32_const(&self, x: i32);
+    fn method2_i32_i32_const(&self, x: i32, y: i32);
+    fn method2_f64_f64_const(&self, x: f64, y: f64);
 }

--- a/tests/unit/out/refcount/huffman.rs
+++ b/tests/unit/out/refcount/huffman.rs
@@ -13,9 +13,6 @@ pub struct MinHeapNode {
     pub left: Value<Ptr<MinHeapNode>>,
     pub right: Value<Ptr<MinHeapNode>>,
 }
-pub trait MinHeapNodeImpl {
-    fn IsLeaf(&self) -> bool;
-}
 impl Clone for MinHeapNode {
     fn clone(&self) -> Self {
         let __this: Value<MinHeapNode> = Rc::new(RefCell::new(Self {
@@ -84,18 +81,6 @@ pub struct MinHeap {
     pub arr: Value<Option<Value<Box<[Ptr<MinHeapNode>]>>>>,
     pub next: Value<i32>,
     pub alloc: Value<Option<Value<Box<[MinHeapNode]>>>>,
-}
-pub trait MinHeapImpl {
-    fn Alloc(&self, data: u8, freq: i32) -> Ptr<MinHeapNode>;
-    fn Heapify(&self, idx: i32);
-    fn ExtractMin(&self) -> Ptr<MinHeapNode>;
-    fn Insert(&self, node: Ptr<MinHeapNode>);
-    fn Build(
-        &self,
-        data: Ptr<Option<Value<Box<[u8]>>>>,
-        freq: Ptr<Option<Value<Box<[i32]>>>>,
-        n: i32,
-    );
 }
 impl ByteRepr for MinHeap {
     fn byte_size() -> usize {
@@ -515,4 +500,19 @@ impl MinHeapNodeImpl for Ptr<MinHeapNode> {
         return ((*(*(*self).upgrade().deref()).left.borrow()).is_null())
             && ((*(*(*self).upgrade().deref()).right.borrow()).is_null());
     }
+}
+pub trait MinHeapImpl {
+    fn Alloc(&self, data: u8, freq: i32) -> Ptr<MinHeapNode>;
+    fn Heapify(&self, idx: i32);
+    fn ExtractMin(&self) -> Ptr<MinHeapNode>;
+    fn Insert(&self, node: Ptr<MinHeapNode>);
+    fn Build(
+        &self,
+        data: Ptr<Option<Value<Box<[u8]>>>>,
+        freq: Ptr<Option<Value<Box<[i32]>>>>,
+        n: i32,
+    );
+}
+pub trait MinHeapNodeImpl {
+    fn IsLeaf(&self) -> bool;
 }

--- a/tests/unit/out/refcount/huffman.rs
+++ b/tests/unit/out/refcount/huffman.rs
@@ -324,6 +324,18 @@ fn main_0() -> i32 {
     );
     return 0;
 }
+pub trait MinHeapImpl {
+    fn Alloc(&self, data: u8, freq: i32) -> Ptr<MinHeapNode>;
+    fn Heapify(&self, idx: i32);
+    fn ExtractMin(&self) -> Ptr<MinHeapNode>;
+    fn Insert(&self, node: Ptr<MinHeapNode>);
+    fn Build(
+        &self,
+        data: Ptr<Option<Value<Box<[u8]>>>>,
+        freq: Ptr<Option<Value<Box<[i32]>>>>,
+        n: i32,
+    );
+}
 impl MinHeapImpl for Ptr<MinHeap> {
     fn Alloc(&self, data: u8, freq: i32) -> Ptr<MinHeapNode> {
         let data: Value<u8> = Rc::new(RefCell::new(data));
@@ -495,24 +507,12 @@ impl MinHeapImpl for Ptr<MinHeap> {
         }
     }
 }
+pub trait MinHeapNodeImpl {
+    fn IsLeaf(&self) -> bool;
+}
 impl MinHeapNodeImpl for Ptr<MinHeapNode> {
     fn IsLeaf(&self) -> bool {
         return ((*(*(*self).upgrade().deref()).left.borrow()).is_null())
             && ((*(*(*self).upgrade().deref()).right.borrow()).is_null());
     }
-}
-pub trait MinHeapImpl {
-    fn Alloc(&self, data: u8, freq: i32) -> Ptr<MinHeapNode>;
-    fn Heapify(&self, idx: i32);
-    fn ExtractMin(&self) -> Ptr<MinHeapNode>;
-    fn Insert(&self, node: Ptr<MinHeapNode>);
-    fn Build(
-        &self,
-        data: Ptr<Option<Value<Box<[u8]>>>>,
-        freq: Ptr<Option<Value<Box<[i32]>>>>,
-        n: i32,
-    );
-}
-pub trait MinHeapNodeImpl {
-    fn IsLeaf(&self) -> bool;
 }

--- a/tests/unit/out/refcount/immutable-deref-on-func-call.rs
+++ b/tests/unit/out/refcount/immutable-deref-on-func-call.rs
@@ -63,12 +63,12 @@ fn main_0() -> i32 {
     assert!(((*result.borrow()) == 11));
     return 0;
 }
+pub trait ItemImpl {
+    fn foo(&self, other: Ptr<Item>);
+}
 impl ItemImpl for Ptr<Item> {
     fn foo(&self, other: Ptr<Item>) {
         let other: Value<Ptr<Item>> = Rc::new(RefCell::new(other));
         (*(*(*other.borrow()).upgrade().deref()).value.borrow_mut()) = 10;
     }
-}
-pub trait ItemImpl {
-    fn foo(&self, other: Ptr<Item>);
 }

--- a/tests/unit/out/refcount/immutable-deref-on-func-call.rs
+++ b/tests/unit/out/refcount/immutable-deref-on-func-call.rs
@@ -10,9 +10,6 @@ use std::rc::{Rc, Weak};
 pub struct Item {
     pub value: Value<i32>,
 }
-pub trait ItemImpl {
-    fn foo(&self, other: Ptr<Item>);
-}
 impl Clone for Item {
     fn clone(&self) -> Self {
         let __this: Value<Item> = Rc::new(RefCell::new(Self {
@@ -71,4 +68,7 @@ impl ItemImpl for Ptr<Item> {
         let other: Value<Ptr<Item>> = Rc::new(RefCell::new(other));
         (*(*(*other.borrow()).upgrade().deref()).value.borrow_mut()) = 10;
     }
+}
+pub trait ItemImpl {
+    fn foo(&self, other: Ptr<Item>);
 }

--- a/tests/unit/out/refcount/kruskal.rs
+++ b/tests/unit/out/refcount/kruskal.rs
@@ -221,11 +221,6 @@ pub struct DisjointSet {
     pub parent: Value<Option<Value<Box<[i32]>>>>,
     pub n: Value<i32>,
 }
-pub trait DisjointSetImpl {
-    fn makeSet(&self);
-    fn find(&self, x: i32) -> i32;
-    fn merge(&self, x: i32, y: i32);
-}
 impl ByteRepr for DisjointSet {
     fn byte_size() -> usize {
         24
@@ -486,4 +481,9 @@ impl DisjointSetImpl for Ptr<DisjointSet> {
                 .borrow_mut()[((*xset.borrow()) as usize) as usize] = __rhs;
         }
     }
+}
+pub trait DisjointSetImpl {
+    fn makeSet(&self);
+    fn find(&self, x: i32) -> i32;
+    fn merge(&self, x: i32, y: i32);
 }

--- a/tests/unit/out/refcount/kruskal.rs
+++ b/tests/unit/out/refcount/kruskal.rs
@@ -386,6 +386,11 @@ fn main_0() -> i32 {
     assert!(((*total_weight.borrow()) == 19_f64));
     return 0;
 }
+pub trait DisjointSetImpl {
+    fn makeSet(&self);
+    fn find(&self, x: i32) -> i32;
+    fn merge(&self, x: i32, y: i32);
+}
 impl DisjointSetImpl for Ptr<DisjointSet> {
     fn makeSet(&self) {
         let i: Value<i32> = Rc::new(RefCell::new(0));
@@ -481,9 +486,4 @@ impl DisjointSetImpl for Ptr<DisjointSet> {
                 .borrow_mut()[((*xset.borrow()) as usize) as usize] = __rhs;
         }
     }
-}
-pub trait DisjointSetImpl {
-    fn makeSet(&self);
-    fn find(&self, x: i32) -> i32;
-    fn merge(&self, x: i32, y: i32);
 }

--- a/tests/unit/out/refcount/linked_list.rs
+++ b/tests/unit/out/refcount/linked_list.rs
@@ -11,9 +11,6 @@ pub struct Node {
     pub val: Value<i32>,
     pub next: Value<Ptr<Node>>,
 }
-pub trait NodeImpl {
-    fn SetNext(&self, next: Ptr<Node>);
-}
 impl Clone for Node {
     fn clone(&self) -> Self {
         let __this: Value<Node> = Rc::new(RefCell::new(Self {
@@ -191,4 +188,7 @@ impl NodeImpl for Ptr<Node> {
         let next: Value<Ptr<Node>> = Rc::new(RefCell::new(next));
         (*(*(*self).upgrade().deref()).next.borrow_mut()) = (*next.borrow()).clone();
     }
+}
+pub trait NodeImpl {
+    fn SetNext(&self, next: Ptr<Node>);
 }

--- a/tests/unit/out/refcount/linked_list.rs
+++ b/tests/unit/out/refcount/linked_list.rs
@@ -183,12 +183,12 @@ fn main_0() -> i32 {
     );
     return 0;
 }
+pub trait NodeImpl {
+    fn SetNext(&self, next: Ptr<Node>);
+}
 impl NodeImpl for Ptr<Node> {
     fn SetNext(&self, next: Ptr<Node>) {
         let next: Value<Ptr<Node>> = Rc::new(RefCell::new(next));
         (*(*(*self).upgrade().deref()).next.borrow_mut()) = (*next.borrow()).clone();
     }
-}
-pub trait NodeImpl {
-    fn SetNext(&self, next: Ptr<Node>);
 }

--- a/tests/unit/out/refcount/pointers.rs
+++ b/tests/unit/out/refcount/pointers.rs
@@ -73,6 +73,12 @@ fn main_0() -> i32 {
     );
     return 0;
 }
+pub trait TestImpl {
+    fn inc(&self);
+    fn dec(&self);
+    fn as_ptr(&self) -> Ptr<i32>;
+    fn update(&self, x: i32, y: i32);
+}
 impl TestImpl for Ptr<Test> {
     fn inc(&self) {
         (*(*(*self).upgrade().deref()).x.borrow_mut()).postfix_inc();
@@ -88,10 +94,4 @@ impl TestImpl for Ptr<Test> {
         let y: Value<i32> = Rc::new(RefCell::new(y));
         (*(*(*self).upgrade().deref()).x.borrow_mut()) = ((*x.borrow()) + (*y.borrow()));
     }
-}
-pub trait TestImpl {
-    fn inc(&self);
-    fn dec(&self);
-    fn as_ptr(&self) -> Ptr<i32>;
-    fn update(&self, x: i32, y: i32);
 }

--- a/tests/unit/out/refcount/pointers.rs
+++ b/tests/unit/out/refcount/pointers.rs
@@ -10,12 +10,6 @@ use std::rc::{Rc, Weak};
 pub struct Test {
     pub x: Value<i32>,
 }
-pub trait TestImpl {
-    fn inc(&self);
-    fn dec(&self);
-    fn as_ptr(&self) -> Ptr<i32>;
-    fn update(&self, x: i32, y: i32);
-}
 impl Clone for Test {
     fn clone(&self) -> Self {
         let __this: Value<Test> = Rc::new(RefCell::new(Self {
@@ -94,4 +88,10 @@ impl TestImpl for Ptr<Test> {
         let y: Value<i32> = Rc::new(RefCell::new(y));
         (*(*(*self).upgrade().deref()).x.borrow_mut()) = ((*x.borrow()) + (*y.borrow()));
     }
+}
+pub trait TestImpl {
+    fn inc(&self);
+    fn dec(&self);
+    fn as_ptr(&self) -> Ptr<i32>;
+    fn update(&self, x: i32, y: i32);
 }

--- a/tests/unit/out/refcount/polymorphism.rs
+++ b/tests/unit/out/refcount/polymorphism.rs
@@ -74,11 +74,11 @@ fn main_0() -> i32 {
     assert!((*eat1.borrow()) && (!(*eat2.borrow())));
     return 0;
 }
+pub trait CatImpl {
+    fn meow(&self) -> bool;
+}
 impl CatImpl for Ptr<Cat> {
     fn meow(&self) -> bool {
         return true;
     }
-}
-pub trait CatImpl {
-    fn meow(&self) -> bool;
 }

--- a/tests/unit/out/refcount/polymorphism.rs
+++ b/tests/unit/out/refcount/polymorphism.rs
@@ -34,9 +34,6 @@ impl ByteRepr for Dog {
 }
 #[derive(Default)]
 pub struct Cat {}
-pub trait CatImpl {
-    fn meow(&self) -> bool;
-}
 impl Animal for Cat {
     fn bark(&self) -> bool {
         return false;
@@ -81,4 +78,7 @@ impl CatImpl for Ptr<Cat> {
     fn meow(&self) -> bool {
         return true;
     }
+}
+pub trait CatImpl {
+    fn meow(&self) -> bool;
 }

--- a/tests/unit/out/refcount/random.rs
+++ b/tests/unit/out/refcount/random.rs
@@ -16,12 +16,6 @@ pub struct Pair {
     pub pair: Value<Ptr<Pair>>,
     pub ap: Value<Box<[Ptr<i32>]>>,
 }
-pub trait PairImpl {
-    fn method(&self);
-    fn as_val(&self) -> i32;
-    fn as_ref(&self) -> Ptr<i32>;
-    fn as_ptr(&self) -> Ptr<i32>;
-}
 impl Clone for Pair {
     fn clone(&self) -> Self {
         let __this: Value<Pair> = Rc::new(RefCell::new(Self {
@@ -321,4 +315,10 @@ impl PairImpl for Ptr<Pair> {
     fn as_ptr(&self) -> Ptr<i32> {
         return ((*(*self).upgrade().deref()).x.as_pointer());
     }
+}
+pub trait PairImpl {
+    fn method(&self);
+    fn as_val(&self) -> i32;
+    fn as_ref(&self) -> Ptr<i32>;
+    fn as_ptr(&self) -> Ptr<i32>;
 }

--- a/tests/unit/out/refcount/random.rs
+++ b/tests/unit/out/refcount/random.rs
@@ -296,6 +296,12 @@ fn main_0() -> i32 {
     let ptr2ptr_2: Value<Ptr<Ptr<Pair>>> = Rc::new(RefCell::new((py1.as_pointer())));
     return 0;
 }
+pub trait PairImpl {
+    fn method(&self);
+    fn as_val(&self) -> i32;
+    fn as_ref(&self) -> Ptr<i32>;
+    fn as_ptr(&self) -> Ptr<i32>;
+}
 impl PairImpl for Ptr<Pair> {
     fn method(&self) {
         (*(*(*self).upgrade().deref()).x.borrow_mut()).postfix_inc();
@@ -315,10 +321,4 @@ impl PairImpl for Ptr<Pair> {
     fn as_ptr(&self) -> Ptr<i32> {
         return ((*(*self).upgrade().deref()).x.as_pointer());
     }
-}
-pub trait PairImpl {
-    fn method(&self);
-    fn as_val(&self) -> i32;
-    fn as_ref(&self) -> Ptr<i32>;
-    fn as_ptr(&self) -> Ptr<i32>;
 }

--- a/tests/unit/out/refcount/static_var_in_class.rs
+++ b/tests/unit/out/refcount/static_var_in_class.rs
@@ -11,9 +11,6 @@ thread_local!(
 );
 #[derive(Default)]
 pub struct C {}
-pub trait CImpl {
-    fn get(&self) -> i32;
-}
 impl Clone for C {
     fn clone(&self) -> Self {
         let __this: Value<C> = Rc::new(RefCell::new(Self {}));
@@ -64,4 +61,7 @@ impl CImpl for Ptr<C> {
     fn get(&self) -> i32 {
         return (*inner_const_0.with(Value::clone).borrow());
     }
+}
+pub trait CImpl {
+    fn get(&self) -> i32;
 }

--- a/tests/unit/out/refcount/static_var_in_class.rs
+++ b/tests/unit/out/refcount/static_var_in_class.rs
@@ -57,11 +57,11 @@ fn main_0() -> i32 {
     assert!(((*inner_const_1.with(Value::clone).borrow()) == 2));
     return 0;
 }
+pub trait CImpl {
+    fn get(&self) -> i32;
+}
 impl CImpl for Ptr<C> {
     fn get(&self) -> i32 {
         return (*inner_const_0.with(Value::clone).borrow());
     }
-}
-pub trait CImpl {
-    fn get(&self) -> i32;
 }

--- a/tests/unit/out/refcount/struct_ctor.rs
+++ b/tests/unit/out/refcount/struct_ctor.rs
@@ -25,10 +25,6 @@ impl StructWithCtor {
         Rc::try_unwrap(__this).ok().unwrap().into_inner()
     }
 }
-pub trait StructWithCtorImpl {
-    fn x1(&self) -> Ptr<i32>;
-    fn x2(&self) -> Ptr<i32>;
-}
 impl Clone for StructWithCtor {
     fn clone(&self) -> Self {
         let __this: Value<StructWithCtor> = Rc::new(RefCell::new(Self {
@@ -78,4 +74,8 @@ impl StructWithCtorImpl for Ptr<StructWithCtor> {
     fn x2(&self) -> Ptr<i32> {
         return (*(*self).upgrade().deref()).x2_.as_pointer();
     }
+}
+pub trait StructWithCtorImpl {
+    fn x1(&self) -> Ptr<i32>;
+    fn x2(&self) -> Ptr<i32>;
 }

--- a/tests/unit/out/refcount/struct_ctor.rs
+++ b/tests/unit/out/refcount/struct_ctor.rs
@@ -67,6 +67,10 @@ fn main_0() -> i32 {
     );
     return 0;
 }
+pub trait StructWithCtorImpl {
+    fn x1(&self) -> Ptr<i32>;
+    fn x2(&self) -> Ptr<i32>;
+}
 impl StructWithCtorImpl for Ptr<StructWithCtor> {
     fn x1(&self) -> Ptr<i32> {
         return (*(*self).upgrade().deref()).x1_.as_pointer();
@@ -74,8 +78,4 @@ impl StructWithCtorImpl for Ptr<StructWithCtor> {
     fn x2(&self) -> Ptr<i32> {
         return (*(*self).upgrade().deref()).x2_.as_pointer();
     }
-}
-pub trait StructWithCtorImpl {
-    fn x1(&self) -> Ptr<i32>;
-    fn x2(&self) -> Ptr<i32>;
 }

--- a/tests/unit/out/refcount/this.rs
+++ b/tests/unit/out/refcount/this.rs
@@ -22,20 +22,6 @@ impl S {
         Rc::try_unwrap(__this).ok().unwrap().into_inner()
     }
 }
-pub trait SImpl {
-    fn returns_this_reference(&self) -> Ptr<S>;
-    fn returns_this_pointer(&self) -> Ptr<S>;
-    fn inc(&self) -> Ptr<S>;
-    fn set_from_this(&self);
-    fn get(&self) -> i32;
-    fn twice(&self) -> i32;
-    fn link(&self);
-    fn bump_me(&self);
-    fn cref(&self) -> Ptr<S>;
-    fn is(&self, o: Ptr<S>) -> bool;
-    fn destroy(&self);
-    fn reset(&self);
-}
 impl Clone for S {
     fn clone(&self) -> Self {
         let __this: Value<S> = Rc::new(RefCell::new(Self {
@@ -198,4 +184,18 @@ impl SImpl for Ptr<S> {
     fn reset(&self) {
         (*self).write(S::S({ 0 }));
     }
+}
+pub trait SImpl {
+    fn returns_this_reference(&self) -> Ptr<S>;
+    fn returns_this_pointer(&self) -> Ptr<S>;
+    fn inc(&self) -> Ptr<S>;
+    fn set_from_this(&self);
+    fn get(&self) -> i32;
+    fn twice(&self) -> i32;
+    fn link(&self);
+    fn bump_me(&self);
+    fn cref(&self) -> Ptr<S>;
+    fn is(&self, o: Ptr<S>) -> bool;
+    fn destroy(&self);
+    fn reset(&self);
 }

--- a/tests/unit/out/refcount/this.rs
+++ b/tests/unit/out/refcount/this.rs
@@ -144,6 +144,20 @@ fn main_0() -> i32 {
     assert!((*(*s.borrow()).self__.borrow()).is_null());
     return 0;
 }
+pub trait SImpl {
+    fn returns_this_reference(&self) -> Ptr<S>;
+    fn returns_this_pointer(&self) -> Ptr<S>;
+    fn inc(&self) -> Ptr<S>;
+    fn set_from_this(&self);
+    fn get(&self) -> i32;
+    fn twice(&self) -> i32;
+    fn link(&self);
+    fn bump_me(&self);
+    fn cref(&self) -> Ptr<S>;
+    fn is(&self, o: Ptr<S>) -> bool;
+    fn destroy(&self);
+    fn reset(&self);
+}
 impl SImpl for Ptr<S> {
     fn returns_this_reference(&self) -> Ptr<S> {
         return (*self).clone();
@@ -184,18 +198,4 @@ impl SImpl for Ptr<S> {
     fn reset(&self) {
         (*self).write(S::S({ 0 }));
     }
-}
-pub trait SImpl {
-    fn returns_this_reference(&self) -> Ptr<S>;
-    fn returns_this_pointer(&self) -> Ptr<S>;
-    fn inc(&self) -> Ptr<S>;
-    fn set_from_this(&self);
-    fn get(&self) -> i32;
-    fn twice(&self) -> i32;
-    fn link(&self);
-    fn bump_me(&self);
-    fn cref(&self) -> Ptr<S>;
-    fn is(&self, o: Ptr<S>) -> bool;
-    fn destroy(&self);
-    fn reset(&self);
 }

--- a/tests/unit/out/refcount/unique_ptr.rs
+++ b/tests/unit/out/refcount/unique_ptr.rs
@@ -292,12 +292,18 @@ fn main_0() -> i32 {
     assert!((({ Consume_1((*safe_ptr.borrow_mut()).take(),) }) == 60));
     return 0;
 }
+pub trait PairImpl {
+    fn inc(&self, k: i32);
+}
 impl PairImpl for Ptr<Pair> {
     fn inc(&self, k: i32) {
         let k: Value<i32> = Rc::new(RefCell::new(k));
         (*(*(*self).upgrade().deref()).x.borrow_mut()) += (*k.borrow());
         (*(*(*self).upgrade().deref()).y.borrow_mut()) += (*k.borrow());
     }
+}
+pub trait SafePointerImpl {
+    fn inc(&self);
 }
 impl SafePointerImpl for Ptr<SafePointer> {
     fn inc(&self) {
@@ -307,10 +313,4 @@ impl SafePointerImpl for Ptr<SafePointer> {
             .borrow_mut())
         .prefix_inc();
     }
-}
-pub trait PairImpl {
-    fn inc(&self, k: i32);
-}
-pub trait SafePointerImpl {
-    fn inc(&self);
 }

--- a/tests/unit/out/refcount/unique_ptr.rs
+++ b/tests/unit/out/refcount/unique_ptr.rs
@@ -10,9 +10,6 @@ use std::rc::{Rc, Weak};
 pub struct SafePointer {
     pub ptr: Value<Option<Value<i32>>>,
 }
-pub trait SafePointerImpl {
-    fn inc(&self);
-}
 impl ByteRepr for SafePointer {
     fn byte_size() -> usize {
         8
@@ -30,9 +27,6 @@ impl ByteRepr for SafePointer {
 pub struct Pair {
     pub x: Value<i32>,
     pub y: Value<i32>,
-}
-pub trait PairImpl {
-    fn inc(&self, k: i32);
 }
 impl Clone for Pair {
     fn clone(&self) -> Self {
@@ -313,4 +307,10 @@ impl SafePointerImpl for Ptr<SafePointer> {
             .borrow_mut())
         .prefix_inc();
     }
+}
+pub trait PairImpl {
+    fn inc(&self, k: i32);
+}
+pub trait SafePointerImpl {
+    fn inc(&self);
 }

--- a/tests/unit/out/refcount/vector_with_allocator.rs
+++ b/tests/unit/out/refcount/vector_with_allocator.rs
@@ -8,10 +8,6 @@ use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
 #[derive(Default)]
 pub struct TestAllocator_int_ {}
-pub trait TestAllocator_int_Impl {
-    fn allocate(&self, n: usize) -> Ptr<i32>;
-    fn deallocate(&self, p: Ptr<i32>, _: usize);
-}
 impl Clone for TestAllocator_int_ {
     fn clone(&self) -> Self {
         let __this: Value<TestAllocator_int_> = Rc::new(RefCell::new(Self {}));
@@ -30,10 +26,6 @@ impl ByteRepr for TestAllocator_int_ {
 }
 #[derive(Default)]
 pub struct TestAllocator_double_ {}
-pub trait TestAllocator_double_Impl {
-    fn allocate(&self, n: usize) -> Ptr<f64>;
-    fn deallocate(&self, p: Ptr<f64>, _: usize);
-}
 impl Clone for TestAllocator_double_ {
     fn clone(&self) -> Self {
         let __this: Value<TestAllocator_double_> = Rc::new(RefCell::new(Self {}));
@@ -374,4 +366,12 @@ impl TestAllocator_int_Impl for Ptr<TestAllocator_int_> {
         let p: Value<Ptr<i32>> = Rc::new(RefCell::new(p));
         (*p.borrow()).delete_array();
     }
+}
+pub trait TestAllocator_double_Impl {
+    fn allocate(&self, n: usize) -> Ptr<f64>;
+    fn deallocate(&self, p: Ptr<f64>, _: usize);
+}
+pub trait TestAllocator_int_Impl {
+    fn allocate(&self, n: usize) -> Ptr<i32>;
+    fn deallocate(&self, p: Ptr<i32>, _: usize);
 }

--- a/tests/unit/out/refcount/vector_with_allocator.rs
+++ b/tests/unit/out/refcount/vector_with_allocator.rs
@@ -339,6 +339,10 @@ fn main_0() -> i32 {
     );
     return 0;
 }
+pub trait TestAllocator_double_Impl {
+    fn allocate(&self, n: usize) -> Ptr<f64>;
+    fn deallocate(&self, p: Ptr<f64>, _: usize);
+}
 impl TestAllocator_double_Impl for Ptr<TestAllocator_double_> {
     fn allocate(&self, n: usize) -> Ptr<f64> {
         let n: Value<usize> = Rc::new(RefCell::new(n));
@@ -353,6 +357,10 @@ impl TestAllocator_double_Impl for Ptr<TestAllocator_double_> {
         (*p.borrow()).delete_array();
     }
 }
+pub trait TestAllocator_int_Impl {
+    fn allocate(&self, n: usize) -> Ptr<i32>;
+    fn deallocate(&self, p: Ptr<i32>, _: usize);
+}
 impl TestAllocator_int_Impl for Ptr<TestAllocator_int_> {
     fn allocate(&self, n: usize) -> Ptr<i32> {
         let n: Value<usize> = Rc::new(RefCell::new(n));
@@ -366,12 +374,4 @@ impl TestAllocator_int_Impl for Ptr<TestAllocator_int_> {
         let p: Value<Ptr<i32>> = Rc::new(RefCell::new(p));
         (*p.borrow()).delete_array();
     }
-}
-pub trait TestAllocator_double_Impl {
-    fn allocate(&self, n: usize) -> Ptr<f64>;
-    fn deallocate(&self, p: Ptr<f64>, _: usize);
-}
-pub trait TestAllocator_int_Impl {
-    fn allocate(&self, n: usize) -> Ptr<i32>;
-    fn deallocate(&self, p: Ptr<i32>, _: usize);
 }


### PR DESCRIPTION
After #333, late instantiated methods from templates were not added in the `impl X for Ptr<Self>` block. For exmaple:

```cpp
// 2 methods, each instantiated in separate TUs. Second TU got it wrong
template <typename T>
struct S {
  T x = 0;

  // visited in first TU: correctly added in `trait SImpl` and `impl SImpl for Ptr<Self>`
  void set(T v) { x = v; }
  // visited in the second TU: not added in `trait SImpl` at all and incorrectly added
  // in `impl S` instead of `impl SImpl for Ptr<Self>`
  T get() { return x; }
};
```

This PR solves it by also deferring trait blocks at the end of the file and adding late instantiated methods in both `trait SImpl` and `impl SImpl for Ptr<Self>`.