### PR TITLE
Call take on unique_ptr in unsafe

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -1718,6 +1718,11 @@ bool Converter::VisitCallExpr(clang::CallExpr *expr) {
   }
 
   if (expr->isCallToStdMove()) {
+    if (IsUniquePtr(expr->getArg(0)->getType())) {
+      StrCat(std::format("{}.take()", ConvertLValue(expr->getArg(0))));
+      computed_expr_type_ = ComputedExprType::FreshValue;
+      return false;
+    }
     StrCat(std::format("{}", ToString(expr->getArg(0))));
     computed_expr_type_ = ComputedExprType::FreshValue;
     return false;

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -1030,13 +1030,7 @@ bool ConverterRefCount::VisitCallExpr(clang::CallExpr *expr) {
   }
 
   if (expr->isCallToStdMove()) {
-    if (IsUniquePtr(expr->getArg(0)->getType())) {
-      StrCat(std::format("{}.take()", ConvertLValue(expr->getArg(0))));
-    } else {
-      Convert(expr->getArg(0));
-    }
-    computed_expr_type_ = ComputedExprType::FreshValue;
-    return false;
+    return Converter::VisitCallExpr(expr);
   }
 
   if (auto *opcall = clang::dyn_cast<clang::CXXOperatorCallExpr>(expr);

--- a/tests/unit/11_move.cpp
+++ b/tests/unit/11_move.cpp
@@ -7,6 +7,7 @@
 void change(std::unique_ptr<int> &n) {
   std::unique_ptr<int> m = std::make_unique<int>(20);
   n = std::move(m);
+  assert(m.get() == nullptr);
 }
 
 int main() {

--- a/tests/unit/out/refcount/11_move.rs
+++ b/tests/unit/out/refcount/11_move.rs
@@ -10,6 +10,7 @@ pub fn change_0(n: Ptr<Option<Value<i32>>>) {
     let m: Value<Option<Value<i32>>> = Rc::new(RefCell::new(Some(Rc::new(RefCell::new(20)))));
     let __rhs = (*m.borrow_mut()).take();
     n.write(__rhs);
+    assert!(((*m.borrow()).as_pointer()).is_null());
 }
 pub fn main() {
     std::process::exit(main_0());

--- a/tests/unit/out/unsafe/07_unique.rs
+++ b/tests/unit/out/unsafe/07_unique.rs
@@ -25,7 +25,7 @@ unsafe fn main_0() -> i32 {
     let mut f_ptr2: *mut i32 = (&mut (*f.as_deref_mut().unwrap()) as *mut i32);
     (*f_ptr2) = 11;
     f = Some(Box::new(9));
-    f = (unsafe { fn_0(f) });
+    f = (unsafe { fn_0(f.take()) });
     assert!(((*f.as_deref_mut().unwrap()) == (10)));
     return 0;
 }

--- a/tests/unit/out/unsafe/11_move.rs
+++ b/tests/unit/out/unsafe/11_move.rs
@@ -8,7 +8,12 @@ use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn change_0(n: *mut Option<Box<i32>>) {
     let mut m: Option<Box<i32>> = Some(Box::new(20));
-    (*n) = m;
+    (*n) = m.take();
+    assert!(
+        (m.as_deref_mut()
+            .map_or(::std::ptr::null_mut(), |v| v as *mut i32))
+        .is_null()
+    );
 }
 pub fn main() {
     unsafe {

--- a/tests/unit/out/unsafe/alloc_array.rs
+++ b/tests/unit/out/unsafe/alloc_array.rs
@@ -17,7 +17,7 @@ pub unsafe fn All_0(arr: *mut Option<Box<[i32]>>, mut N: i32, mut element: i32) 
         all.as_mut().unwrap()[(i as usize)] = element;
         i.prefix_inc();
     }
-    (*arr) = all;
+    (*arr) = all.take();
 }
 pub unsafe fn Consume_1(mut arr: Option<Box<[i32]>>, mut N: i32) -> i32 {
     let mut sum: i32 = 0;
@@ -40,6 +40,6 @@ unsafe fn main_0() -> i32 {
             .collect::<Box<[_]>>(),
     );
     (unsafe { All_0(&mut arr as *mut Option<Box<[i32]>>, N, 1) });
-    assert!(((unsafe { Consume_1(arr, N,) }) == (10)));
+    assert!(((unsafe { Consume_1(arr.take(), N,) }) == (10)));
     return 0;
 }

--- a/tests/unit/out/unsafe/matmul.rs
+++ b/tests/unit/out/unsafe/matmul.rs
@@ -66,10 +66,10 @@ unsafe fn main_0() -> i32 {
     let mut m1: Option<Box<[Option<Box<[i32]>>]>> = (unsafe { matalloc_0(n, p, 1) });
     let mut m2: Option<Box<[Option<Box<[i32]>>]>> = (unsafe { matalloc_0(p, n, 2) });
     let mut m3: Option<Box<[Option<Box<[i32]>>]>> = (unsafe {
-        let _m1: Option<Box<[Option<Box<[i32]>>]>> = m1;
+        let _m1: Option<Box<[Option<Box<[i32]>>]>> = m1.take();
         let _n1: i32 = n;
         let _p1: i32 = p;
-        let _m2: Option<Box<[Option<Box<[i32]>>]>> = m2;
+        let _m2: Option<Box<[Option<Box<[i32]>>]>> = m2.take();
         let _n2: i32 = p;
         let _p2: i32 = n;
         matmul_1(_m1, _n1, _p1, _m2, _n2, _p2)

--- a/tests/unit/out/unsafe/references2.rs
+++ b/tests/unit/out/unsafe/references2.rs
@@ -8,7 +8,7 @@ use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn change_0(p: *mut Option<Box<i32>>) {
     let mut q: Option<Box<i32>> = Some(Box::new(7));
-    (*p) = q;
+    (*p) = q.take();
 }
 pub fn main() {
     unsafe {

--- a/tests/unit/out/unsafe/unique_ptr.rs
+++ b/tests/unit/out/unsafe/unique_ptr.rs
@@ -32,16 +32,16 @@ pub unsafe fn DoStuffWithSafePointer_0(safe_ptr: *mut Option<Box<SafePointer>>) 
     let mut x1: Option<Box<i32>> = Some(Box::new(0));
     let mut x2: Option<Box<i32>> = Some(Box::new(0));
     (*x2.as_deref_mut().unwrap()) = 1;
-    x1 = x2;
+    x1 = x2.take();
     let mut raw_ptr1: *mut i32 = (&mut (*x1.as_deref_mut().unwrap()) as *mut i32);
     (*raw_ptr1).prefix_inc();
-    (*(*safe_ptr).as_deref_mut().unwrap()).ptr = x1;
+    (*(*safe_ptr).as_deref_mut().unwrap()).ptr = x1.take();
     (unsafe { SafePointer::inc(&mut (*(*safe_ptr).as_deref_mut().unwrap())) });
     (unsafe { SafePointer::inc(&mut (*(*safe_ptr).as_deref_mut().unwrap())) });
     let mut x3: Option<Box<i32>> = Some(Box::new(10));
     let mut x4: Option<Box<i32>> = Some(Box::new(20));
     (*x3.as_deref_mut().unwrap()) = ((*x3.as_deref_mut().unwrap()) + (*x4.as_deref_mut().unwrap()));
-    x4 = x3;
+    x4 = x3.take();
     let mut raw_ptr2: *mut i32 = (&mut (*x4.as_deref_mut().unwrap()) as *mut i32);
     (*raw_ptr2) += 1;
     let mut pair: Option<Box<Pair>> = Some(Box::new(Pair {
@@ -60,7 +60,7 @@ pub unsafe fn DoStuffWithSafePointer_0(safe_ptr: *mut Option<Box<SafePointer>>) 
         + ((*pair.as_deref_mut().unwrap()).y));
 }
 pub unsafe fn Consume_1(mut safe_ptr: Option<Box<SafePointer>>) -> i32 {
-    let mut x: Option<Box<SafePointer>> = safe_ptr;
+    let mut x: Option<Box<SafePointer>> = safe_ptr.take();
     let mut p: Option<Box<Pair>> = Some(Box::from_raw(
         (Box::leak(Box::new(<Pair>::default())) as *mut Pair),
     ));
@@ -149,8 +149,8 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut x: Option<Box<i32>> = Some(Box::new(0));
-    let mut safe_ptr: Option<Box<SafePointer>> = Some(Box::new(SafePointer { ptr: x }));
+    let mut safe_ptr: Option<Box<SafePointer>> = Some(Box::new(SafePointer { ptr: x.take() }));
     (unsafe { DoStuffWithSafePointer_0(&mut safe_ptr as *mut Option<Box<SafePointer>>) });
-    assert!(((unsafe { Consume_1(safe_ptr,) }) == (60)));
+    assert!(((unsafe { Consume_1(safe_ptr.take(),) }) == (60)));
     return 0;
 }

--- a/tests/unit/out/unsafe/unique_ptr_small.rs
+++ b/tests/unit/out/unsafe/unique_ptr_small.rs
@@ -8,7 +8,7 @@ use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
 use std::rc::Rc;
 pub unsafe fn change_0(n: *mut Option<Box<i32>>) {
     let mut m: Option<Box<i32>> = Some(Box::new(20));
-    (*n) = m;
+    (*n) = m.take();
 }
 pub fn main() {
     unsafe {


### PR DESCRIPTION
After a `std::move` from a `std::unique_ptr`, C++ nulls the unique_ptr. Refcount already did that, unsafe did not. Also call `take()` in unsafe to null the pointer.