### PR TITLE
Fix default arguments

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -1913,6 +1913,11 @@ void Converter::EmitArgList(const CallInfo &info) {
   for (unsigned i = 0; i < info.args.size(); i++) {
     const auto &ca = info.args[i];
 
+    if (ca.has_default && clang::isa<clang::CXXDefaultArgExpr>(ca.expr)) {
+      StrCat("None", token::kComma);
+      continue;
+    }
+
     if (ca.has_default) {
       StrCat("Some");
     }

--- a/tests/unit/default_function_arguments.cpp
+++ b/tests/unit/default_function_arguments.cpp
@@ -1,0 +1,20 @@
+#include <cassert>
+
+int foo(int a, int b = 10) {
+  return a + b;
+}
+
+bool baz(int *a, int *b = nullptr) {
+  return a == b;
+}
+
+int main() {
+  assert(foo(1) == 11);
+  assert(foo(1, 2) == 3);
+
+  int a = 0;
+  assert(baz(&a) == false);
+  assert(baz(&a, &a) == true);
+
+  return 0;
+}

--- a/tests/unit/default_function_arguments.cpp
+++ b/tests/unit/default_function_arguments.cpp
@@ -1,12 +1,8 @@
 #include <cassert>
 
-int foo(int a, int b = 10) {
-  return a + b;
-}
+int foo(int a, int b = 10) { return a + b; }
 
-bool baz(int *a, int *b = nullptr) {
-  return a == b;
-}
+bool baz(int *a, int *b = nullptr) { return a == b; }
 
 int main() {
   assert(foo(1) == 11);

--- a/tests/unit/out/refcount/default_function_arguments.rs
+++ b/tests/unit/out/refcount/default_function_arguments.rs
@@ -1,0 +1,39 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn foo_0(a: i32, b: Option<i32>) -> i32 {
+    let a: Value<i32> = Rc::new(RefCell::new(a));
+    let b: Value<i32> = Rc::new(RefCell::new(b.unwrap_or(10)));
+    return ((*a.borrow()) + (*b.borrow()));
+}
+pub fn baz_1(a: Ptr<i32>, b: Option<Ptr<i32>>) -> bool {
+    let a: Value<Ptr<i32>> = Rc::new(RefCell::new(a));
+    let b: Value<Ptr<i32>> = Rc::new(RefCell::new(b.unwrap_or(Ptr::<i32>::null())));
+    return {
+        let _lhs = (*a.borrow()).clone();
+        _lhs == (*b.borrow()).clone()
+    };
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!((({ foo_0(1, None,) }) == 11));
+    assert!((({ foo_0(1, Some(2),) }) == 3));
+    let a: Value<i32> = Rc::new(RefCell::new(0));
+    assert!(((({ baz_1((a.as_pointer()), None,) }) as i32) == (false as i32)));
+    assert!(
+        ((({
+            let _a: Ptr<i32> = (a.as_pointer());
+            let _b: Ptr<i32> = (a.as_pointer());
+            baz_1(_a, Some(_b))
+        }) as i32)
+            == (true as i32))
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/fn_ptr_default_arg.rs
+++ b/tests/unit/out/refcount/fn_ptr_default_arg.rs
@@ -23,7 +23,7 @@ pub fn main() {
     std::process::exit(main_0());
 }
 fn main_0() -> i32 {
-    assert!((({ apply_1(5, Some(Default::default()),) }) == 5));
+    assert!((({ apply_1(5, None,) }) == 5));
     assert!((({ apply_1(5, Some(FnPtr::<fn(i32) -> i32>::null()),) }) == 5));
     assert!((({ apply_1(5, Some(FnPtr::<fn(i32) -> i32>::new(identity_0)),) }) == 5));
     let negate: Value<FnPtr<fn(i32) -> i32>> = Rc::new(RefCell::new(FnPtr::new(

--- a/tests/unit/out/unsafe/default_function_arguments.rs
+++ b/tests/unit/out/unsafe/default_function_arguments.rs
@@ -1,0 +1,36 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn foo_0(mut a: i32, mut b: Option<i32>) -> i32 {
+    let mut b: i32 = b.unwrap_or(10);
+    return ((a) + (b));
+}
+pub unsafe fn baz_1(mut a: *mut i32, mut b: Option<*mut i32>) -> bool {
+    let mut b: *mut i32 = b.unwrap_or(std::ptr::null_mut());
+    return ((a) == (b));
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(((unsafe { foo_0(1, None,) }) == (11)));
+    assert!(((unsafe { foo_0(1, Some(2),) }) == (3)));
+    let mut a: i32 = 0;
+    assert!((((unsafe { baz_1((&mut a as *mut i32), None,) }) as i32) == (false as i32)));
+    assert!(
+        (((unsafe {
+            let _a: *mut i32 = (&mut a as *mut i32);
+            let _b: *mut i32 = (&mut a as *mut i32);
+            baz_1(_a, Some(_b))
+        }) as i32)
+            == (true as i32))
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/fn_ptr_default_arg.rs
+++ b/tests/unit/out/unsafe/fn_ptr_default_arg.rs
@@ -22,7 +22,7 @@ pub fn main() {
     }
 }
 unsafe fn main_0() -> i32 {
-    assert!(((unsafe { apply_1(5, Some(Default::default()),) }) == (5)));
+    assert!(((unsafe { apply_1(5, None,) }) == (5)));
     assert!(((unsafe { apply_1(5, Some(None),) }) == (5)));
     assert!(((unsafe { apply_1(5, Some(Some(identity_0)),) }) == (5)));
     let mut negate: Option<unsafe fn(i32) -> i32> = Some(|x: i32| {


### PR DESCRIPTION
If no default argument is provided, the Rust argument should be `None`, not `Some(Default)`