### PR TITLE
Add traits on field-less structs

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -76,6 +76,7 @@ std::string Converter::EmitMethodsOnPtr() {
 std::string Converter::EmitOpaqueRecords() {
   std::string out;
   record_decls_.ForEachUndefined([&](const std::string &name) {
+    out += "#[derive(Clone, Copy, Default, ByteRepr)]";
     out += "pub struct ";
     out += name;
     out += ";\n";

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -98,6 +98,11 @@ bool Converter::Convert(clang::QualType qual_type) {
     return false;
   }
 
+  if (auto decl = qual_type->getAsRecordDecl();
+      decl && IsUserDefinedDecl(decl)) {
+    record_decls_.MarkReferenced(GetRecordName(decl));
+  }
+
   auto mapped = Mapper::Map(qual_type);
   if (!mapped.empty() && mapped != token::kIgnoreRule) {
     StrCat(mapped);
@@ -206,11 +211,7 @@ bool Converter::VisitRecordType(clang::RecordType *type) {
     }
   }
 
-  auto name = GetRecordName(decl);
-  StrCat(name);
-  if (!ctx_.getSourceManager().isInSystemHeader(decl->getLocation())) {
-    record_decls_.MarkReferenced(std::move(name));
-  }
+  StrCat(GetRecordName(decl));
   Mapper::AddRuleForUserDefinedType(decl);
   return false;
 }

--- a/docs/src/runtime/overview.md
+++ b/docs/src/runtime/overview.md
@@ -69,7 +69,8 @@ The OS and libc surface:
 
 The crate has five dependencies:
 
-- `libcc2rs-macros` provides the control-flow proc macros.
+- `libcc2rs-macros` provides the [control-flow](./control-flow.md) and
+  [`derive(ByteRepr)`](./reinterpret.md#derivebyterepr) proc macros.
 - `libc` and `nix` provide the raw and safe OS interfaces the shims wrap.
 - `jiff` backs the time shims.
 - `sprintf` backs `printf`-style formatting.

--- a/docs/src/runtime/reinterpret.md
+++ b/docs/src/runtime/reinterpret.md
@@ -62,6 +62,18 @@ trait by hand with the byte layout of their C structs. Types with no meaningful
 C layout, such as `std::fs::File` or `Vec<T>`, implement the trait with defaults
 that panic, so reinterpreting one is caught at run time.
 
+### derive(ByteRepr)
+
+`libcc2rs-macros` provides a `#[derive(ByteRepr)]` proc macro. It is implemented
+only for unit structs, and expanding it on a struct with fields, an enum, or a
+union is a compile-time error. The expansion sets `byte_size` to 1 and leaves
+`to_bytes` and `from_bytes` on the trait's panicking defaults:
+
+```rust
+#[derive(Default, Clone, Copy, ByteRepr)]
+pub struct UnitStruct;
+```
+
 ## Views over the original allocation
 
 `reinterpret_cast` copies nothing. It produces a `Ptr` in the `Reinterpreted`

--- a/libcc2rs-macros/src/byte_repr.rs
+++ b/libcc2rs-macros/src/byte_repr.rs
@@ -1,0 +1,31 @@
+// Copyright (c) 2022-present INESC-ID.
+// Distributed under the MIT license that can be found in the LICENSE file.
+
+use proc_macro::TokenStream;
+use syn::{Data, DeriveInput, Fields, parse_macro_input};
+
+pub fn expand(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+    let empty = match &input.data {
+        Data::Struct(s) => match &s.fields {
+            Fields::Unit => true,
+            Fields::Named(f) => f.named.is_empty(),
+            Fields::Unnamed(f) => f.unnamed.is_empty(),
+        },
+        _ => false,
+    };
+    if !empty {
+        panic!("derive(ByteRepr) is only supported on empty structs, `{name}` is not empty");
+    }
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    quote::quote! {
+        impl #impl_generics ::libcc2rs::ByteRepr for #name #ty_generics #where_clause {
+            #[inline]
+            fn byte_size() -> usize {
+                1
+            }
+        }
+    }
+    .into()
+}

--- a/libcc2rs-macros/src/lib.rs
+++ b/libcc2rs-macros/src/lib.rs
@@ -3,6 +3,7 @@
 
 use proc_macro::TokenStream;
 
+mod byte_repr;
 mod goto;
 mod state_machine;
 mod switch;
@@ -78,4 +79,15 @@ pub fn goto(_input: TokenStream) -> TokenStream {
         compile_error!("goto!() can only be used inside goto_block!")
     }
     .into()
+}
+
+//     #[derive(ByteRepr)]
+//     pub struct S;
+//
+// Adds ByteRepr implementation for S. Currently only empty structs are handled. Non-empty structs
+// panic.
+
+#[proc_macro_derive(ByteRepr)]
+pub fn derive_byte_repr(input: TokenStream) -> TokenStream {
+    byte_repr::expand(input)
 }

--- a/libcc2rs-macros/tests/ui/byte_repr_non_empty.rs
+++ b/libcc2rs-macros/tests/ui/byte_repr_non_empty.rs
@@ -1,0 +1,8 @@
+use libcc2rs_macros::ByteRepr;
+
+#[derive(ByteRepr)]
+struct NonEmpty {
+    x: i32,
+}
+
+fn main() {}

--- a/libcc2rs-macros/tests/ui/byte_repr_non_empty.stderr
+++ b/libcc2rs-macros/tests/ui/byte_repr_non_empty.stderr
@@ -1,0 +1,7 @@
+error: proc-macro derive panicked
+ --> tests/ui/byte_repr_non_empty.rs:3:10
+  |
+3 | #[derive(ByteRepr)]
+  |          ^^^^^^^^
+  |
+  = help: message: derive(ByteRepr) is only supported on empty structs, `NonEmpty` is not empty

--- a/libcc2rs/src/lib.rs
+++ b/libcc2rs/src/lib.rs
@@ -51,4 +51,4 @@ pub use fd::*;
 mod format;
 pub use format::*;
 
-pub use libcc2rs_macros::{goto, goto_block, switch};
+pub use libcc2rs_macros::{ByteRepr, goto, goto_block, switch};

--- a/tests/multi-file/opaque_forward_decl/out/refcount/opaque_forward_decl.rs
+++ b/tests/multi-file/opaque_forward_decl/out/refcount/opaque_forward_decl.rs
@@ -51,4 +51,5 @@ pub fn touch_0(c: Ptr<container>) {
     let c: Value<Ptr<container>> = Rc::new(RefCell::new(c));
     &(*(*(*c.borrow()).upgrade().deref()).p.borrow());
 }
+#[derive(Clone, Copy, Default, ByteRepr)]
 pub struct opaque;

--- a/tests/multi-file/opaque_forward_decl/out/unsafe/opaque_forward_decl.rs
+++ b/tests/multi-file/opaque_forward_decl/out/unsafe/opaque_forward_decl.rs
@@ -30,4 +30,5 @@ unsafe fn main_0() -> i32 {
 pub unsafe fn touch_0(mut c: *mut container) {
     &((*c).p);
 }
+#[derive(Clone, Copy, Default, ByteRepr)]
 pub struct opaque;

--- a/tests/unit/opaque_record_copy.cpp
+++ b/tests/unit/opaque_record_copy.cpp
@@ -1,0 +1,20 @@
+#include <cassert>
+
+class Probe {
+public:
+  Probe &operator++();
+};
+
+template <class T>
+struct Wrapper {
+  T base_;
+  int tag;
+};
+
+int main() {
+  Wrapper<Probe> a{};
+  a.tag = 3;
+  Wrapper<Probe> b = a;
+  assert(b.tag == 3);
+  return 0;
+}

--- a/tests/unit/opaque_record_copy.cpp
+++ b/tests/unit/opaque_record_copy.cpp
@@ -5,8 +5,7 @@ public:
   Probe &operator++();
 };
 
-template <class T>
-struct Wrapper {
+template <class T> struct Wrapper {
   T base_;
   int tag;
 };

--- a/tests/unit/out/refcount/opaque_forward_decl.rs
+++ b/tests/unit/out/refcount/opaque_forward_decl.rs
@@ -45,4 +45,5 @@ fn main_0() -> i32 {
     &(*(*c.borrow()).p.borrow());
     return ((*(*c.borrow()).x.borrow()) - 42);
 }
+#[derive(Clone, Copy, Default, ByteRepr)]
 pub struct opaque;

--- a/tests/unit/out/refcount/opaque_record_copy.rs
+++ b/tests/unit/out/refcount/opaque_record_copy.rs
@@ -1,0 +1,53 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+#[derive(Default)]
+pub struct Wrapper_Probe_ {
+    pub base_: Value<Probe>,
+    pub tag: Value<i32>,
+}
+impl Clone for Wrapper_Probe_ {
+    fn clone(&self) -> Self {
+        let __this: Value<Wrapper_Probe_> = Rc::new(RefCell::new(Self {
+            base_: Rc::new(RefCell::new((*self.base_.borrow()).clone())),
+            tag: Rc::new(RefCell::new((*self.tag.borrow()))),
+        }));
+        let this: Ptr<Wrapper_Probe_> = __this.as_pointer();
+        Rc::try_unwrap(__this).ok().unwrap().into_inner()
+    }
+}
+impl ByteRepr for Wrapper_Probe_ {
+    fn byte_size() -> usize {
+        8
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.base_.borrow()).to_bytes(&mut buf[0..1]);
+        (*self.tag.borrow()).to_bytes(&mut buf[4..8]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            base_: Rc::new(RefCell::new(<Probe>::from_bytes(&buf[0..1]))),
+            tag: Rc::new(RefCell::new(<i32>::from_bytes(&buf[4..8]))),
+        }
+    }
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let a: Value<Wrapper_Probe_> = Rc::new(RefCell::new(Wrapper_Probe_ {
+        base_: Rc::new(RefCell::new(Probe {})),
+        tag: Rc::new(RefCell::new(<i32>::default())),
+    }));
+    (*(*a.borrow()).tag.borrow_mut()) = 3;
+    let b: Value<Wrapper_Probe_> = Rc::new(RefCell::new((*a.borrow()).clone()));
+    assert!(((*(*b.borrow()).tag.borrow()) == 3));
+    return 0;
+}
+#[derive(Clone, Copy, Default, ByteRepr)]
+pub struct Probe;

--- a/tests/unit/out/unsafe/opaque_forward_decl.rs
+++ b/tests/unit/out/unsafe/opaque_forward_decl.rs
@@ -25,4 +25,5 @@ unsafe fn main_0() -> i32 {
     &(c.p);
     return ((c.x) - (42));
 }
+#[derive(Clone, Copy, Default, ByteRepr)]
 pub struct opaque;

--- a/tests/unit/out/unsafe/opaque_record_copy.rs
+++ b/tests/unit/out/unsafe/opaque_record_copy.rs
@@ -1,0 +1,31 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+#[repr(C)]
+#[derive(Clone, Default)]
+pub struct Wrapper_Probe_ {
+    pub base_: Probe,
+    pub tag: i32,
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut a: Wrapper_Probe_ = Wrapper_Probe_ {
+        base_: Probe {},
+        tag: 0_i32,
+    };
+    a.tag = 3;
+    let mut b: Wrapper_Probe_ = a.clone();
+    assert!(((b.tag) == (3)));
+    return 0;
+}
+#[derive(Clone, Copy, Default, ByteRepr)]
+pub struct Probe;


### PR DESCRIPTION
Instantiated templates can be generated as structs with zero fields, aka unit struct.

We need unit structs to be copyable, clonable, defaultable and byterepr because they can be included in other structs that already satisfy those traits. For example:

```cpp

// This will be converted as a unit struct, it has no fields
class Probe {
public:
  Probe &operator++();
};

// Wrapper contains a unit struct, the unit struct must be clonable, copyable, etc,
// so that Wrapper can be clonable, copyable, etc
template <class T>
struct Wrapper {
  T base_;
  int tag;
};

int main() {
  // Instantiating Wrapper with Probe
  Wrapper<Probe> a{};
}
```

I also implemented ByteRepr as a proc-macro. Currently it only supports unit structs. 