### PR TITLE
Don't translate constexpr functions to const fn

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -377,8 +377,7 @@ bool Converter::VisitFunctionDecl(clang::FunctionDecl *decl) {
   // main_0 should be static
   if (!decl->isMain())
     ConvertFunctionQualifiers(decl);
-  StrCat(decl->isConstexpr() ? keyword_const_fn_ : "", keyword_unsafe_,
-         keyword::kFn, std::move(function_name));
+  StrCat(keyword_unsafe_, keyword::kFn, std::move(function_name));
   {
     PushParen paren(*this);
     ConvertFunctionParameters(decl);

--- a/cpp2rust/converter/converter.h
+++ b/cpp2rust/converter/converter.h
@@ -29,10 +29,9 @@ class Converter : public clang::RecursiveASTVisitor<Converter> {
 public:
   explicit Converter(std::string &rs_code, clang::ASTContext &ctx,
                      const char *keyword_unsafe = "unsafe",
-                     const char *keyword_mut = keyword::kMut,
-                     const char *keyword_const_fn = keyword::kConst)
+                     const char *keyword_mut = keyword::kMut)
       : rs_code_(&rs_code), ctx_(ctx), keyword_unsafe_(keyword_unsafe),
-        keyword_mut_(keyword_mut), keyword_const_fn_(keyword_const_fn) {}
+        keyword_mut_(keyword_mut) {}
 
   virtual ~Converter() = default;
 
@@ -1011,7 +1010,6 @@ private:
                                 const clang::QualType *type = nullptr);
   const char *keyword_unsafe_;
   const char *keyword_mut_;
-  const char *keyword_const_fn_;
   std::vector<ExprKind> curr_expr_kind_;
   static std::unordered_map<std::string, std::string> inner_structs_;
   static std::unordered_set<std::string> globals_;

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -19,7 +19,7 @@
 namespace cpp2rust {
 ConverterRefCount::ConverterRefCount(std::string &rs_code,
                                      clang::ASTContext &ctx)
-    : Converter(rs_code, ctx, "", "", ""),
+    : Converter(rs_code, ctx, "", ""),
       conversion_kind_({ConversionKind::Unboxed}) {}
 
 void ConverterRefCount::EmitFilePreamble() {

--- a/tests/unit/constexpr_function.cpp
+++ b/tests/unit/constexpr_function.cpp
@@ -1,0 +1,33 @@
+#include <cassert>
+
+int runtime_only(int x) { return x * 2; }
+
+constexpr int first(const int *p) { return *p; }
+
+constexpr int scaled(int x) {
+  if (x < 0) {
+    return runtime_only(-x);
+  }
+  return x;
+}
+
+constexpr double half(double x) { return x / 2.0; }
+
+struct P {
+  int v;
+  constexpr int get() const { return v; }
+};
+
+int main() {
+  int arr[2] = {7, 8};
+  assert(first(arr) == 7);
+  assert(first(arr + 1) == 8);
+  assert(scaled(3) == 3);
+  assert(scaled(-3) == 6);
+  assert(half(5.0) == 2.5);
+  P p{9};
+  assert(p.get() == 9);
+  constexpr int k = scaled(4);
+  assert(k == 4);
+  return 0;
+}

--- a/tests/unit/out/refcount/constexpr_function.rs
+++ b/tests/unit/out/refcount/constexpr_function.rs
@@ -1,0 +1,79 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn runtime_only_0(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    return ((*x.borrow()) * 2);
+}
+pub fn first_1(p: Ptr<i32>) -> i32 {
+    let p: Value<Ptr<i32>> = Rc::new(RefCell::new(p));
+    return ((*p.borrow()).read());
+}
+pub fn scaled_2(x: i32) -> i32 {
+    let x: Value<i32> = Rc::new(RefCell::new(x));
+    if ((*x.borrow()) < 0) {
+        return ({ runtime_only_0(-(*x.borrow())) });
+    }
+    return (*x.borrow());
+}
+pub fn half_3(x: f64) -> f64 {
+    let x: Value<f64> = Rc::new(RefCell::new(x));
+    return ((*x.borrow()) / 2.0E+0);
+}
+#[derive(Default)]
+pub struct P {
+    pub v: Value<i32>,
+}
+impl Clone for P {
+    fn clone(&self) -> Self {
+        let __this: Value<P> = Rc::new(RefCell::new(Self {
+            v: Rc::new(RefCell::new((*self.v.borrow()))),
+        }));
+        let this: Ptr<P> = __this.as_pointer();
+        Rc::try_unwrap(__this).ok().unwrap().into_inner()
+    }
+}
+impl ByteRepr for P {
+    fn byte_size() -> usize {
+        4
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.v.borrow()).to_bytes(&mut buf[0..4]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            v: Rc::new(RefCell::new(<i32>::from_bytes(&buf[0..4]))),
+        }
+    }
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let arr: Value<Box<[i32]>> = Rc::new(RefCell::new(Box::new([7, 8])));
+    assert!((({ first_1((arr.as_pointer() as Ptr::<i32>),) }) == 7));
+    assert!((({ first_1((arr.as_pointer() as Ptr::<i32>).offset((1) as isize),) }) == 8));
+    assert!((({ scaled_2(3,) }) == 3));
+    assert!((({ scaled_2(-3_i32,) }) == 6));
+    assert!((({ half_3(5.0E+0,) }) == 2.5E+0));
+    let p: Value<P> = Rc::new(RefCell::new(P {
+        v: Rc::new(RefCell::new(9)),
+    }));
+    assert!((({ PImpl::get(&p.as_pointer(),) }) == 9));
+    let k: Value<i32> = Rc::new(RefCell::new(({ scaled_2(4) })));
+    assert!(((*k.borrow()) == 4));
+    return 0;
+}
+pub trait PImpl {
+    fn get(&self) -> i32;
+}
+impl PImpl for Ptr<P> {
+    fn get(&self) -> i32 {
+        return (*(*(*self).upgrade().deref()).v.borrow());
+    }
+}

--- a/tests/unit/out/unsafe/constexpr_function.rs
+++ b/tests/unit/out/unsafe/constexpr_function.rs
@@ -1,0 +1,51 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn runtime_only_0(mut x: i32) -> i32 {
+    return ((x) * (2));
+}
+pub unsafe fn first_1(mut p: *const i32) -> i32 {
+    return (*p);
+}
+pub unsafe fn scaled_2(mut x: i32) -> i32 {
+    if ((x) < (0)) {
+        return (unsafe { runtime_only_0(-x) });
+    }
+    return x;
+}
+pub unsafe fn half_3(mut x: f64) -> f64 {
+    return ((x) / (2.0E+0));
+}
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct P {
+    pub v: i32,
+}
+impl P {
+    pub unsafe fn get(&self) -> i32 {
+        return self.v;
+    }
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut arr: [i32; 2] = [7, 8];
+    assert!(((unsafe { first_1((arr.as_mut_ptr()).cast_const(),) }) == (7)));
+    assert!(((unsafe { first_1((arr.as_mut_ptr().offset((1) as isize)).cast_const(),) }) == (8)));
+    assert!(((unsafe { scaled_2(3,) }) == (3)));
+    assert!(((unsafe { scaled_2(-3_i32,) }) == (6)));
+    assert!(((unsafe { half_3(5.0E+0,) }) == (2.5E+0)));
+    let mut p: P = P { v: 9 };
+    assert!(((unsafe { P::get(&p,) }) == (9)));
+    let k: i32 = (unsafe { scaled_2(4) });
+    assert!(((k) == (4)));
+    return 0;
+}


### PR DESCRIPTION
In C++ constexpr can call non-constexpr functions. Rust does not allow calling non-const function in const fn. This includes user-defined non-const functions and std functions like `.clone()`, `Rc::new()`, etc.