### PR TITLE
Fix comparison operator call for move-only structs

### DIFF
--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -438,10 +438,9 @@ bool ConverterRefCount::VisitOffsetOfExpr(clang::OffsetOfExpr *expr) {
 std::string ConverterRefCount::GetComparisonCall(
     const clang::FunctionDecl *op, const clang::CXXRecordDecl *decl,
     std::string_view lhs, std::string_view rhs) {
-  auto lhs_ptr =
-      std::format("Rc::new(RefCell::new({}.clone())).as_pointer()", lhs);
-  auto rhs_ptr =
-      std::format("Rc::new(RefCell::new({}.clone())).as_pointer()", rhs);
+  PushConversionKind push(*this, ConversionKind::FullRefCount);
+  auto lhs_ptr = BoxValue(GetShallowCopy(decl, lhs)) + ".as_pointer()";
+  auto rhs_ptr = BoxValue(GetShallowCopy(decl, rhs)) + ".as_pointer()";
   if (const auto *method = clang::dyn_cast<clang::CXXMethodDecl>(op)) {
     return std::format("{}::{}(&{}, {})", GetUFCSName(method),
                        GetMethodName(method), lhs_ptr, rhs_ptr);
@@ -450,17 +449,14 @@ std::string ConverterRefCount::GetComparisonCall(
                      lhs_ptr, rhs_ptr);
 }
 
-void ConverterRefCount::EmitShallowCopy(const clang::RecordDecl *decl) {
-  StrCat("Rc::new");
-  PushParen rc_paren(*this);
-  StrCat("RefCell::new");
-  PushParen cell_paren(*this);
-  StrCat(GetRecordName(decl));
-  PushBrace init_brace(*this);
+std::string ConverterRefCount::GetShallowCopy(const clang::RecordDecl *decl,
+                                              std::string_view src) {
+  std::string fields;
   for (auto *field : decl->fields()) {
     auto name = GetNamedDeclAsString(field);
-    StrCat(std::format("{0}: self.{0}.clone(),", name));
+    fields += std::format("{0}: {1}.{0}.clone(),", name, src);
   }
+  return std::format("{} {{ {} }}", GetRecordName(decl), fields);
 }
 
 void ConverterRefCount::AddCloneTrait(const clang::RecordDecl *decl) {
@@ -500,9 +496,9 @@ void ConverterRefCount::AddCloneTrait(const clang::RecordDecl *decl) {
   StrCat("fn clone(&self) -> Self {");
 
   if (auto *ctor = GetUserDefinedCopyConstructor(cxx)) {
-    StrCat(std::format("let __src: Value<{}> =", record_name));
-    EmitShallowCopy(decl);
-    StrCat(token::kSemiColon);
+    PushConversionKind push(*this, ConversionKind::FullRefCount);
+    StrCat(std::format("let __src: Value<{}> = {};", record_name,
+                       BoxValue(GetShallowCopy(decl, "self"))));
     StrCat(std::format("{}::{}(__src.as_pointer())", record_name,
                        GetCtorName(ctor)));
   } else {

--- a/cpp2rust/converter/models/converter_refcount.h
+++ b/cpp2rust/converter/models/converter_refcount.h
@@ -41,7 +41,8 @@ public:
                                 std::string_view lhs,
                                 std::string_view rhs) override;
 
-  void EmitShallowCopy(const clang::RecordDecl *decl);
+  std::string GetShallowCopy(const clang::RecordDecl *decl,
+                             std::string_view src);
   void AddCloneTrait(const clang::RecordDecl *decl) override;
 
   void AddByteReprTrait(const clang::RecordDecl *decl) override;

--- a/tests/unit/operator_comparison_noncopyable.cpp
+++ b/tests/unit/operator_comparison_noncopyable.cpp
@@ -9,12 +9,8 @@ public:
   S &operator=(const S &) = delete;
   S(S &&) = default;
 
-  friend bool operator==(const S &x, const S &y) {
-    return x.data_ == y.data_;
-  }
-  friend bool operator<(const S &x, const S &y) {
-    return x.data_ < y.data_;
-  }
+  friend bool operator==(const S &x, const S &y) { return x.data_ == y.data_; }
+  friend bool operator<(const S &x, const S &y) { return x.data_ < y.data_; }
 };
 
 int main() {

--- a/tests/unit/operator_comparison_noncopyable.cpp
+++ b/tests/unit/operator_comparison_noncopyable.cpp
@@ -1,0 +1,26 @@
+#include <cassert>
+
+class S {
+  int data_;
+
+public:
+  S(int data) : data_(data) {}
+  S(const S &) = delete;
+  S &operator=(const S &) = delete;
+  S(S &&) = default;
+
+  friend bool operator==(const S &x, const S &y) {
+    return x.data_ == y.data_;
+  }
+  friend bool operator<(const S &x, const S &y) {
+    return x.data_ < y.data_;
+  }
+};
+
+int main() {
+  S a(1), b(2), c(1);
+  assert(a == c);
+  assert(a < b);
+  assert(!(b < a));
+  return 0;
+}

--- a/tests/unit/out/refcount/friend.rs
+++ b/tests/unit/out/refcount/friend.rs
@@ -37,8 +37,8 @@ impl std::cmp::PartialEq for V {
     fn eq(&self, other: &Self) -> bool {
         {
             operator_eq_1(
-                Rc::new(RefCell::new(self.clone())).as_pointer(),
-                Rc::new(RefCell::new(other.clone())).as_pointer(),
+                Rc::new(RefCell::new(V { x: self.x.clone() })).as_pointer(),
+                Rc::new(RefCell::new(V { x: other.x.clone() })).as_pointer(),
             )
         }
     }

--- a/tests/unit/out/refcount/operator_comparison_free.rs
+++ b/tests/unit/out/refcount/operator_comparison_free.rs
@@ -14,13 +14,13 @@ impl std::cmp::Ord for S {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         {
             if operator_lt_0(
-                Rc::new(RefCell::new(self.clone())).as_pointer(),
-                Rc::new(RefCell::new(other.clone())).as_pointer(),
+                Rc::new(RefCell::new(S { v: self.v.clone() })).as_pointer(),
+                Rc::new(RefCell::new(S { v: other.v.clone() })).as_pointer(),
             ) {
                 std::cmp::Ordering::Less
             } else if operator_lt_0(
-                Rc::new(RefCell::new(other.clone())).as_pointer(),
-                Rc::new(RefCell::new(self.clone())).as_pointer(),
+                Rc::new(RefCell::new(S { v: other.v.clone() })).as_pointer(),
+                Rc::new(RefCell::new(S { v: self.v.clone() })).as_pointer(),
             ) {
                 std::cmp::Ordering::Greater
             } else {
@@ -38,8 +38,8 @@ impl std::cmp::PartialEq for S {
     fn eq(&self, other: &Self) -> bool {
         {
             operator_eq_1(
-                Rc::new(RefCell::new(self.clone())).as_pointer(),
-                Rc::new(RefCell::new(other.clone())).as_pointer(),
+                Rc::new(RefCell::new(S { v: self.v.clone() })).as_pointer(),
+                Rc::new(RefCell::new(S { v: other.v.clone() })).as_pointer(),
             )
         }
     }

--- a/tests/unit/out/refcount/operator_comparison_member.rs
+++ b/tests/unit/out/refcount/operator_comparison_member.rs
@@ -14,13 +14,13 @@ impl std::cmp::Ord for S {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         {
             if SImpl::operator_lt_pconstS_const(
-                &Rc::new(RefCell::new(self.clone())).as_pointer(),
-                Rc::new(RefCell::new(other.clone())).as_pointer(),
+                &Rc::new(RefCell::new(S { v: self.v.clone() })).as_pointer(),
+                Rc::new(RefCell::new(S { v: other.v.clone() })).as_pointer(),
             ) {
                 std::cmp::Ordering::Less
             } else if SImpl::operator_lt_pconstS_const(
-                &Rc::new(RefCell::new(other.clone())).as_pointer(),
-                Rc::new(RefCell::new(self.clone())).as_pointer(),
+                &Rc::new(RefCell::new(S { v: other.v.clone() })).as_pointer(),
+                Rc::new(RefCell::new(S { v: self.v.clone() })).as_pointer(),
             ) {
                 std::cmp::Ordering::Greater
             } else {
@@ -38,8 +38,8 @@ impl std::cmp::PartialEq for S {
     fn eq(&self, other: &Self) -> bool {
         {
             SImpl::operator_eq(
-                &Rc::new(RefCell::new(self.clone())).as_pointer(),
-                Rc::new(RefCell::new(other.clone())).as_pointer(),
+                &Rc::new(RefCell::new(S { v: self.v.clone() })).as_pointer(),
+                Rc::new(RefCell::new(S { v: other.v.clone() })).as_pointer(),
             )
         }
     }

--- a/tests/unit/out/refcount/operator_comparison_noncopyable.rs
+++ b/tests/unit/out/refcount/operator_comparison_noncopyable.rs
@@ -1,0 +1,127 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn operator_eq_0(x: Ptr<S>, y: Ptr<S>) -> bool {
+    return {
+        let _lhs = (*(*x.upgrade().deref()).data_.borrow());
+        _lhs == (*(*y.upgrade().deref()).data_.borrow())
+    };
+}
+pub fn operator_lt_1(x: Ptr<S>, y: Ptr<S>) -> bool {
+    return {
+        let _lhs = (*(*x.upgrade().deref()).data_.borrow());
+        _lhs < (*(*y.upgrade().deref()).data_.borrow())
+    };
+}
+#[derive(Default)]
+pub struct S {
+    data_: Value<i32>,
+}
+impl S {
+    pub fn S(data: i32) -> Self {
+        let data: Value<i32> = Rc::new(RefCell::new(data));
+        let __this: Value<S> = Rc::new(RefCell::new(Self {
+            data_: Rc::new(RefCell::new((*data.borrow()))),
+        }));
+        let this: Ptr<S> = __this.as_pointer();
+        Rc::try_unwrap(__this).ok().unwrap().into_inner()
+    }
+}
+impl std::cmp::Ord for S {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        {
+            if operator_lt_1(
+                Rc::new(RefCell::new(S {
+                    data_: self.data_.clone(),
+                }))
+                .as_pointer(),
+                Rc::new(RefCell::new(S {
+                    data_: other.data_.clone(),
+                }))
+                .as_pointer(),
+            ) {
+                std::cmp::Ordering::Less
+            } else if operator_lt_1(
+                Rc::new(RefCell::new(S {
+                    data_: other.data_.clone(),
+                }))
+                .as_pointer(),
+                Rc::new(RefCell::new(S {
+                    data_: self.data_.clone(),
+                }))
+                .as_pointer(),
+            ) {
+                std::cmp::Ordering::Greater
+            } else {
+                std::cmp::Ordering::Equal
+            }
+        }
+    }
+}
+impl std::cmp::PartialOrd for S {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl std::cmp::PartialEq for S {
+    fn eq(&self, other: &Self) -> bool {
+        {
+            operator_eq_0(
+                Rc::new(RefCell::new(S {
+                    data_: self.data_.clone(),
+                }))
+                .as_pointer(),
+                Rc::new(RefCell::new(S {
+                    data_: other.data_.clone(),
+                }))
+                .as_pointer(),
+            )
+        }
+    }
+}
+impl std::cmp::Eq for S {}
+impl ByteRepr for S {
+    fn byte_size() -> usize {
+        4
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.data_.borrow()).to_bytes(&mut buf[0..4]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            data_: Rc::new(RefCell::new(<i32>::from_bytes(&buf[0..4]))),
+        }
+    }
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let a: Value<S> = Rc::new(RefCell::new(S::S({ 1 })));
+    let b: Value<S> = Rc::new(RefCell::new(S::S({ 2 })));
+    let c: Value<S> = Rc::new(RefCell::new(S::S({ 1 })));
+    assert!(
+        ({
+            let _x: Ptr<S> = a.as_pointer();
+            operator_eq_0(_x, c.as_pointer())
+        })
+    );
+    assert!(
+        ({
+            let _x: Ptr<S> = a.as_pointer();
+            operator_lt_1(_x, b.as_pointer())
+        })
+    );
+    assert!(
+        !({
+            let _x: Ptr<S> = b.as_pointer();
+            operator_lt_1(_x, a.as_pointer())
+        })
+    );
+    return 0;
+}

--- a/tests/unit/out/refcount/operator_less_than.rs
+++ b/tests/unit/out/refcount/operator_less_than.rs
@@ -15,13 +15,29 @@ impl std::cmp::Ord for Pair {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         {
             if PairImpl::operator_lt(
-                &Rc::new(RefCell::new(self.clone())).as_pointer(),
-                Rc::new(RefCell::new(other.clone())).as_pointer(),
+                &Rc::new(RefCell::new(Pair {
+                    x: self.x.clone(),
+                    y: self.y.clone(),
+                }))
+                .as_pointer(),
+                Rc::new(RefCell::new(Pair {
+                    x: other.x.clone(),
+                    y: other.y.clone(),
+                }))
+                .as_pointer(),
             ) {
                 std::cmp::Ordering::Less
             } else if PairImpl::operator_lt(
-                &Rc::new(RefCell::new(other.clone())).as_pointer(),
-                Rc::new(RefCell::new(self.clone())).as_pointer(),
+                &Rc::new(RefCell::new(Pair {
+                    x: other.x.clone(),
+                    y: other.y.clone(),
+                }))
+                .as_pointer(),
+                Rc::new(RefCell::new(Pair {
+                    x: self.x.clone(),
+                    y: self.y.clone(),
+                }))
+                .as_pointer(),
             ) {
                 std::cmp::Ordering::Greater
             } else {
@@ -39,11 +55,27 @@ impl std::cmp::PartialEq for Pair {
     fn eq(&self, other: &Self) -> bool {
         {
             !(PairImpl::operator_lt(
-                &Rc::new(RefCell::new(self.clone())).as_pointer(),
-                Rc::new(RefCell::new(other.clone())).as_pointer(),
+                &Rc::new(RefCell::new(Pair {
+                    x: self.x.clone(),
+                    y: self.y.clone(),
+                }))
+                .as_pointer(),
+                Rc::new(RefCell::new(Pair {
+                    x: other.x.clone(),
+                    y: other.y.clone(),
+                }))
+                .as_pointer(),
             )) && !(PairImpl::operator_lt(
-                &Rc::new(RefCell::new(other.clone())).as_pointer(),
-                Rc::new(RefCell::new(self.clone())).as_pointer(),
+                &Rc::new(RefCell::new(Pair {
+                    x: other.x.clone(),
+                    y: other.y.clone(),
+                }))
+                .as_pointer(),
+                Rc::new(RefCell::new(Pair {
+                    x: self.x.clone(),
+                    y: self.y.clone(),
+                }))
+                .as_pointer(),
             ))
         }
     }

--- a/tests/unit/out/refcount/operator_three_way.rs
+++ b/tests/unit/out/refcount/operator_three_way.rs
@@ -14,8 +14,8 @@ impl std::cmp::Ord for S {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         {
             SImpl::operator_cmp(
-                &Rc::new(RefCell::new(self.clone())).as_pointer(),
-                Rc::new(RefCell::new(other.clone())).as_pointer(),
+                &Rc::new(RefCell::new(S { v: self.v.clone() })).as_pointer(),
+                Rc::new(RefCell::new(S { v: other.v.clone() })).as_pointer(),
             )
         }
     }
@@ -29,8 +29,8 @@ impl std::cmp::PartialEq for S {
     fn eq(&self, other: &Self) -> bool {
         {
             SImpl::operator_eq(
-                &Rc::new(RefCell::new(self.clone())).as_pointer(),
-                Rc::new(RefCell::new(other.clone())).as_pointer(),
+                &Rc::new(RefCell::new(S { v: self.v.clone() })).as_pointer(),
+                Rc::new(RefCell::new(S { v: other.v.clone() })).as_pointer(),
             )
         }
     }

--- a/tests/unit/out/refcount/operator_traits.rs
+++ b/tests/unit/out/refcount/operator_traits.rs
@@ -14,13 +14,13 @@ impl std::cmp::Ord for Lt {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         {
             if LtImpl::operator_lt(
-                &Rc::new(RefCell::new(self.clone())).as_pointer(),
-                Rc::new(RefCell::new(other.clone())).as_pointer(),
+                &Rc::new(RefCell::new(Lt { v: self.v.clone() })).as_pointer(),
+                Rc::new(RefCell::new(Lt { v: other.v.clone() })).as_pointer(),
             ) {
                 std::cmp::Ordering::Less
             } else if LtImpl::operator_lt(
-                &Rc::new(RefCell::new(other.clone())).as_pointer(),
-                Rc::new(RefCell::new(self.clone())).as_pointer(),
+                &Rc::new(RefCell::new(Lt { v: other.v.clone() })).as_pointer(),
+                Rc::new(RefCell::new(Lt { v: self.v.clone() })).as_pointer(),
             ) {
                 std::cmp::Ordering::Greater
             } else {
@@ -38,11 +38,11 @@ impl std::cmp::PartialEq for Lt {
     fn eq(&self, other: &Self) -> bool {
         {
             !(LtImpl::operator_lt(
-                &Rc::new(RefCell::new(self.clone())).as_pointer(),
-                Rc::new(RefCell::new(other.clone())).as_pointer(),
+                &Rc::new(RefCell::new(Lt { v: self.v.clone() })).as_pointer(),
+                Rc::new(RefCell::new(Lt { v: other.v.clone() })).as_pointer(),
             )) && !(LtImpl::operator_lt(
-                &Rc::new(RefCell::new(other.clone())).as_pointer(),
-                Rc::new(RefCell::new(self.clone())).as_pointer(),
+                &Rc::new(RefCell::new(Lt { v: other.v.clone() })).as_pointer(),
+                Rc::new(RefCell::new(Lt { v: self.v.clone() })).as_pointer(),
             ))
         }
     }
@@ -78,8 +78,8 @@ impl std::cmp::PartialEq for Eq {
     fn eq(&self, other: &Self) -> bool {
         {
             EqImpl::operator_eq(
-                &Rc::new(RefCell::new(self.clone())).as_pointer(),
-                Rc::new(RefCell::new(other.clone())).as_pointer(),
+                &Rc::new(RefCell::new(Eq { v: self.v.clone() })).as_pointer(),
+                Rc::new(RefCell::new(Eq { v: other.v.clone() })).as_pointer(),
             )
         }
     }
@@ -115,8 +115,8 @@ impl std::cmp::Ord for Cmp {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         {
             CmpImpl::operator_cmp(
-                &Rc::new(RefCell::new(self.clone())).as_pointer(),
-                Rc::new(RefCell::new(other.clone())).as_pointer(),
+                &Rc::new(RefCell::new(Cmp { v: self.v.clone() })).as_pointer(),
+                Rc::new(RefCell::new(Cmp { v: other.v.clone() })).as_pointer(),
             )
         }
     }
@@ -130,8 +130,8 @@ impl std::cmp::PartialEq for Cmp {
     fn eq(&self, other: &Self) -> bool {
         {
             CmpImpl::operator_eq(
-                &Rc::new(RefCell::new(self.clone())).as_pointer(),
-                Rc::new(RefCell::new(other.clone())).as_pointer(),
+                &Rc::new(RefCell::new(Cmp { v: self.v.clone() })).as_pointer(),
+                Rc::new(RefCell::new(Cmp { v: other.v.clone() })).as_pointer(),
             )
         }
     }
@@ -167,13 +167,13 @@ impl std::cmp::Ord for Free {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         {
             if operator_lt_0(
-                Rc::new(RefCell::new(self.clone())).as_pointer(),
-                Rc::new(RefCell::new(other.clone())).as_pointer(),
+                Rc::new(RefCell::new(Free { v: self.v.clone() })).as_pointer(),
+                Rc::new(RefCell::new(Free { v: other.v.clone() })).as_pointer(),
             ) {
                 std::cmp::Ordering::Less
             } else if operator_lt_0(
-                Rc::new(RefCell::new(other.clone())).as_pointer(),
-                Rc::new(RefCell::new(self.clone())).as_pointer(),
+                Rc::new(RefCell::new(Free { v: other.v.clone() })).as_pointer(),
+                Rc::new(RefCell::new(Free { v: self.v.clone() })).as_pointer(),
             ) {
                 std::cmp::Ordering::Greater
             } else {
@@ -191,8 +191,8 @@ impl std::cmp::PartialEq for Free {
     fn eq(&self, other: &Self) -> bool {
         {
             operator_eq_1(
-                Rc::new(RefCell::new(self.clone())).as_pointer(),
-                Rc::new(RefCell::new(other.clone())).as_pointer(),
+                Rc::new(RefCell::new(Free { v: self.v.clone() })).as_pointer(),
+                Rc::new(RefCell::new(Free { v: other.v.clone() })).as_pointer(),
             )
         }
     }

--- a/tests/unit/out/unsafe/operator_comparison_noncopyable.rs
+++ b/tests/unit/out/unsafe/operator_comparison_noncopyable.rs
@@ -1,0 +1,78 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn operator_eq_0(x: *const S, y: *const S) -> bool {
+    return (((*x).data_) == ((*y).data_));
+}
+pub unsafe fn operator_lt_1(x: *const S, y: *const S) -> bool {
+    return (((*x).data_) < ((*y).data_));
+}
+#[repr(C)]
+#[derive(Default)]
+pub struct S {
+    data_: i32,
+}
+impl S {
+    pub unsafe fn S(mut data: i32) -> Self {
+        let mut this = Self { data_: data };
+        this
+    }
+}
+impl std::cmp::Ord for S {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        unsafe {
+            if operator_lt_1(self as *const S, other as *const S) {
+                std::cmp::Ordering::Less
+            } else if operator_lt_1(other as *const S, self as *const S) {
+                std::cmp::Ordering::Greater
+            } else {
+                std::cmp::Ordering::Equal
+            }
+        }
+    }
+}
+impl std::cmp::PartialOrd for S {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl std::cmp::PartialEq for S {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { operator_eq_0(self as *const S, other as *const S) }
+    }
+}
+impl std::cmp::Eq for S {}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut a: S = S::S({ 1 });
+    let mut b: S = S::S({ 2 });
+    let mut c: S = S::S({ 1 });
+    assert!(
+        (unsafe {
+            let _x: *const S = &a as *const S;
+            operator_eq_0(_x, &c as *const S)
+        })
+    );
+    assert!(
+        (unsafe {
+            let _x: *const S = &a as *const S;
+            operator_lt_1(_x, &b as *const S)
+        })
+    );
+    assert!(
+        !(unsafe {
+            let _x: *const S = &b as *const S;
+            operator_lt_1(_x, &a as *const S)
+        })
+    );
+    return 0;
+}


### PR DESCRIPTION
A move-only type, i.e. one that has copy constructor and assignment deleted, cannot be `.clone()`'ed. PartialOrd/Ord assumed that the type is aways clonable.

This PR fixes PartialOrd/Ord by cloning the Rc's of the fields, instead of calling clone on the entire struct. The comparison semantics are not changed.