### PR TITLE
Shadow `self` receiver with `this` pointer in unsafe

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -2293,8 +2293,7 @@ bool Converter::VisitImplicitCastExpr(clang::ImplicitCastExpr *expr) {
     const char *suffix = nullptr;
     bool type_changed = false;
     if (expr->getType()->isPointerType() &&
-        sub_expr->getType()->isPointerType() &&
-        !clang::isa<clang::CXXThisExpr>(expr->IgnoreImplicit())) {
+        sub_expr->getType()->isPointerType()) {
       switch (GetConstCastType(expr->getType()->getPointeeType(),
                                sub_expr->getType()->getPointeeType())) {
       case ConstCastType::MutableToConst:

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -1154,8 +1154,9 @@ void Converter::EmitFunctionPreamble(clang::FunctionDecl *decl) {
   if (auto *method = clang::dyn_cast<clang::CXXMethodDecl>(decl);
       method && method->isInstance() && !method->getParent()->isLambda() &&
       !clang::isa<clang::CXXConstructorDecl>(method)) {
-    StrCat(std::format("let this = self as {}", ToString(method->getThisType())),
-           token::kSemiColon);
+    StrCat(
+        std::format("let this = self as {}", ToString(method->getThisType())),
+        token::kSemiColon);
   }
 }
 

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -1080,15 +1080,16 @@ bool Converter::VisitCXXConstructorDecl(clang::CXXConstructorDecl *decl) {
 
 void Converter::ConvertCXXConstructorBody(clang::CXXConstructorDecl *decl) {
   EmitFunctionPreamble(decl);
-  StrCat(keyword::kLet, "mut", "this", token::kAssign, "Self");
+  StrCat(keyword::kLet, "mut", "__this", token::kAssign, "Self");
   {
     PushBrace this_init(*this);
     EmitConstructorFieldInits(decl);
   }
-
   StrCat(token::kSemiColon);
+  StrCat(keyword::kLet, "this", token::kAssign, "&raw mut __this",
+         token::kSemiColon);
   ConvertBodyStmts(decl->getBody());
-  StrCat("this");
+  StrCat("__this");
 }
 
 void Converter::EmitConstructorFieldInits(clang::CXXConstructorDecl *decl) {
@@ -1149,6 +1150,12 @@ void Converter::EmitFunctionPreamble(clang::FunctionDecl *decl) {
       StrCat(std::format("let mut {} : {} = {}", name, type, init),
              token::kSemiColon);
     }
+  }
+  if (auto *method = clang::dyn_cast<clang::CXXMethodDecl>(decl);
+      method && method->isInstance() && !method->getParent()->isLambda() &&
+      !clang::isa<clang::CXXConstructorDecl>(method)) {
+    StrCat(std::format("let this = self as {}", ToString(method->getThisType())),
+           token::kSemiColon);
   }
 }
 
@@ -2985,7 +2992,7 @@ void Converter::SetUFCSReceiver(clang::Expr *base, bool is_arrow,
   if (clang::isa<clang::CXXThisExpr>(base->IgnoreParenImpCasts())) {
     bool in_ctor =
         curr_function_ && clang::isa<clang::CXXConstructorDecl>(curr_function_);
-    ufcs_receiver_ = in_ctor ? "&mut this" : keyword::kSelfValue;
+    ufcs_receiver_ = in_ctor ? "&mut *this" : keyword::kSelfValue;
     return;
   }
   Buffer buf(*this);
@@ -3055,15 +3062,7 @@ void Converter::ConvertMemberExpr(clang::MemberExpr *expr) {
     expr = inner;
   }
 
-  auto *base = expr->getBase();
-  bool base_is_this =
-      clang::isa<clang::CXXThisExpr>(base->IgnoreCasts()) && !ThisIsRustPtr();
-  PushExprKind push(*this, isLValue() ? ExprKind::LValue : ExprKind::RValue);
-  if (expr->isArrow() && !base_is_this) {
-    ConvertArrow(base);
-  } else {
-    Convert(base);
-  }
+  ConvertMemberBase(expr);
 
   if (auto *method = clang::dyn_cast<clang::CXXMethodDecl>(member);
       method && IsOverloadedMethod(method)) {
@@ -3077,12 +3076,17 @@ void Converter::ConvertMemberExpr(clang::MemberExpr *expr) {
   }
 }
 
-bool Converter::VisitCXXThisExpr([[maybe_unused]] clang::CXXThisExpr *expr) {
-  if (clang::isa<clang::CXXConstructorDecl>(curr_function_)) {
-    StrCat("this");
+void Converter::ConvertMemberBase(clang::MemberExpr *expr) {
+  PushExprKind push(*this, isLValue() ? ExprKind::LValue : ExprKind::RValue);
+  if (expr->isArrow()) {
+    ConvertArrow(expr->getBase());
   } else {
-    StrCat(keyword::kSelfValue);
+    Convert(expr->getBase());
   }
+}
+
+bool Converter::VisitCXXThisExpr([[maybe_unused]] clang::CXXThisExpr *expr) {
+  StrCat("this");
   return false;
 }
 

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -144,6 +144,7 @@ public:
   virtual std::string GetUFCSName(const clang::CXXMethodDecl *method) const;
 
   virtual bool ThisIsRustPtr() const { return false; }
+  virtual void ConvertMemberBase(clang::MemberExpr *expr);
 
   virtual void ConvertCXXConstructorBody(clang::CXXConstructorDecl *decl);
   void EmitConstructorFieldInits(clang::CXXConstructorDecl *decl);

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -2579,6 +2579,20 @@ bool ConverterRefCount::ShouldConvertMethod(const clang::CXXMethodDecl *decl) {
   return Converter::ShouldConvertMethod(decl);
 }
 
+void ConverterRefCount::ConvertMemberBase(clang::MemberExpr *expr) {
+  PushExprKind push(*this, isLValue() ? ExprKind::LValue : ExprKind::RValue);
+  auto *base = expr->getBase();
+  // ThisIsRustPtr should disappear after virtual methods are implemented on
+  // Ptr<Self> instead of Self.
+  bool base_is_this =
+      clang::isa<clang::CXXThisExpr>(base->IgnoreCasts()) && !ThisIsRustPtr();
+  if (expr->isArrow() && !base_is_this) {
+    ConvertArrow(base);
+  } else {
+    Convert(base);
+  }
+}
+
 bool ConverterRefCount::ThisIsRustPtr() const {
   auto *method = clang::dyn_cast_or_null<clang::CXXMethodDecl>(curr_function_);
   return method && (IsMethodOnPtr(method) ||

--- a/cpp2rust/converter/models/converter_refcount.h
+++ b/cpp2rust/converter/models/converter_refcount.h
@@ -69,6 +69,7 @@ public:
   bool VisitCXXThisExpr(clang::CXXThisExpr *expr) override;
 
   bool ThisIsRustPtr() const override;
+  void ConvertMemberBase(clang::MemberExpr *expr) override;
 
   bool VisitCXXConstructorDecl(clang::CXXConstructorDecl *decl) override;
 

--- a/tests/multi-file/template_method_late_instantiation/out/unsafe/template_method_late_instantiation.rs
+++ b/tests/multi-file/template_method_late_instantiation/out/unsafe/template_method_late_instantiation.rs
@@ -13,7 +13,8 @@ pub struct S_int_ {
 }
 impl S_int_ {
     pub unsafe fn set(&mut self, mut v: i32) {
-        self.x = v;
+        let this = self as *mut S_int_;
+        (*this).x = v;
     }
 }
 pub fn main() {
@@ -29,7 +30,8 @@ unsafe fn main_0() -> i32 {
 }
 impl S_int_ {
     pub unsafe fn get(&mut self) -> i32 {
-        return self.x;
+        let this = self as *mut S_int_;
+        return (*this).x;
     }
 }
 pub unsafe fn f_0(mut p: *mut S_int_) -> i32 {

--- a/tests/ub/out/unsafe/ctor_ref_member.rs
+++ b/tests/ub/out/unsafe/ctor_ref_member.rs
@@ -13,8 +13,9 @@ pub struct S {
 }
 impl S {
     pub unsafe fn S(x: *const i32) -> Self {
-        let mut this = Self { r: x };
-        this
+        let mut __this = Self { r: x };
+        let this = &raw mut __this;
+        __this
     }
 }
 pub fn main() {

--- a/tests/unit/out/refcount/this.rs
+++ b/tests/unit/out/refcount/this.rs
@@ -12,13 +12,28 @@ pub struct S {
     pub self__: Value<Ptr<S>>,
 }
 impl S {
-    pub fn S(a: i32) -> Self {
+    pub fn S1(a: i32) -> Self {
         let a: Value<i32> = Rc::new(RefCell::new(a));
         let __this: Value<S> = Rc::new(RefCell::new(Self {
             a_: Rc::new(RefCell::new((*a.borrow()))),
             self__: Rc::new(RefCell::new(Ptr::<S>::null())),
         }));
         let this: Ptr<S> = __this.as_pointer();
+        Rc::try_unwrap(__this).ok().unwrap().into_inner()
+    }
+    pub fn S2(a: i32, other: Ptr<S>) -> Self {
+        let a: Value<i32> = Rc::new(RefCell::new(a));
+        let other: Value<Ptr<S>> = Rc::new(RefCell::new(other));
+        let __this: Value<S> = Rc::new(RefCell::new(Self {
+            a_: Rc::new(RefCell::new((*a.borrow()))),
+            self__: Rc::new(RefCell::new(Ptr::<S>::null())),
+        }));
+        let this: Ptr<S> = __this.as_pointer();
+        if (this == (*other.borrow())) {
+            (*(*this.upgrade().deref()).self__.borrow_mut()) = Ptr::<S>::null();
+        } else {
+            (*(*this.upgrade().deref()).self__.borrow_mut()) = (*other.borrow()).clone();
+        }
         Rc::try_unwrap(__this).ok().unwrap().into_inner()
     }
 }
@@ -92,7 +107,7 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    let s: Value<S> = Rc::new(RefCell::new(S::S({ 1 })));
+    let s: Value<S> = Rc::new(RefCell::new(S::S1({ 1 })));
     let ref_: Ptr<S> = ({ SImpl::returns_this_reference(&s.as_pointer()) });
     (*(*ref_.upgrade().deref()).a_.borrow_mut()).postfix_inc();
     assert!(((*(*s.borrow()).a_.borrow()) == 2));
@@ -122,7 +137,7 @@ fn main_0() -> i32 {
     assert!(((*(*d.borrow()).a_.borrow()) == 6));
     let cr: Ptr<S> = ({ SImpl::cref(&s.as_pointer()) });
     assert!(((*(*cr.upgrade().deref()).a_.borrow()) == 9));
-    let t: Value<S> = Rc::new(RefCell::new(S::S({ 0 })));
+    let t: Value<S> = Rc::new(RefCell::new(S::S1({ 0 })));
     assert!(
         ({
             let _o: Ptr<S> = (s.as_pointer());
@@ -130,14 +145,14 @@ fn main_0() -> i32 {
         })
     );
     assert!(!({ SImpl::is(&s.as_pointer(), (t.as_pointer()),) }));
-    let p: Value<Ptr<S>> = Rc::new(RefCell::new(Ptr::alloc(S::S({ 1 }))));
+    let p: Value<Ptr<S>> = Rc::new(RefCell::new(Ptr::alloc(S::S1({ 1 }))));
     let q: Value<Ptr<S>> = Rc::new(RefCell::new(
         ({ SImpl::returns_this_pointer(&(*p.borrow())) }),
     ));
     (*(*(*q.borrow()).upgrade().deref()).a_.borrow_mut()).postfix_inc();
     assert!(((*(*(*p.borrow()).upgrade().deref()).a_.borrow()) == 2));
     (*p.borrow()).delete();
-    let h: Value<Ptr<S>> = Rc::new(RefCell::new(Ptr::alloc(S::S({ 5 }))));
+    let h: Value<Ptr<S>> = Rc::new(RefCell::new(Ptr::alloc(S::S1({ 5 }))));
     ({ SImpl::destroy(&(*h.borrow())) });
     ({ SImpl::reset(&s.as_pointer()) });
     assert!(((*(*s.borrow()).a_.borrow()) == 0));
@@ -156,7 +171,7 @@ fn main_0() -> i32 {
         }) as i32)
             == (false as i32))
     );
-    let other: Value<S> = Rc::new(RefCell::new(S::S({ 22 })));
+    let other: Value<S> = Rc::new(RefCell::new(S::S1({ 22 })));
     assert!(
         ((({ SImpl::copy_if_different(&s.as_pointer(), (other.as_pointer()),) }) as i32)
             == (true as i32))
@@ -165,6 +180,11 @@ fn main_0() -> i32 {
     assert!({
         let _lhs = (*(*s.borrow()).self__.borrow()).clone();
         _lhs == (*(*other.borrow()).self__.borrow()).clone()
+    });
+    let u: Value<S> = Rc::new(RefCell::new(S::S2({ 1 }, { (s.as_pointer()) })));
+    assert!({
+        let _lhs = (*(*u.borrow()).self__.borrow()).clone();
+        _lhs == (s.as_pointer())
     });
     return 0;
 }
@@ -222,7 +242,7 @@ impl SImpl for Ptr<S> {
         (*self).delete();
     }
     fn reset(&self) {
-        (*self).write(S::S({ 0 }));
+        (*self).write(S::S1({ 0 }));
     }
     fn copy_if_different_const(&self, other: Ptr<S>) -> bool {
         let other: Value<Ptr<S>> = Rc::new(RefCell::new(other));

--- a/tests/unit/out/refcount/this.rs
+++ b/tests/unit/out/refcount/this.rs
@@ -149,6 +149,13 @@ fn main_0() -> i32 {
         }) as i32)
             == (false as i32))
     );
+    assert!(
+        ((({
+            let _other: Ptr<S> = (s.as_pointer());
+            SImpl::copy_if_different_const(&s.as_pointer(), _other)
+        }) as i32)
+            == (false as i32))
+    );
     let other: Value<S> = Rc::new(RefCell::new(S::S({ 22 })));
     assert!(
         ((({ SImpl::copy_if_different(&s.as_pointer(), (other.as_pointer()),) }) as i32)
@@ -174,6 +181,7 @@ pub trait SImpl {
     fn is(&self, o: Ptr<S>) -> bool;
     fn destroy(&self);
     fn reset(&self);
+    fn copy_if_different_const(&self, other: Ptr<S>) -> bool;
     fn copy_if_different(&self, other: Ptr<S>) -> bool;
 }
 impl SImpl for Ptr<S> {
@@ -215,6 +223,17 @@ impl SImpl for Ptr<S> {
     }
     fn reset(&self) {
         (*self).write(S::S({ 0 }));
+    }
+    fn copy_if_different_const(&self, other: Ptr<S>) -> bool {
+        let other: Value<Ptr<S>> = Rc::new(RefCell::new(other));
+        if ((*self) == (*other.borrow())) {
+            return false;
+        }
+        let __rhs = (*(*(*other.borrow()).upgrade().deref()).a_.borrow());
+        (*(*(*self).upgrade().deref()).a_.borrow_mut()) = __rhs;
+        let __rhs = (*(*(*other.borrow()).upgrade().deref()).self__.borrow()).clone();
+        (*(*(*self).upgrade().deref()).self__.borrow_mut()) = __rhs;
+        return true;
     }
     fn copy_if_different(&self, other: Ptr<S>) -> bool {
         let other: Value<Ptr<S>> = Rc::new(RefCell::new(other));

--- a/tests/unit/out/refcount/this.rs
+++ b/tests/unit/out/refcount/this.rs
@@ -142,6 +142,23 @@ fn main_0() -> i32 {
     ({ SImpl::reset(&s.as_pointer()) });
     assert!(((*(*s.borrow()).a_.borrow()) == 0));
     assert!((*(*s.borrow()).self__.borrow()).is_null());
+    assert!(
+        ((({
+            let _other: Ptr<S> = (s.as_pointer());
+            SImpl::copy_if_different(&s.as_pointer(), _other)
+        }) as i32)
+            == (false as i32))
+    );
+    let other: Value<S> = Rc::new(RefCell::new(S::S({ 22 })));
+    assert!(
+        ((({ SImpl::copy_if_different(&s.as_pointer(), (other.as_pointer()),) }) as i32)
+            == (true as i32))
+    );
+    assert!(((*(*s.borrow()).a_.borrow()) == (*(*other.borrow()).a_.borrow())));
+    assert!({
+        let _lhs = (*(*s.borrow()).self__.borrow()).clone();
+        _lhs == (*(*other.borrow()).self__.borrow()).clone()
+    });
     return 0;
 }
 pub trait SImpl {
@@ -157,6 +174,7 @@ pub trait SImpl {
     fn is(&self, o: Ptr<S>) -> bool;
     fn destroy(&self);
     fn reset(&self);
+    fn copy_if_different(&self, other: Ptr<S>) -> bool;
 }
 impl SImpl for Ptr<S> {
     fn returns_this_reference(&self) -> Ptr<S> {
@@ -197,5 +215,16 @@ impl SImpl for Ptr<S> {
     }
     fn reset(&self) {
         (*self).write(S::S({ 0 }));
+    }
+    fn copy_if_different(&self, other: Ptr<S>) -> bool {
+        let other: Value<Ptr<S>> = Rc::new(RefCell::new(other));
+        if ((*self) == (*other.borrow())) {
+            return false;
+        }
+        let __rhs = (*(*(*other.borrow()).upgrade().deref()).a_.borrow());
+        (*(*(*self).upgrade().deref()).a_.borrow_mut()) = __rhs;
+        let __rhs = (*(*(*other.borrow()).upgrade().deref()).self__.borrow()).clone();
+        (*(*(*self).upgrade().deref()).self__.borrow_mut()) = __rhs;
+        return true;
     }
 }

--- a/tests/unit/out/unsafe/10_struct.rs
+++ b/tests/unit/out/unsafe/10_struct.rs
@@ -20,13 +20,14 @@ pub struct Graph {
 }
 impl Graph {
     pub unsafe fn push(&self, mut src: u32, mut dst: u32) {
-        (*self.adj.offset((src) as isize)) = (Box::leak(Box::new(GraphNode {
+        let this = self as *const Graph;
+        (*(*this).adj.offset((src) as isize)) = (Box::leak(Box::new(GraphNode {
             dst: dst,
-            next: (*self.adj.offset((src) as isize)),
+            next: (*(*this).adj.offset((src) as isize)),
         })) as *mut GraphNode);
-        (*self.adj.offset((dst) as isize)) = (Box::leak(Box::new(GraphNode {
+        (*(*this).adj.offset((dst) as isize)) = (Box::leak(Box::new(GraphNode {
             dst: src,
-            next: (*self.adj.offset((dst) as isize)),
+            next: (*(*this).adj.offset((dst) as isize)),
         })) as *mut GraphNode);
     }
 }

--- a/tests/unit/out/unsafe/class.rs
+++ b/tests/unit/out/unsafe/class.rs
@@ -13,30 +13,37 @@ pub struct Pair {
     pub second: i32,
 }
 impl Pair {
-    pub unsafe fn NOP(&mut self) {}
+    pub unsafe fn NOP(&mut self) {
+        let this = self as *mut Pair;
+    }
     pub unsafe fn GetFirst(&self) -> i32 {
-        return self.first;
+        let this = self as *const Pair;
+        return (*this).first;
     }
     pub unsafe fn GetSecond(&self) -> i32 {
-        return self.second;
+        let this = self as *const Pair;
+        return (*this).second;
     }
     pub unsafe fn Set(&mut self, field: *mut i32, mut new_val: i32) -> i32 {
+        let this = self as *mut Pair;
         (unsafe { Pair::NOP(self) });
         let mut old_val: i32 = (*field);
         (*field) = new_val;
         return old_val;
     }
     pub unsafe fn SetFirst(&mut self, mut new_first: i32) -> i32 {
+        let this = self as *mut Pair;
         return ((unsafe { Pair::GetFirst(self) })
             + (unsafe {
-                let _field: *mut i32 = &mut self.first as *mut i32;
+                let _field: *mut i32 = &mut (*this).first as *mut i32;
                 Pair::Set(self, _field, new_first)
             }));
     }
     pub unsafe fn SetSecond(&mut self, mut new_second: i32) -> i32 {
+        let this = self as *mut Pair;
         return ((unsafe { Pair::GetSecond(self) })
             + (unsafe {
-                let _field: *mut i32 = &mut self.second as *mut i32;
+                let _field: *mut i32 = &mut (*this).second as *mut i32;
                 Pair::Set(self, _field, new_second)
             }));
     }
@@ -49,8 +56,9 @@ pub struct Route {
 }
 impl Route {
     pub unsafe fn SetCost(&mut self, mut new_cost: f64) -> f64 {
-        let mut old_cost: f64 = self.cost;
-        self.cost = new_cost;
+        let this = self as *mut Route;
+        let mut old_cost: f64 = (*this).cost;
+        (*this).cost = new_cost;
         return old_cost;
     }
 }

--- a/tests/unit/out/unsafe/class_template_lazy_member.rs
+++ b/tests/unit/out/unsafe/class_template_lazy_member.rs
@@ -18,7 +18,8 @@ pub struct Box_int_ {
 }
 impl Box_int_ {
     pub unsafe fn twice(&mut self) -> i32 {
-        return ((self.val) + (self.val));
+        let this = self as *mut Box_int_;
+        return (((*this).val) + ((*this).val));
     }
 }
 #[repr(C)]
@@ -28,7 +29,8 @@ pub struct Box_Point_ {
 }
 impl Box_Point_ {
     pub unsafe fn get(&mut self) -> Point {
-        return self.val;
+        let this = self as *mut Box_Point_;
+        return (*this).val;
     }
 }
 pub fn main() {

--- a/tests/unit/out/unsafe/class_templates.rs
+++ b/tests/unit/out/unsafe/class_templates.rs
@@ -13,22 +13,27 @@ pub struct MyContainer_int_ {
 }
 impl MyContainer_int_ {
     pub unsafe fn empty(&self) -> bool {
-        return self.vec_.is_empty();
+        let this = self as *const MyContainer_int_;
+        return (*this).vec_.is_empty();
     }
     pub unsafe fn size(&self) -> usize {
-        return self.vec_.len();
+        let this = self as *const MyContainer_int_;
+        return (*this).vec_.len();
     }
     pub unsafe fn back(&mut self) -> *mut i32 {
-        return ((self.vec_).last_mut().unwrap());
+        let this = self as *mut MyContainer_int_;
+        return (((*this).vec_).last_mut().unwrap());
     }
     pub unsafe fn pop_back(&mut self) {
-        self.vec_.pop();
+        let this = self as *mut MyContainer_int_;
+        (*this).vec_.pop();
         return;
     }
     pub unsafe fn push_back(&mut self, item: *const i32) {
+        let this = self as *mut MyContainer_int_;
         {
             let a0_clone = (*item).clone();
-            self.vec_.push(a0_clone)
+            (*this).vec_.push(a0_clone)
         };
     }
 }
@@ -39,22 +44,27 @@ pub struct MyContainer_char_ {
 }
 impl MyContainer_char_ {
     pub unsafe fn empty(&self) -> bool {
-        return self.vec_.is_empty();
+        let this = self as *const MyContainer_char_;
+        return (*this).vec_.is_empty();
     }
     pub unsafe fn size(&self) -> usize {
-        return self.vec_.len();
+        let this = self as *const MyContainer_char_;
+        return (*this).vec_.len();
     }
     pub unsafe fn back(&mut self) -> *mut libc::c_char {
-        return ((self.vec_).last_mut().unwrap());
+        let this = self as *mut MyContainer_char_;
+        return (((*this).vec_).last_mut().unwrap());
     }
     pub unsafe fn pop_back(&mut self) {
-        self.vec_.pop();
+        let this = self as *mut MyContainer_char_;
+        (*this).vec_.pop();
         return;
     }
     pub unsafe fn push_back(&mut self, item: *const libc::c_char) {
+        let this = self as *mut MyContainer_char_;
         {
             let a0_clone = (*item).clone();
-            self.vec_.push(a0_clone)
+            (*this).vec_.push(a0_clone)
         };
     }
 }
@@ -65,22 +75,27 @@ pub struct MyContainer_float_ {
 }
 impl MyContainer_float_ {
     pub unsafe fn empty(&self) -> bool {
-        return self.vec_.is_empty();
+        let this = self as *const MyContainer_float_;
+        return (*this).vec_.is_empty();
     }
     pub unsafe fn size(&self) -> usize {
-        return self.vec_.len();
+        let this = self as *const MyContainer_float_;
+        return (*this).vec_.len();
     }
     pub unsafe fn back(&mut self) -> *mut f32 {
-        return ((self.vec_).last_mut().unwrap());
+        let this = self as *mut MyContainer_float_;
+        return (((*this).vec_).last_mut().unwrap());
     }
     pub unsafe fn pop_back(&mut self) {
-        self.vec_.pop();
+        let this = self as *mut MyContainer_float_;
+        (*this).vec_.pop();
         return;
     }
     pub unsafe fn push_back(&mut self, item: *const f32) {
+        let this = self as *mut MyContainer_float_;
         {
             let a0_clone = (*item).clone();
-            self.vec_.push(a0_clone)
+            (*this).vec_.push(a0_clone)
         };
     }
 }

--- a/tests/unit/out/unsafe/complex_function.rs
+++ b/tests/unit/out/unsafe/complex_function.rs
@@ -27,7 +27,8 @@ pub struct X2 {
 }
 impl X2 {
     pub unsafe fn get(&mut self) -> *mut X1 {
-        return self.v;
+        let this = self as *mut X2;
+        return (*this).v;
     }
 }
 #[repr(C)]
@@ -37,7 +38,8 @@ pub struct X3 {
 }
 impl X3 {
     pub unsafe fn get(&mut self) -> *mut X2 {
-        return self.v;
+        let this = self as *mut X3;
+        return (*this).v;
     }
 }
 #[repr(C)]
@@ -47,7 +49,8 @@ pub struct X4 {
 }
 impl X4 {
     pub unsafe fn get(&mut self) -> *mut X3 {
-        return &mut self.v as *mut X3;
+        let this = self as *mut X4;
+        return &mut (*this).v as *mut X3;
     }
 }
 pub fn main() {

--- a/tests/unit/out/unsafe/constructor.rs
+++ b/tests/unit/out/unsafe/constructor.rs
@@ -14,18 +14,22 @@ pub struct S {
 }
 impl S {
     pub unsafe fn const_method(&self) -> i32 {
-        return ((self.v) * (2));
+        let this = self as *const S;
+        return (((*this).v) * (2));
     }
     pub unsafe fn mut_method(&mut self) {
-        self.v += 1;
+        let this = self as *mut S;
+        (*this).v += 1;
     }
     pub unsafe fn S(mut init: i32) -> Self {
-        let mut this = Self { v: init };
-        (unsafe { S::mut_method(&mut this) });
-        total_0 += (unsafe { S::const_method(&mut this) });
-        this
+        let mut __this = Self { v: init };
+        let this = &raw mut __this;
+        (unsafe { S::mut_method(&mut *this) });
+        total_0 += (unsafe { S::const_method(&mut *this) });
+        __this
     }
     pub unsafe fn destructor(&mut self) {
+        let this = self as *mut S;
         (unsafe { S::mut_method(self) });
         total_0 += (unsafe { S::const_method(self) });
     }

--- a/tests/unit/out/unsafe/destructor.rs
+++ b/tests/unit/out/unsafe/destructor.rs
@@ -12,6 +12,7 @@ pub static mut global_0: i32 = unsafe { 0 };
 pub struct S {}
 impl S {
     pub unsafe fn destructor(&mut self) {
+        let this = self as *mut S;
         global_0.postfix_inc();
     }
 }
@@ -71,6 +72,7 @@ pub struct EmptyBody {
 }
 impl EmptyBody {
     pub unsafe fn destructor(&mut self) {
+        let this = self as *mut EmptyBody;
         S::destructor(&mut self.s);
     }
 }
@@ -81,6 +83,7 @@ pub struct Templated_char_ {
 }
 impl Templated_char_ {
     pub unsafe fn destructor(&mut self) {
+        let this = self as *mut Templated_char_;
         global_0 = ((global_0 as usize)
             .wrapping_add((::std::mem::size_of::<libc::c_char>() as usize)))
             as i32;
@@ -93,6 +96,7 @@ pub struct Templated_int_ {
 }
 impl Templated_int_ {
     pub unsafe fn destructor(&mut self) {
+        let this = self as *mut Templated_int_;
         global_0 =
             ((global_0 as usize).wrapping_add((::std::mem::size_of::<i32>() as usize))) as i32;
     }
@@ -104,6 +108,7 @@ pub struct Copied {
 }
 impl Copied {
     pub unsafe fn destructor(&mut self) {
+        let this = self as *mut Copied;
         global_0.postfix_inc();
     }
 }
@@ -116,7 +121,8 @@ pub struct Tagged {
 }
 impl Tagged {
     pub unsafe fn destructor(&mut self) {
-        order_1[(order_count_2.postfix_inc()) as usize] = self.tag;
+        let this = self as *mut Tagged;
+        order_1[(order_count_2.postfix_inc()) as usize] = (*this).tag;
     }
 }
 #[repr(C)]

--- a/tests/unit/out/unsafe/doubly_linked_list.rs
+++ b/tests/unit/out/unsafe/doubly_linked_list.rs
@@ -15,10 +15,12 @@ pub struct Node {
 }
 impl Node {
     pub unsafe fn SetNext(&mut self, mut n: *mut Node) {
-        self.next = n;
+        let this = self as *mut Node;
+        (*this).next = n;
     }
     pub unsafe fn SetPrev(&mut self, mut p: *mut Node) {
-        self.prev = p;
+        let this = self as *mut Node;
+        (*this).prev = p;
     }
 }
 pub unsafe fn Find_0(mut head: *mut Node, mut idx: i32) -> *mut Node {

--- a/tests/unit/out/unsafe/exprs.rs
+++ b/tests/unit/out/unsafe/exprs.rs
@@ -19,10 +19,12 @@ pub struct Y {
 }
 impl Y {
     pub unsafe fn foo(&mut self) -> *mut X {
-        return &mut self.x as *mut X;
+        let this = self as *mut Y;
+        return &mut (*this).x as *mut X;
     }
     pub unsafe fn ptr(&mut self) -> *mut X {
-        return (&mut self.x as *mut X);
+        let this = self as *mut Y;
+        return (&mut (*this).x as *mut X);
     }
 }
 pub fn main() {

--- a/tests/unit/out/unsafe/function_overloading.rs
+++ b/tests/unit/out/unsafe/function_overloading.rs
@@ -25,12 +25,24 @@ pub unsafe fn bar_4(x: *mut i32) -> i32 {
 #[derive(Copy, Clone, Default)]
 pub struct Foo {}
 impl Foo {
-    pub unsafe fn foo_const(&self) {}
-    pub unsafe fn foo(&mut self) {}
-    pub unsafe fn method_i32(&mut self, mut x: i32) {}
-    pub unsafe fn method_i32_const(&self, mut x: i32) {}
-    pub unsafe fn method2_i32_i32_const(&self, mut x: i32, mut y: i32) {}
-    pub unsafe fn method2_f64_f64_const(&self, mut x: f64, mut y: f64) {}
+    pub unsafe fn foo_const(&self) {
+        let this = self as *const Foo;
+    }
+    pub unsafe fn foo(&mut self) {
+        let this = self as *mut Foo;
+    }
+    pub unsafe fn method_i32(&mut self, mut x: i32) {
+        let this = self as *mut Foo;
+    }
+    pub unsafe fn method_i32_const(&self, mut x: i32) {
+        let this = self as *const Foo;
+    }
+    pub unsafe fn method2_i32_i32_const(&self, mut x: i32, mut y: i32) {
+        let this = self as *const Foo;
+    }
+    pub unsafe fn method2_f64_f64_const(&self, mut x: f64, mut y: f64) {
+        let this = self as *const Foo;
+    }
 }
 pub unsafe fn func_5(mut x: i32) -> i32 {
     return 1;

--- a/tests/unit/out/unsafe/huffman.rs
+++ b/tests/unit/out/unsafe/huffman.rs
@@ -16,7 +16,8 @@ pub struct MinHeapNode {
 }
 impl MinHeapNode {
     pub unsafe fn IsLeaf(&self) -> bool {
-        return ((self.left).is_null()) && ((self.right).is_null());
+        let this = self as *const MinHeapNode;
+        return (((*this).left).is_null()) && (((*this).right).is_null());
     }
 }
 pub unsafe fn Swap_0(a: *mut MinHeapNode, b: *mut MinHeapNode) {
@@ -52,61 +53,66 @@ pub struct MinHeap {
 }
 impl MinHeap {
     pub unsafe fn Alloc(&mut self, mut data: libc::c_char, mut freq: i32) -> *mut MinHeapNode {
-        self.alloc.as_mut().unwrap()[(self.next as usize)] = MinHeapNode {
+        let this = self as *mut MinHeap;
+        (*this).alloc.as_mut().unwrap()[((*this).next as usize)] = MinHeapNode {
             data: data,
             freq: freq,
             left: std::ptr::null_mut(),
             right: std::ptr::null_mut(),
         };
-        return (&mut self.alloc.as_mut().unwrap()[(self.next.postfix_inc() as usize)]
+        return (&mut (*this).alloc.as_mut().unwrap()[((*this).next.postfix_inc() as usize)]
             as *mut MinHeapNode);
     }
     pub unsafe fn Heapify(&mut self, mut idx: i32) {
+        let this = self as *mut MinHeap;
         let mut smallest: i32 = idx;
         let mut left: i32 = (((2) * (idx)) + (1));
         let mut right: i32 = (((2) * (idx)) + (2));
-        if ((left) < (self.size))
-            && (((*self.arr.as_mut().unwrap()[(left as usize)]).freq)
-                < ((*self.arr.as_mut().unwrap()[(smallest as usize)]).freq))
+        if ((left) < ((*this).size))
+            && (((*(*this).arr.as_mut().unwrap()[(left as usize)]).freq)
+                < ((*(*this).arr.as_mut().unwrap()[(smallest as usize)]).freq))
         {
             smallest = left;
         }
-        if ((right) < (self.size))
-            && (((*self.arr.as_mut().unwrap()[(right as usize)]).freq)
-                < ((*self.arr.as_mut().unwrap()[(smallest as usize)]).freq))
+        if ((right) < ((*this).size))
+            && (((*(*this).arr.as_mut().unwrap()[(right as usize)]).freq)
+                < ((*(*this).arr.as_mut().unwrap()[(smallest as usize)]).freq))
         {
             smallest = right;
         }
         if ((smallest) != (idx)) {
             (unsafe {
                 let _a: *mut MinHeapNode =
-                    &mut (*self.arr.as_mut().unwrap()[(smallest as usize)]) as *mut MinHeapNode;
+                    &mut (*(*this).arr.as_mut().unwrap()[(smallest as usize)]) as *mut MinHeapNode;
                 let _b: *mut MinHeapNode =
-                    &mut (*self.arr.as_mut().unwrap()[(idx as usize)]) as *mut MinHeapNode;
+                    &mut (*(*this).arr.as_mut().unwrap()[(idx as usize)]) as *mut MinHeapNode;
                 Swap_0(_a, _b)
             });
             (unsafe { MinHeap::Heapify(self, smallest) });
         }
     }
     pub unsafe fn ExtractMin(&mut self) -> *mut MinHeapNode {
-        let mut out: *mut MinHeapNode = self.arr.as_mut().unwrap()[(0_usize)];
-        self.size.prefix_dec();
-        self.arr.as_mut().unwrap()[(0_usize)] = self.arr.as_mut().unwrap()[(self.size as usize)];
+        let this = self as *mut MinHeap;
+        let mut out: *mut MinHeapNode = (*this).arr.as_mut().unwrap()[(0_usize)];
+        (*this).size.prefix_dec();
+        (*this).arr.as_mut().unwrap()[(0_usize)] =
+            (*this).arr.as_mut().unwrap()[((*this).size as usize)];
         (unsafe { MinHeap::Heapify(self, 0) });
         return out;
     }
     pub unsafe fn Insert(&mut self, mut node: *mut MinHeapNode) {
-        self.size.prefix_inc();
-        let mut i: i32 = ((self.size) - (1));
+        let this = self as *mut MinHeap;
+        (*this).size.prefix_inc();
+        let mut i: i32 = (((*this).size) - (1));
         'loop_: while ((i) != (0))
             && (((*node).freq)
-                < ((*self.arr.as_mut().unwrap()[((((i) - (1)) / (2)) as usize)]).freq))
+                < ((*(*this).arr.as_mut().unwrap()[((((i) - (1)) / (2)) as usize)]).freq))
         {
-            self.arr.as_mut().unwrap()[(i as usize)] =
-                self.arr.as_mut().unwrap()[((((i) - (1)) / (2)) as usize)];
+            (*this).arr.as_mut().unwrap()[(i as usize)] =
+                (*this).arr.as_mut().unwrap()[((((i) - (1)) / (2)) as usize)];
             i = (((i) - (1)) / (2));
         }
-        self.arr.as_mut().unwrap()[(i as usize)] = node;
+        (*this).arr.as_mut().unwrap()[(i as usize)] = node;
     }
     pub unsafe fn Build(
         &mut self,
@@ -114,16 +120,17 @@ impl MinHeap {
         freq: *mut Option<Box<[i32]>>,
         mut n: i32,
     ) {
+        let this = self as *mut MinHeap;
         let mut i: i32 = 0;
         'loop_: while ((i) < (n)) {
-            self.arr.as_mut().unwrap()[(self.size.postfix_inc() as usize)] = (unsafe {
+            (*this).arr.as_mut().unwrap()[((*this).size.postfix_inc() as usize)] = (unsafe {
                 let _data: libc::c_char = (*data).as_mut().unwrap()[(i as usize)];
                 let _freq: i32 = (*freq).as_mut().unwrap()[(i as usize)];
                 MinHeap::Alloc(self, _data, _freq)
             });
             i.prefix_inc();
         }
-        let mut i: i32 = (((self.size) - (2)) / (2));
+        let mut i: i32 = ((((*this).size) - (2)) / (2));
         'loop_: while ((i) >= (0)) {
             (unsafe { MinHeap::Heapify(self, i) });
             i.prefix_dec();

--- a/tests/unit/out/unsafe/immutable-deref-on-func-call.rs
+++ b/tests/unit/out/unsafe/immutable-deref-on-func-call.rs
@@ -13,6 +13,7 @@ pub struct Item {
 }
 impl Item {
     pub unsafe fn foo(&mut self, mut other: *mut Item) {
+        let this = self as *mut Item;
         (*other).value = 10;
     }
 }

--- a/tests/unit/out/unsafe/kruskal.rs
+++ b/tests/unit/out/unsafe/kruskal.rs
@@ -102,40 +102,43 @@ pub struct DisjointSet {
 }
 impl DisjointSet {
     pub unsafe fn makeSet(&mut self) {
+        let this = self as *mut DisjointSet;
         let mut i: i32 = 0;
-        'loop_: while ((i) < (self.n)) {
-            self.parent.as_mut().unwrap()[(i as usize)] = i;
-            self.rank.as_mut().unwrap()[(i as usize)] = 1;
+        'loop_: while ((i) < ((*this).n)) {
+            (*this).parent.as_mut().unwrap()[(i as usize)] = i;
+            (*this).rank.as_mut().unwrap()[(i as usize)] = 1;
             i.postfix_inc();
         }
     }
     pub unsafe fn find(&mut self, mut x: i32) -> i32 {
-        if ((self.parent.as_mut().unwrap()[(x as usize)]) != (x)) {
-            self.parent.as_mut().unwrap()[(x as usize)] = (unsafe {
-                let _x: i32 = self.parent.as_mut().unwrap()[(x as usize)];
+        let this = self as *mut DisjointSet;
+        if (((*this).parent.as_mut().unwrap()[(x as usize)]) != (x)) {
+            (*this).parent.as_mut().unwrap()[(x as usize)] = (unsafe {
+                let _x: i32 = (*this).parent.as_mut().unwrap()[(x as usize)];
                 DisjointSet::find(self, _x)
             });
         }
-        return self.parent.as_mut().unwrap()[(x as usize)];
+        return (*this).parent.as_mut().unwrap()[(x as usize)];
     }
     pub unsafe fn merge(&mut self, mut x: i32, mut y: i32) {
+        let this = self as *mut DisjointSet;
         let mut xset: i32 = (unsafe { DisjointSet::find(self, x) });
         let mut yset: i32 = (unsafe { DisjointSet::find(self, y) });
         if ((xset) == (yset)) {
             return;
         }
-        if ((self.rank.as_mut().unwrap()[(xset as usize)])
-            < (self.rank.as_mut().unwrap()[(yset as usize)]))
+        if (((*this).rank.as_mut().unwrap()[(xset as usize)])
+            < ((*this).rank.as_mut().unwrap()[(yset as usize)]))
         {
-            self.parent.as_mut().unwrap()[(xset as usize)] = yset;
-        } else if ((self.rank.as_mut().unwrap()[(xset as usize)])
-            > (self.rank.as_mut().unwrap()[(yset as usize)]))
+            (*this).parent.as_mut().unwrap()[(xset as usize)] = yset;
+        } else if (((*this).rank.as_mut().unwrap()[(xset as usize)])
+            > ((*this).rank.as_mut().unwrap()[(yset as usize)]))
         {
-            self.parent.as_mut().unwrap()[(yset as usize)] = xset;
+            (*this).parent.as_mut().unwrap()[(yset as usize)] = xset;
         } else {
-            self.parent.as_mut().unwrap()[(yset as usize)] = xset;
-            self.rank.as_mut().unwrap()[(xset as usize)] =
-                ((self.rank.as_mut().unwrap()[(xset as usize)]) + (1));
+            (*this).parent.as_mut().unwrap()[(yset as usize)] = xset;
+            (*this).rank.as_mut().unwrap()[(xset as usize)] =
+                (((*this).rank.as_mut().unwrap()[(xset as usize)]) + (1));
         }
     }
 }

--- a/tests/unit/out/unsafe/linked_list.rs
+++ b/tests/unit/out/unsafe/linked_list.rs
@@ -14,7 +14,8 @@ pub struct Node {
 }
 impl Node {
     pub unsafe fn SetNext(&mut self, mut next: *mut Node) {
-        self.next = next;
+        let this = self as *mut Node;
+        (*this).next = next;
     }
 }
 pub unsafe fn Find_0(mut head: *mut Node, mut idx: i32) -> *mut Node {

--- a/tests/unit/out/unsafe/operator_arithmetic_member.rs
+++ b/tests/unit/out/unsafe/operator_arithmetic_member.rs
@@ -13,52 +13,63 @@ pub struct S {
 }
 impl S {
     pub unsafe fn operator_add_pconstS_const(&self, o: *const S) -> S {
+        let this = self as *const S;
         return S {
-            v: ((self.v) + ((*o).v)),
+            v: (((*this).v) + ((*o).v)),
         };
     }
     pub unsafe fn operator_sub_pconstS_const(&self, o: *const S) -> S {
+        let this = self as *const S;
         return S {
-            v: ((self.v) - ((*o).v)),
+            v: (((*this).v) - ((*o).v)),
         };
     }
     pub unsafe fn operator_mul(&self, o: *const S) -> S {
+        let this = self as *const S;
         return S {
-            v: ((self.v) * ((*o).v)),
+            v: (((*this).v) * ((*o).v)),
         };
     }
     pub unsafe fn operator_div(&self, o: *const S) -> S {
+        let this = self as *const S;
         return S {
-            v: ((self.v) / ((*o).v)),
+            v: (((*this).v) / ((*o).v)),
         };
     }
     pub unsafe fn operator_rem(&self, o: *const S) -> S {
+        let this = self as *const S;
         return S {
-            v: ((self.v) % ((*o).v)),
+            v: (((*this).v) % ((*o).v)),
         };
     }
     pub unsafe fn operator_pos_const(&self) -> S {
-        return S { v: self.v };
+        let this = self as *const S;
+        return S { v: (*this).v };
     }
     pub unsafe fn operator_neg_const(&self) -> S {
-        return S { v: -self.v };
+        let this = self as *const S;
+        return S { v: -(*this).v };
     }
     pub unsafe fn operator_inc(&mut self) -> *mut S {
-        self.v.prefix_inc();
-        return &mut (*self) as *mut S;
+        let this = self as *mut S;
+        (*this).v.prefix_inc();
+        return &mut (*this) as *mut S;
     }
     pub unsafe fn operator_post_inc_i32(&mut self, _: i32) -> S {
-        let mut old: S = (*self);
-        self.v.prefix_inc();
+        let this = self as *mut S;
+        let mut old: S = (*this);
+        (*this).v.prefix_inc();
         return old;
     }
     pub unsafe fn operator_dec(&mut self) -> *mut S {
-        self.v.prefix_dec();
-        return &mut (*self) as *mut S;
+        let this = self as *mut S;
+        (*this).v.prefix_dec();
+        return &mut (*this) as *mut S;
     }
     pub unsafe fn operator_post_dec_i32(&mut self, _: i32) -> S {
-        let mut old: S = (*self);
-        self.v.prefix_dec();
+        let this = self as *mut S;
+        let mut old: S = (*this);
+        (*this).v.prefix_dec();
         return old;
     }
 }

--- a/tests/unit/out/unsafe/operator_bitwise_member.rs
+++ b/tests/unit/out/unsafe/operator_bitwise_member.rs
@@ -13,31 +13,37 @@ pub struct S {
 }
 impl S {
     pub unsafe fn operator_bitnot(&self) -> S {
-        return S { v: !self.v };
+        let this = self as *const S;
+        return S { v: !(*this).v };
     }
     pub unsafe fn operator_bitand(&self, o: *const S) -> S {
+        let this = self as *const S;
         return S {
-            v: ((self.v) & ((*o).v)),
+            v: (((*this).v) & ((*o).v)),
         };
     }
     pub unsafe fn operator_bitor(&self, o: *const S) -> S {
+        let this = self as *const S;
         return S {
-            v: ((self.v) | ((*o).v)),
+            v: (((*this).v) | ((*o).v)),
         };
     }
     pub unsafe fn operator_bitxor(&self, o: *const S) -> S {
+        let this = self as *const S;
         return S {
-            v: ((self.v) ^ ((*o).v)),
+            v: (((*this).v) ^ ((*o).v)),
         };
     }
     pub unsafe fn operator_shl(&self, mut n: i32) -> S {
+        let this = self as *const S;
         return S {
-            v: ((self.v) << (n)),
+            v: (((*this).v) << (n)),
         };
     }
     pub unsafe fn operator_shr(&self, mut n: i32) -> S {
+        let this = self as *const S;
         return S {
-            v: ((self.v) >> (n)),
+            v: (((*this).v) >> (n)),
         };
     }
 }

--- a/tests/unit/out/unsafe/operator_comparison_member.rs
+++ b/tests/unit/out/unsafe/operator_comparison_member.rs
@@ -13,25 +13,32 @@ pub struct S {
 }
 impl S {
     pub unsafe fn operator_eq(&self, o: *const S) -> bool {
-        return ((self.v) == ((*o).v));
+        let this = self as *const S;
+        return (((*this).v) == ((*o).v));
     }
     pub unsafe fn operator_ne(&self, o: *const S) -> bool {
-        return ((self.v) != ((*o).v));
+        let this = self as *const S;
+        return (((*this).v) != ((*o).v));
     }
     pub unsafe fn operator_lt_pconstS_const(&self, o: *const S) -> bool {
-        return ((self.v) < ((*o).v));
+        let this = self as *const S;
+        return (((*this).v) < ((*o).v));
     }
     pub unsafe fn operator_gt(&self, o: *const S) -> bool {
-        return ((self.v) > ((*o).v));
+        let this = self as *const S;
+        return (((*this).v) > ((*o).v));
     }
     pub unsafe fn operator_le(&self, o: *const S) -> bool {
-        return ((self.v) <= ((*o).v));
+        let this = self as *const S;
+        return (((*this).v) <= ((*o).v));
     }
     pub unsafe fn operator_ge(&self, o: *const S) -> bool {
-        return ((self.v) >= ((*o).v));
+        let this = self as *const S;
+        return (((*this).v) >= ((*o).v));
     }
     pub unsafe fn operator_lt_i32_const(&self, mut o: i32) -> bool {
-        return ((self.v) < (o));
+        let this = self as *const S;
+        return (((*this).v) < (o));
     }
 }
 impl std::cmp::Ord for S {

--- a/tests/unit/out/unsafe/operator_comparison_mixed.rs
+++ b/tests/unit/out/unsafe/operator_comparison_mixed.rs
@@ -13,22 +13,28 @@ pub struct S {
 }
 impl S {
     pub unsafe fn operator_eq(&self, mut o: i32) -> bool {
-        return ((self.v) == (o));
+        let this = self as *const S;
+        return (((*this).v) == (o));
     }
     pub unsafe fn operator_ne(&self, mut o: i32) -> bool {
-        return ((self.v) != (o));
+        let this = self as *const S;
+        return (((*this).v) != (o));
     }
     pub unsafe fn operator_lt(&self, mut o: i32) -> bool {
-        return ((self.v) < (o));
+        let this = self as *const S;
+        return (((*this).v) < (o));
     }
     pub unsafe fn operator_gt(&self, mut o: f64) -> bool {
-        return ((self.v as f64) > (o));
+        let this = self as *const S;
+        return (((*this).v as f64) > (o));
     }
     pub unsafe fn operator_le(&self, mut o: i64) -> bool {
-        return ((self.v as i64) <= (o));
+        let this = self as *const S;
+        return (((*this).v as i64) <= (o));
     }
     pub unsafe fn operator_ge(&self, mut o: *const libc::c_char) -> bool {
-        return ((self.v) >= (((*o) as i32) - (('0' as libc::c_char) as i32)));
+        let this = self as *const S;
+        return (((*this).v) >= (((*o) as i32) - (('0' as libc::c_char) as i32)));
     }
 }
 pub unsafe fn operator_eq_0(mut a: i32, b: *const S) -> bool {

--- a/tests/unit/out/unsafe/operator_compound_assignment_member.rs
+++ b/tests/unit/out/unsafe/operator_compound_assignment_member.rs
@@ -13,48 +13,59 @@ pub struct S {
 }
 impl S {
     pub unsafe fn operator_assign_u32(&mut self, mut n: u32) -> *mut S {
-        self.v = n;
-        return &mut (*self) as *mut S;
+        let this = self as *mut S;
+        (*this).v = n;
+        return &mut (*this) as *mut S;
     }
     pub unsafe fn operator_add_assign(&mut self, o: *const S) -> *mut S {
-        self.v = (self.v).wrapping_add((*o).v);
-        return &mut (*self) as *mut S;
+        let this = self as *mut S;
+        (*this).v = ((*this).v).wrapping_add((*o).v);
+        return &mut (*this) as *mut S;
     }
     pub unsafe fn operator_sub_assign(&mut self, o: *const S) -> *mut S {
-        self.v = (self.v).wrapping_sub((*o).v);
-        return &mut (*self) as *mut S;
+        let this = self as *mut S;
+        (*this).v = ((*this).v).wrapping_sub((*o).v);
+        return &mut (*this) as *mut S;
     }
     pub unsafe fn operator_mul_assign(&mut self, o: *const S) -> *mut S {
-        self.v = (self.v).wrapping_mul((*o).v);
-        return &mut (*self) as *mut S;
+        let this = self as *mut S;
+        (*this).v = ((*this).v).wrapping_mul((*o).v);
+        return &mut (*this) as *mut S;
     }
     pub unsafe fn operator_div_assign(&mut self, o: *const S) -> *mut S {
-        self.v = (self.v).wrapping_div((*o).v);
-        return &mut (*self) as *mut S;
+        let this = self as *mut S;
+        (*this).v = ((*this).v).wrapping_div((*o).v);
+        return &mut (*this) as *mut S;
     }
     pub unsafe fn operator_rem_assign(&mut self, o: *const S) -> *mut S {
-        self.v = (self.v).wrapping_rem((*o).v);
-        return &mut (*self) as *mut S;
+        let this = self as *mut S;
+        (*this).v = ((*this).v).wrapping_rem((*o).v);
+        return &mut (*this) as *mut S;
     }
     pub unsafe fn operator_bitand_assign(&mut self, o: *const S) -> *mut S {
-        self.v &= (*o).v;
-        return &mut (*self) as *mut S;
+        let this = self as *mut S;
+        (*this).v &= (*o).v;
+        return &mut (*this) as *mut S;
     }
     pub unsafe fn operator_bitor_assign(&mut self, o: *const S) -> *mut S {
-        self.v |= (*o).v;
-        return &mut (*self) as *mut S;
+        let this = self as *mut S;
+        (*this).v |= (*o).v;
+        return &mut (*this) as *mut S;
     }
     pub unsafe fn operator_bitxor_assign(&mut self, o: *const S) -> *mut S {
-        self.v ^= (*o).v;
-        return &mut (*self) as *mut S;
+        let this = self as *mut S;
+        (*this).v ^= (*o).v;
+        return &mut (*this) as *mut S;
     }
     pub unsafe fn operator_shl_assign(&mut self, mut n: i32) -> *mut S {
-        self.v <<= n;
-        return &mut (*self) as *mut S;
+        let this = self as *mut S;
+        (*this).v <<= n;
+        return &mut (*this) as *mut S;
     }
     pub unsafe fn operator_shr_assign(&mut self, mut n: i32) -> *mut S {
-        self.v >>= n;
-        return &mut (*self) as *mut S;
+        let this = self as *mut S;
+        (*this).v >>= n;
+        return &mut (*this) as *mut S;
     }
 }
 pub fn main() {

--- a/tests/unit/out/unsafe/operator_less_than.rs
+++ b/tests/unit/out/unsafe/operator_less_than.rs
@@ -14,8 +14,9 @@ pub struct Pair {
 }
 impl Pair {
     pub unsafe fn operator_lt(&mut self, other: *const Pair) -> bool {
-        return ((self.x) < ((*other).x))
-            || (((self.x) == ((*other).x)) && ((self.y) < ((*other).y)));
+        let this = self as *mut Pair;
+        return (((*this).x) < ((*other).x))
+            || ((((*this).x) == ((*other).x)) && (((*this).y) < ((*other).y)));
     }
 }
 impl std::cmp::Ord for Pair {

--- a/tests/unit/out/unsafe/operator_logical_member.rs
+++ b/tests/unit/out/unsafe/operator_logical_member.rs
@@ -13,13 +13,16 @@ pub struct S {
 }
 impl S {
     pub unsafe fn operator_not(&self) -> bool {
-        return ((self.v) == (0));
+        let this = self as *const S;
+        return (((*this).v) == (0));
     }
     pub unsafe fn operator_and(&self, o: *const S) -> bool {
-        return ((self.v) != (0)) && (((*o).v) != (0));
+        let this = self as *const S;
+        return (((*this).v) != (0)) && (((*o).v) != (0));
     }
     pub unsafe fn operator_or(&self, o: *const S) -> bool {
-        return ((self.v) != (0)) || (((*o).v) != (0));
+        let this = self as *const S;
+        return (((*this).v) != (0)) || (((*o).v) != (0));
     }
 }
 pub fn main() {

--- a/tests/unit/out/unsafe/operator_member_pointer_member.rs
+++ b/tests/unit/out/unsafe/operator_member_pointer_member.rs
@@ -28,19 +28,24 @@ pub struct S {
 }
 impl S {
     pub unsafe fn operator_index_i32(&mut self, mut i: i32) -> *mut i32 {
-        return &mut self.data[(i) as usize] as *mut i32;
+        let this = self as *mut S;
+        return &mut (*this).data[(i) as usize] as *mut i32;
     }
     pub unsafe fn operator_index_i32_const(&self, mut i: i32) -> *const i32 {
-        return &self.data[(i) as usize] as *const i32;
+        let this = self as *const S;
+        return &(*this).data[(i) as usize] as *const i32;
     }
     pub unsafe fn operator_deref(&mut self) -> *mut Inner {
-        return &mut self.inner as *mut Inner;
+        let this = self as *mut S;
+        return &mut (*this).inner as *mut Inner;
     }
     pub unsafe fn operator_arrow(&mut self) -> *mut Inner {
-        return (&mut self.inner as *mut Inner);
+        let this = self as *mut S;
+        return (&mut (*this).inner as *mut Inner);
     }
     pub unsafe fn operator_addr(&mut self) -> *mut i32 {
-        return (&mut self.data[(0) as usize] as *mut i32);
+        let this = self as *mut S;
+        return (&mut (*this).data[(0) as usize] as *mut i32);
     }
 }
 impl Default for S {

--- a/tests/unit/out/unsafe/operator_other_member.rs
+++ b/tests/unit/out/unsafe/operator_other_member.rs
@@ -21,24 +21,30 @@ pub struct S {
 }
 impl S {
     pub unsafe fn operator_call_const(&self) -> i32 {
-        return self.v;
+        let this = self as *const S;
+        return (*this).v;
     }
     pub unsafe fn operator_call_i32_const(&self, mut a: i32) -> i32 {
-        return ((self.v) + (a));
+        let this = self as *const S;
+        return (((*this).v) + (a));
     }
     pub unsafe fn operator_call_i32_i32_const(&self, mut a: i32, mut b: i32) -> i32 {
-        return (((self.v) + (a)) + (b));
+        let this = self as *const S;
+        return ((((*this).v) + (a)) + (b));
     }
     pub unsafe fn operator_comma(&self, o: *const S) -> S {
+        let this = self as *const S;
         return S {
-            v: (((self.v) * (10)) + ((*o).v)),
+            v: ((((*this).v) * (10)) + ((*o).v)),
         };
     }
     pub unsafe fn operator_int(&self) -> i32 {
-        return self.v;
+        let this = self as *const S;
+        return (*this).v;
     }
     pub unsafe fn operator__Bool(&self) -> bool {
-        return ((self.v) != (0));
+        let this = self as *const S;
+        return (((*this).v) != (0));
     }
 }
 pub fn main() {

--- a/tests/unit/out/unsafe/operator_overloads.rs
+++ b/tests/unit/out/unsafe/operator_overloads.rs
@@ -13,25 +13,32 @@ pub struct S {
 }
 impl S {
     pub unsafe fn operator_eq_i32_const(&self, mut o: i32) -> i32 {
-        return if ((self.v) == (o)) { 1 } else { 0 };
+        let this = self as *const S;
+        return if (((*this).v) == (o)) { 1 } else { 0 };
     }
     pub unsafe fn operator_eq_i64_const(&self, mut o: i64) -> i32 {
-        return if ((self.v as i64) == (o)) { 2 } else { 0 };
+        let this = self as *const S;
+        return if (((*this).v as i64) == (o)) { 2 } else { 0 };
     }
     pub unsafe fn operator_eq_f64_const(&self, mut o: f64) -> i32 {
-        return if ((self.v as f64) == (o)) { 3 } else { 0 };
+        let this = self as *const S;
+        return if (((*this).v as f64) == (o)) { 3 } else { 0 };
     }
     pub unsafe fn operator_add(&self, o: *const S) -> i32 {
-        return ((self.v) + ((*o).v));
+        let this = self as *const S;
+        return (((*this).v) + ((*o).v));
     }
     pub unsafe fn operator_sub(&self, mut o: S) -> i32 {
-        return ((self.v) - (o.v));
+        let this = self as *const S;
+        return (((*this).v) - (o.v));
     }
     pub unsafe fn operator_mul_pconstS_const(&self, o: *const S) -> i32 {
-        return ((self.v) * ((*o).v));
+        let this = self as *const S;
+        return (((*this).v) * ((*o).v));
     }
     pub unsafe fn operator_mul_i32_const(&self, mut o: i32) -> i32 {
-        return (((self.v) * (o)) + (1));
+        let this = self as *const S;
+        return ((((*this).v) * (o)) + (1));
     }
 }
 pub unsafe fn operator_div_0(a: *const S, b: *const S) -> i32 {

--- a/tests/unit/out/unsafe/operator_qualifiers.rs
+++ b/tests/unit/out/unsafe/operator_qualifiers.rs
@@ -13,31 +13,40 @@ pub struct S {
 }
 impl S {
     pub unsafe fn operator_add_i32(&mut self, mut a: i32) -> i32 {
-        return ((self.v) + (a));
+        let this = self as *mut S;
+        return (((*this).v) + (a));
     }
     pub unsafe fn operator_add_i32_const(&self, mut a: i32) -> i32 {
-        return (((self.v) + (a)) + (1));
+        let this = self as *const S;
+        return ((((*this).v) + (a)) + (1));
     }
     pub unsafe fn operator_add_i32_volatile(&mut self, mut a: i32) -> i32 {
-        return (((self.v) + (a)) + (2));
+        let this = self as *mut S;
+        return ((((*this).v) + (a)) + (2));
     }
     pub unsafe fn operator_sub_i32_lref(&mut self, mut a: i32) -> i32 {
-        return ((self.v) - (a));
+        let this = self as *mut S;
+        return (((*this).v) - (a));
     }
     pub unsafe fn operator_sub_i32_rref(&mut self, mut a: i32) -> i32 {
-        return (((self.v) - (a)) - (1));
+        let this = self as *mut S;
+        return ((((*this).v) - (a)) - (1));
     }
     pub unsafe fn operator_mul_i32_const_lref(&self, mut a: i32) -> i32 {
-        return ((self.v) * (a));
+        let this = self as *const S;
+        return (((*this).v) * (a));
     }
     pub unsafe fn operator_mul_i32_const_rref(&self, mut a: i32) -> i32 {
-        return (((self.v) * (a)) * (2));
+        let this = self as *const S;
+        return ((((*this).v) * (a)) * (2));
     }
     pub unsafe fn operator_index_i32_lref(&mut self, mut i: i32) -> i32 {
-        return ((self.v) + (i));
+        let this = self as *mut S;
+        return (((*this).v) + (i));
     }
     pub unsafe fn operator_index_i32_const_lref(&self, mut i: i32) -> i32 {
-        return (((self.v) + (i)) + (100));
+        let this = self as *const S;
+        return ((((*this).v) + (i)) + (100));
     }
 }
 pub fn main() {

--- a/tests/unit/out/unsafe/operator_three_way.rs
+++ b/tests/unit/out/unsafe/operator_three_way.rs
@@ -13,16 +13,18 @@ pub struct S {
 }
 impl S {
     pub unsafe fn operator_cmp(&self, o: *const S) -> std::cmp::Ordering {
-        if ((self.v) < ((*o).v)) {
+        let this = self as *const S;
+        if (((*this).v) < ((*o).v)) {
             return std::cmp::Ordering::Less;
         }
-        if ((self.v) > ((*o).v)) {
+        if (((*this).v) > ((*o).v)) {
             return std::cmp::Ordering::Greater;
         }
         return std::cmp::Ordering::Equal;
     }
     pub unsafe fn operator_eq(&self, o: *const S) -> bool {
-        return ((self.v) == ((*o).v));
+        let this = self as *const S;
+        return (((*this).v) == ((*o).v));
     }
 }
 impl std::cmp::Ord for S {

--- a/tests/unit/out/unsafe/operator_traits.rs
+++ b/tests/unit/out/unsafe/operator_traits.rs
@@ -13,7 +13,8 @@ pub struct Lt {
 }
 impl Lt {
     pub unsafe fn operator_lt(&self, o: *const Lt) -> bool {
-        return ((self.v) < ((*o).v));
+        let this = self as *const Lt;
+        return (((*this).v) < ((*o).v));
     }
 }
 impl std::cmp::Ord for Lt {
@@ -50,7 +51,8 @@ pub struct Eq {
 }
 impl Eq {
     pub unsafe fn operator_eq(&self, o: *const Eq) -> bool {
-        return ((self.v) == ((*o).v));
+        let this = self as *const Eq;
+        return (((*this).v) == ((*o).v));
     }
 }
 impl std::cmp::PartialEq for Eq {
@@ -66,10 +68,12 @@ pub struct Cmp {
 }
 impl Cmp {
     pub unsafe fn operator_cmp(&self, o: *const Cmp) -> std::cmp::Ordering {
-        return (self.v).cmp(&((*o).v));
+        let this = self as *const Cmp;
+        return ((*this).v).cmp(&((*o).v));
     }
     pub unsafe fn operator_eq(&self, o: *const Cmp) -> bool {
-        return ((self.v) == ((*o).v));
+        let this = self as *const Cmp;
+        return (((*this).v) == ((*o).v));
     }
 }
 impl std::cmp::Ord for Cmp {

--- a/tests/unit/out/unsafe/pointers.rs
+++ b/tests/unit/out/unsafe/pointers.rs
@@ -13,16 +13,20 @@ pub struct Test {
 }
 impl Test {
     pub unsafe fn inc(&mut self) {
-        self.x.postfix_inc();
+        let this = self as *mut Test;
+        (*this).x.postfix_inc();
     }
     pub unsafe fn dec(&mut self) {
-        self.x.postfix_dec();
+        let this = self as *mut Test;
+        (*this).x.postfix_dec();
     }
     pub unsafe fn as_ptr(&mut self) -> *mut i32 {
-        return (&mut self.x as *mut i32);
+        let this = self as *mut Test;
+        return (&mut (*this).x as *mut i32);
     }
     pub unsafe fn update(&mut self, mut x: i32, mut y: i32) {
-        self.x = ((x) + (y));
+        let this = self as *mut Test;
+        (*this).x = ((x) + (y));
     }
 }
 pub unsafe fn Update_0(mut t: *mut Test) -> *mut Test {

--- a/tests/unit/out/unsafe/polymorphism.rs
+++ b/tests/unit/out/unsafe/polymorphism.rs
@@ -14,6 +14,7 @@ pub unsafe trait Animal {
 pub struct Dog {}
 unsafe impl Animal for Dog {
     unsafe fn bark(&self) -> bool {
+        let this = self as *const Dog;
         return true;
     }
 }
@@ -22,11 +23,13 @@ unsafe impl Animal for Dog {
 pub struct Cat {}
 impl Cat {
     unsafe fn meow(&self) -> bool {
+        let this = self as *const Cat;
         return true;
     }
 }
 unsafe impl Animal for Cat {
     unsafe fn bark(&self) -> bool {
+        let this = self as *const Cat;
         return false;
     }
 }

--- a/tests/unit/out/unsafe/random.rs
+++ b/tests/unit/out/unsafe/random.rs
@@ -19,22 +19,26 @@ pub struct Pair {
 }
 impl Pair {
     pub unsafe fn method(&mut self) {
-        self.x.postfix_inc();
-        self.y.prefix_inc();
-        self.a[(4) as usize] = 1;
-        (*self.r) = 1;
-        self.p = std::ptr::null_mut();
-        self.pair = std::ptr::null_mut();
-        self.ap[(0) as usize] = std::ptr::null_mut();
+        let this = self as *mut Pair;
+        (*this).x.postfix_inc();
+        (*this).y.prefix_inc();
+        (*this).a[(4) as usize] = 1;
+        (*(*this).r) = 1;
+        (*this).p = std::ptr::null_mut();
+        (*this).pair = std::ptr::null_mut();
+        (*this).ap[(0) as usize] = std::ptr::null_mut();
     }
     pub unsafe fn as_val(&mut self) -> i32 {
-        return self.x;
+        let this = self as *mut Pair;
+        return (*this).x;
     }
     pub unsafe fn as_ref(&mut self) -> *mut i32 {
-        return &mut self.x as *mut i32;
+        let this = self as *mut Pair;
+        return &mut (*this).x as *mut i32;
     }
     pub unsafe fn as_ptr(&mut self) -> *mut i32 {
-        return (&mut self.x as *mut i32);
+        let this = self as *mut Pair;
+        return (&mut (*this).x as *mut i32);
     }
 }
 impl Default for Pair {

--- a/tests/unit/out/unsafe/rvalue_struct.rs
+++ b/tests/unit/out/unsafe/rvalue_struct.rs
@@ -14,8 +14,9 @@ pub struct S {
 }
 impl S {
     pub unsafe fn S(mut a: i32, mut b: i32) -> Self {
-        let mut this = Self { a: a, b: b };
-        this
+        let mut __this = Self { a: a, b: b };
+        let this = &raw mut __this;
+        __this
     }
 }
 pub fn main() {

--- a/tests/unit/out/unsafe/static_var_in_class.rs
+++ b/tests/unit/out/unsafe/static_var_in_class.rs
@@ -12,6 +12,7 @@ static mut inner_const_0: i32 = unsafe { 1 };
 pub struct C {}
 impl C {
     pub unsafe fn get(&mut self) -> i32 {
+        let this = self as *mut C;
         return inner_const_0;
     }
 }

--- a/tests/unit/out/unsafe/struct_ctor.rs
+++ b/tests/unit/out/unsafe/struct_ctor.rs
@@ -14,16 +14,19 @@ pub struct StructWithCtor {
 }
 impl StructWithCtor {
     pub unsafe fn StructWithCtor(mut x1: i32, mut x2: i32) -> Self {
-        let mut this = Self { x1_: x1, x2_: x2 };
-        this.x1_.prefix_inc();
-        this.x2_.prefix_dec();
-        this
+        let mut __this = Self { x1_: x1, x2_: x2 };
+        let this = &raw mut __this;
+        (*this).x1_.prefix_inc();
+        (*this).x2_.prefix_dec();
+        __this
     }
     pub unsafe fn x1(&self) -> *const i32 {
-        return &self.x1_ as *const i32;
+        let this = self as *const StructWithCtor;
+        return &(*this).x1_ as *const i32;
     }
     pub unsafe fn x2(&self) -> *const i32 {
-        return &self.x2_ as *const i32;
+        let this = self as *const StructWithCtor;
+        return &(*this).x2_ as *const i32;
     }
 }
 pub unsafe fn foo_0(x: *mut i32) -> *mut i32 {

--- a/tests/unit/out/unsafe/struct_default_ctor.rs
+++ b/tests/unit/out/unsafe/struct_default_ctor.rs
@@ -14,8 +14,9 @@ pub struct S {
 }
 impl S {
     pub unsafe fn S() -> Self {
-        let mut this = Self { a: 11, b: true };
-        this
+        let mut __this = Self { a: 11, b: true };
+        let this = &raw mut __this;
+        __this
     }
 }
 impl Default for S {

--- a/tests/unit/out/unsafe/this.rs
+++ b/tests/unit/out/unsafe/this.rs
@@ -70,6 +70,15 @@ impl S {
         let this = self as *mut S;
         (*this) = S::S({ 0 });
     }
+    pub unsafe fn copy_if_different(&mut self, mut other: *mut S) -> bool {
+        let this = self as *mut S;
+        if ((this) == (other)) {
+            return false;
+        }
+        (*this).a_ = (*other).a_;
+        (*this).self__ = (*other).self__;
+        return true;
+    }
 }
 pub unsafe fn bump_0(mut p: *mut S) {
     (*p).a_.postfix_inc();
@@ -133,5 +142,19 @@ unsafe fn main_0() -> i32 {
     (unsafe { S::reset(&mut s) });
     assert!(((s.a_) == (0)));
     assert!((s.self__).is_null());
+    assert!(
+        (((unsafe {
+            let _other: *mut S = (&mut s as *mut S);
+            S::copy_if_different(&mut s, _other)
+        }) as i32)
+            == (false as i32))
+    );
+    let mut other: S = S::S({ 22 });
+    assert!(
+        (((unsafe { S::copy_if_different(&mut s, (&mut other as *mut S),) }) as i32)
+            == (true as i32))
+    );
+    assert!(((s.a_) == (other.a_)));
+    assert!(((s.self__) == (other.self__)));
     return 0;
 }

--- a/tests/unit/out/unsafe/this.rs
+++ b/tests/unit/out/unsafe/this.rs
@@ -14,48 +14,61 @@ pub struct S {
 }
 impl S {
     pub unsafe fn S(mut a: i32) -> Self {
-        let mut this = Self {
+        let mut __this = Self {
             a_: a,
             self__: std::ptr::null_mut(),
         };
-        this
+        let this = &raw mut __this;
+        __this
     }
     pub unsafe fn returns_this_reference(&mut self) -> *mut S {
-        return &mut (*self) as *mut S;
+        let this = self as *mut S;
+        return &mut (*this) as *mut S;
     }
     pub unsafe fn returns_this_pointer(&mut self) -> *mut S {
-        return self;
+        let this = self as *mut S;
+        return this;
     }
     pub unsafe fn inc(&mut self) -> *mut S {
-        self.a_.postfix_inc();
-        return &mut (*self) as *mut S;
+        let this = self as *mut S;
+        (*this).a_.postfix_inc();
+        return &mut (*this) as *mut S;
     }
     pub unsafe fn set_from_this(&mut self) {
-        self.a_ = ((self.a_) + (1));
+        let this = self as *mut S;
+        (*this).a_ = (((*this).a_) + (1));
     }
     pub unsafe fn get(&mut self) -> i32 {
-        return self.a_;
+        let this = self as *mut S;
+        return (*this).a_;
     }
     pub unsafe fn twice(&mut self) -> i32 {
+        let this = self as *mut S;
         return ((unsafe { S::get(self) }) * (2));
     }
     pub unsafe fn link(&mut self) {
-        self.self__ = self;
+        let this = self as *mut S;
+        (*this).self__ = this;
     }
     pub unsafe fn bump_me(&mut self) {
-        (unsafe { bump_0(self) });
+        let this = self as *mut S;
+        (unsafe { bump_0(this) });
     }
     pub unsafe fn cref(&self) -> *const S {
-        return &(*self) as *const S;
+        let this = self as *const S;
+        return &(*this) as *const S;
     }
     pub unsafe fn is(&self, mut o: *const S) -> bool {
-        return ((o) == (self));
+        let this = self as *const S;
+        return ((o) == (this));
     }
     pub unsafe fn destroy(&mut self) {
-        ::std::mem::drop(Box::from_raw(self));
+        let this = self as *mut S;
+        ::std::mem::drop(Box::from_raw(this));
     }
     pub unsafe fn reset(&mut self) {
-        (*self) = S::S({ 0 });
+        let this = self as *mut S;
+        (*this) = S::S({ 0 });
     }
 }
 pub unsafe fn bump_0(mut p: *mut S) {
@@ -68,9 +81,10 @@ pub struct D {
 }
 impl D {
     pub unsafe fn D(mut a: i32) -> Self {
-        let mut this = Self { a_: a };
-        this.a_ *= 2;
-        this
+        let mut __this = Self { a_: a };
+        let this = &raw mut __this;
+        (*this).a_ *= 2;
+        __this
     }
 }
 pub fn main() {

--- a/tests/unit/out/unsafe/this.rs
+++ b/tests/unit/out/unsafe/this.rs
@@ -70,6 +70,15 @@ impl S {
         let this = self as *mut S;
         (*this) = S::S({ 0 });
     }
+    pub unsafe fn copy_if_different_const(&mut self, mut other: *const S) -> bool {
+        let this = self as *mut S;
+        if (((this).cast_const()) == (other)) {
+            return false;
+        }
+        (*this).a_ = (*other).a_;
+        (*this).self__ = (*other).self__;
+        return true;
+    }
     pub unsafe fn copy_if_different(&mut self, mut other: *mut S) -> bool {
         let this = self as *mut S;
         if ((this) == (other)) {
@@ -146,6 +155,13 @@ unsafe fn main_0() -> i32 {
         (((unsafe {
             let _other: *mut S = (&mut s as *mut S);
             S::copy_if_different(&mut s, _other)
+        }) as i32)
+            == (false as i32))
+    );
+    assert!(
+        (((unsafe {
+            let _other: *const S = (&mut s as *mut S).cast_const();
+            S::copy_if_different_const(&mut s, _other)
         }) as i32)
             == (false as i32))
     );

--- a/tests/unit/out/unsafe/this.rs
+++ b/tests/unit/out/unsafe/this.rs
@@ -13,12 +13,25 @@ pub struct S {
     pub self__: *mut S,
 }
 impl S {
-    pub unsafe fn S(mut a: i32) -> Self {
+    pub unsafe fn S1(mut a: i32) -> Self {
         let mut __this = Self {
             a_: a,
             self__: std::ptr::null_mut(),
         };
         let this = &raw mut __this;
+        __this
+    }
+    pub unsafe fn S2(mut a: i32, mut other: *mut S) -> Self {
+        let mut __this = Self {
+            a_: a,
+            self__: std::ptr::null_mut(),
+        };
+        let this = &raw mut __this;
+        if ((this) == (other)) {
+            (*this).self__ = std::ptr::null_mut();
+        } else {
+            (*this).self__ = other;
+        }
         __this
     }
     pub unsafe fn returns_this_reference(&mut self) -> *mut S {
@@ -68,7 +81,7 @@ impl S {
     }
     pub unsafe fn reset(&mut self) {
         let this = self as *mut S;
-        (*this) = S::S({ 0 });
+        (*this) = S::S1({ 0 });
     }
     pub unsafe fn copy_if_different_const(&mut self, mut other: *const S) -> bool {
         let this = self as *mut S;
@@ -111,7 +124,7 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    let mut s: S = S::S({ 1 });
+    let mut s: S = S::S1({ 1 });
     let ref_: *mut S = (unsafe { S::returns_this_reference(&mut s) });
     (*ref_).a_.postfix_inc();
     assert!(((s.a_) == (2)));
@@ -133,7 +146,7 @@ unsafe fn main_0() -> i32 {
     assert!(((d.a_) == (6)));
     let cr: *const S = (unsafe { S::cref(&s) });
     assert!((((*cr).a_) == (9)));
-    let mut t: S = S::S({ 0 });
+    let mut t: S = S::S1({ 0 });
     assert!(
         (unsafe {
             let _o: *const S = (&mut s as *mut S).cast_const();
@@ -141,12 +154,12 @@ unsafe fn main_0() -> i32 {
         })
     );
     assert!(!(unsafe { S::is(&s, (&mut t as *mut S).cast_const(),) }));
-    let mut p: *mut S = (Box::leak(Box::new(S::S({ 1 }))) as *mut S);
+    let mut p: *mut S = (Box::leak(Box::new(S::S1({ 1 }))) as *mut S);
     let mut q: *mut S = (unsafe { S::returns_this_pointer(&mut (*p)) });
     (*q).a_.postfix_inc();
     assert!((((*p).a_) == (2)));
     ::std::mem::drop(Box::from_raw(p));
-    let mut h: *mut S = (Box::leak(Box::new(S::S({ 5 }))) as *mut S);
+    let mut h: *mut S = (Box::leak(Box::new(S::S1({ 5 }))) as *mut S);
     (unsafe { S::destroy(&mut (*h)) });
     (unsafe { S::reset(&mut s) });
     assert!(((s.a_) == (0)));
@@ -165,12 +178,14 @@ unsafe fn main_0() -> i32 {
         }) as i32)
             == (false as i32))
     );
-    let mut other: S = S::S({ 22 });
+    let mut other: S = S::S1({ 22 });
     assert!(
         (((unsafe { S::copy_if_different(&mut s, (&mut other as *mut S),) }) as i32)
             == (true as i32))
     );
     assert!(((s.a_) == (other.a_)));
     assert!(((s.self__) == (other.self__)));
+    let mut u: S = S::S2({ 1 }, { (&mut s as *mut S) });
+    assert!(((u.self__) == (&mut s as *mut S)));
     return 0;
 }

--- a/tests/unit/out/unsafe/unique_ptr.rs
+++ b/tests/unit/out/unsafe/unique_ptr.rs
@@ -13,7 +13,8 @@ pub struct SafePointer {
 }
 impl SafePointer {
     pub unsafe fn inc(&mut self) {
-        (*self.ptr.as_deref_mut().unwrap()).prefix_inc();
+        let this = self as *mut SafePointer;
+        (*(*this).ptr.as_deref_mut().unwrap()).prefix_inc();
     }
 }
 #[repr(C)]
@@ -24,24 +25,25 @@ pub struct Pair {
 }
 impl Pair {
     pub unsafe fn inc(&mut self, mut k: i32) {
-        self.x += k;
-        self.y += k;
+        let this = self as *mut Pair;
+        (*this).x += k;
+        (*this).y += k;
     }
 }
 pub unsafe fn DoStuffWithSafePointer_0(safe_ptr: *mut Option<Box<SafePointer>>) {
     let mut x1: Option<Box<i32>> = Some(Box::new(0));
     let mut x2: Option<Box<i32>> = Some(Box::new(0));
     (*x2.as_deref_mut().unwrap()) = 1;
-    x1 = x2;
+    x1 = x2.take();
     let mut raw_ptr1: *mut i32 = (&mut (*x1.as_deref_mut().unwrap()) as *mut i32);
     (*raw_ptr1).prefix_inc();
-    (*(*safe_ptr).as_deref_mut().unwrap()).ptr = x1;
+    (*(*safe_ptr).as_deref_mut().unwrap()).ptr = x1.take();
     (unsafe { SafePointer::inc(&mut (*(*safe_ptr).as_deref_mut().unwrap())) });
     (unsafe { SafePointer::inc(&mut (*(*safe_ptr).as_deref_mut().unwrap())) });
     let mut x3: Option<Box<i32>> = Some(Box::new(10));
     let mut x4: Option<Box<i32>> = Some(Box::new(20));
     (*x3.as_deref_mut().unwrap()) = ((*x3.as_deref_mut().unwrap()) + (*x4.as_deref_mut().unwrap()));
-    x4 = x3;
+    x4 = x3.take();
     let mut raw_ptr2: *mut i32 = (&mut (*x4.as_deref_mut().unwrap()) as *mut i32);
     (*raw_ptr2) += 1;
     let mut pair: Option<Box<Pair>> = Some(Box::new(Pair {
@@ -60,7 +62,7 @@ pub unsafe fn DoStuffWithSafePointer_0(safe_ptr: *mut Option<Box<SafePointer>>) 
         + ((*pair.as_deref_mut().unwrap()).y));
 }
 pub unsafe fn Consume_1(mut safe_ptr: Option<Box<SafePointer>>) -> i32 {
-    let mut x: Option<Box<SafePointer>> = safe_ptr;
+    let mut x: Option<Box<SafePointer>> = safe_ptr.take();
     let mut p: Option<Box<Pair>> = Some(Box::from_raw(
         (Box::leak(Box::new(<Pair>::default())) as *mut Pair),
     ));
@@ -149,8 +151,8 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut x: Option<Box<i32>> = Some(Box::new(0));
-    let mut safe_ptr: Option<Box<SafePointer>> = Some(Box::new(SafePointer { ptr: x }));
+    let mut safe_ptr: Option<Box<SafePointer>> = Some(Box::new(SafePointer { ptr: x.take() }));
     (unsafe { DoStuffWithSafePointer_0(&mut safe_ptr as *mut Option<Box<SafePointer>>) });
-    assert!(((unsafe { Consume_1(safe_ptr,) }) == (60)));
+    assert!(((unsafe { Consume_1(safe_ptr.take(),) }) == (60)));
     return 0;
 }

--- a/tests/unit/out/unsafe/unique_ptr.rs
+++ b/tests/unit/out/unsafe/unique_ptr.rs
@@ -34,16 +34,16 @@ pub unsafe fn DoStuffWithSafePointer_0(safe_ptr: *mut Option<Box<SafePointer>>) 
     let mut x1: Option<Box<i32>> = Some(Box::new(0));
     let mut x2: Option<Box<i32>> = Some(Box::new(0));
     (*x2.as_deref_mut().unwrap()) = 1;
-    x1 = x2.take();
+    x1 = x2;
     let mut raw_ptr1: *mut i32 = (&mut (*x1.as_deref_mut().unwrap()) as *mut i32);
     (*raw_ptr1).prefix_inc();
-    (*(*safe_ptr).as_deref_mut().unwrap()).ptr = x1.take();
+    (*(*safe_ptr).as_deref_mut().unwrap()).ptr = x1;
     (unsafe { SafePointer::inc(&mut (*(*safe_ptr).as_deref_mut().unwrap())) });
     (unsafe { SafePointer::inc(&mut (*(*safe_ptr).as_deref_mut().unwrap())) });
     let mut x3: Option<Box<i32>> = Some(Box::new(10));
     let mut x4: Option<Box<i32>> = Some(Box::new(20));
     (*x3.as_deref_mut().unwrap()) = ((*x3.as_deref_mut().unwrap()) + (*x4.as_deref_mut().unwrap()));
-    x4 = x3.take();
+    x4 = x3;
     let mut raw_ptr2: *mut i32 = (&mut (*x4.as_deref_mut().unwrap()) as *mut i32);
     (*raw_ptr2) += 1;
     let mut pair: Option<Box<Pair>> = Some(Box::new(Pair {
@@ -62,7 +62,7 @@ pub unsafe fn DoStuffWithSafePointer_0(safe_ptr: *mut Option<Box<SafePointer>>) 
         + ((*pair.as_deref_mut().unwrap()).y));
 }
 pub unsafe fn Consume_1(mut safe_ptr: Option<Box<SafePointer>>) -> i32 {
-    let mut x: Option<Box<SafePointer>> = safe_ptr.take();
+    let mut x: Option<Box<SafePointer>> = safe_ptr;
     let mut p: Option<Box<Pair>> = Some(Box::from_raw(
         (Box::leak(Box::new(<Pair>::default())) as *mut Pair),
     ));
@@ -151,8 +151,8 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut x: Option<Box<i32>> = Some(Box::new(0));
-    let mut safe_ptr: Option<Box<SafePointer>> = Some(Box::new(SafePointer { ptr: x.take() }));
+    let mut safe_ptr: Option<Box<SafePointer>> = Some(Box::new(SafePointer { ptr: x }));
     (unsafe { DoStuffWithSafePointer_0(&mut safe_ptr as *mut Option<Box<SafePointer>>) });
-    assert!(((unsafe { Consume_1(safe_ptr.take(),) }) == (60)));
+    assert!(((unsafe { Consume_1(safe_ptr,) }) == (60)));
     return 0;
 }

--- a/tests/unit/out/unsafe/vector_with_allocator.rs
+++ b/tests/unit/out/unsafe/vector_with_allocator.rs
@@ -11,9 +11,12 @@ use std::rc::Rc;
 pub struct TestAllocator_int_ {}
 impl TestAllocator_int_ {
     pub unsafe fn allocate(&mut self, mut n: usize) -> *mut i32 {
+        let this = self as *mut TestAllocator_int_;
         return Box::leak((0..n).map(|_| 0_i32).collect::<Box<[i32]>>()).as_mut_ptr();
     }
     pub unsafe fn deallocate(&mut self, mut p: *mut i32, _: usize) {
+        let this = self as *mut TestAllocator_int_;
+
         ::std::mem::drop(Box::from_raw(::std::slice::from_raw_parts_mut(
             p,
             libcc2rs::malloc_usable_size(p as *mut ::libc::c_void) / ::std::mem::size_of::<i32>(),
@@ -25,9 +28,12 @@ impl TestAllocator_int_ {
 pub struct TestAllocator_double_ {}
 impl TestAllocator_double_ {
     pub unsafe fn allocate(&mut self, mut n: usize) -> *mut f64 {
+        let this = self as *mut TestAllocator_double_;
         return Box::leak((0..n).map(|_| 0.0_f64).collect::<Box<[f64]>>()).as_mut_ptr();
     }
     pub unsafe fn deallocate(&mut self, mut p: *mut f64, _: usize) {
+        let this = self as *mut TestAllocator_double_;
+
         ::std::mem::drop(Box::from_raw(::std::slice::from_raw_parts_mut(
             p,
             libcc2rs::malloc_usable_size(p as *mut ::libc::c_void) / ::std::mem::size_of::<f64>(),

--- a/tests/unit/this.cpp
+++ b/tests/unit/this.cpp
@@ -33,6 +33,15 @@ struct S {
 
   void reset() { *this = S(0); }
 
+  bool copy_if_different_const(const S *other) {
+    if (this == other) {
+      return false;
+    }
+    a_ = other->a_;
+    self_ = other->self_;
+    return true;
+  }
+
   bool copy_if_different(S *other) {
     if (this == other) {
       return false;
@@ -105,6 +114,7 @@ int main() {
   assert(s.self_ == nullptr);
 
   assert(s.copy_if_different(&s) == false);
+  assert(s.copy_if_different_const(&s) == false);
   auto other = S(22);
   assert(s.copy_if_different(&other) == true);
   assert(s.a_ == other.a_);

--- a/tests/unit/this.cpp
+++ b/tests/unit/this.cpp
@@ -33,6 +33,15 @@ struct S {
 
   void reset() { *this = S(0); }
 
+  bool copy_if_different(S *other) {
+    if (this == other) {
+      return false;
+    }
+    a_ = other->a_;
+    self_ = other->self_;
+    return true;
+  }
+
   int a_;
   S *self_;
 };
@@ -94,6 +103,12 @@ int main() {
   s.reset();
   assert(s.a_ == 0);
   assert(s.self_ == nullptr);
+
+  assert(s.copy_if_different(&s) == false);
+  auto other = S(22);
+  assert(s.copy_if_different(&other) == true);
+  assert(s.a_ == other.a_);
+  assert(s.self_ == other.self_);
 
   return 0;
 }

--- a/tests/unit/this.cpp
+++ b/tests/unit/this.cpp
@@ -6,6 +6,14 @@ void bump(S *p);
 struct S {
   S(int a) : a_(a), self_(nullptr) {}
 
+  S(int a, S *other) : a_(a) {
+    if (this == other) {
+      self_ = nullptr;
+    } else {
+      self_ = other;
+    }
+  }
+
   S &returns_this_reference() { return *this; }
 
   S *returns_this_pointer() { return this; }
@@ -119,6 +127,9 @@ int main() {
   assert(s.copy_if_different(&other) == true);
   assert(s.a_ == other.a_);
   assert(s.self_ == other.self_);
+
+  S u(1, &s);
+  assert(u.self_ == &s);
 
   return 0;
 }


### PR DESCRIPTION
In unsafe, method receivers have type `&Self`. This is incompatible for pointer comparisons between `this` and other pointers, for example:

```cpp
bool copy_if_different_const(const S* other) {
  if (this == other) {
    return false;
  }
  ...
}
```

Translates to:

```rs
fn copy_if_different_const(&mut self, other: *const S) {
  if self == other { return false; }
  ...
```

In rust, comparing a mutable reference with a const pointer is not allowed. To fix this, I added a function preamble that creates a this pointer with mutability attached:

```rs
let this = self as *mut S
```

and the check becomes:

```rs
if this.cast_const() == other { return false; }
```