### PR TITLE
Translate defaulted and implicit comparison operators

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -966,6 +966,14 @@ bool Converter::VisitCXXRecordDecl(clang::CXXRecordDecl *decl) {
         sema_->DefineImplicitCopyConstructor(decl->getLocation(), ctor);
       }
     }
+    for (auto *method : decl->methods()) {
+      if (IsComparisonOperator(method) && method->isDefaulted() &&
+          !method->doesThisDeclarationHaveABody()) {
+        sema_->DefineDefaultedComparison(
+            decl->getLocation(), method,
+            sema_->getDefaultedComparisonKind(method));
+      }
+    }
 
     EmitRustStructOrUnion(decl);
   } else if (decl->isUnion()) {

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -2742,7 +2742,10 @@ bool Converter::VisitUnaryOperator(clang::UnaryOperator *expr) {
         expr->getType()->isIntegerType() && !expr->getType()->isBooleanType();
     PushParen paren_cast(*this, needs_int_cast);
     StrCat(token::kNot);
-    ConvertCondition(sub_expr);
+    {
+      PushParen paren_operand(*this);
+      ConvertCondition(sub_expr);
+    }
     if (needs_int_cast) {
       ConvertCast(expr->getType());
     }

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -1848,7 +1848,7 @@ Converter::CallInfo Converter::CollectCallInfo(clang::CallExpr *expr) {
   for (unsigned i = 0; i < num_named_params && i < num_args; ++i) {
     auto *arg = expr->getArg(i + arg_begin);
     CallArg ca{
-        .param_name = function
+        .param_name = function && !function->getParamDecl(i)->getName().empty()
                           ? ("_" + function->getParamDecl(i)->getNameAsString())
                           : ("_arg" + std::to_string(i)),
         .param_type = function ? function->getParamDecl(i)->getType()

--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -1268,6 +1268,14 @@ void Converter::ConvertCondition(clang::Expr *cond) {
 }
 
 bool Converter::VisitIfStmt(clang::IfStmt *stmt) {
+  if (auto *init = stmt->getInit()) {
+    PushBrace scope(*this);
+    Convert(init);
+    stmt->setInit(nullptr);
+    Convert(stmt);
+    stmt->setInit(init);
+    return false;
+  }
   StrCat(keyword::kIf);
   ConvertCondition(stmt->getCond());
   ConvertBody(stmt->getThen());

--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -919,9 +919,11 @@ bool IsEmittableMethod(clang::CXXMethodDecl *method) {
 }
 
 bool IsMethodOnPtr(const clang::CXXMethodDecl *method) {
-  if ((method->isImplicit() && !IsComparisonOperator(method)) ||
-      method->isDeleted() || method->isStatic() || method->isVirtual() ||
+  if (method->isDeleted() || method->isStatic() || method->isVirtual() ||
       clang::isa<clang::CXXConstructorDecl>(method)) {
+    return false;
+  }
+  if (method->isImplicit() && !IsComparisonOperator(method)) {
     return false;
   }
   if (!IsUserDefinedDecl(method->getParent()) ||

--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -375,7 +375,7 @@ bool IsConvertibleCXXMethodDecl(const clang::CXXMethodDecl *decl) {
   if (llvm::isa<clang::CXXDestructorDecl>(decl)) {
     return GetUserDefinedDestructor(decl->getParent()) != nullptr;
   }
-  return !decl->isImplicit();
+  return !decl->isImplicit() || IsComparisonOperator(decl);
 }
 
 bool IsConvertibleFunctionDecl(const clang::FunctionDecl *decl) {
@@ -804,7 +804,14 @@ bool IsSameTypeComparison(const clang::FunctionDecl *fn,
 
 bool IsUserOperatorCall(const clang::CXXOperatorCallExpr *expr) {
   const auto *callee = expr->getDirectCallee();
-  if (!callee || !callee->isUserProvided() || !IsUserDefinedDecl(callee)) {
+  if (!callee) {
+    return false;
+  }
+  if (const auto *method = clang::dyn_cast<clang::CXXMethodDecl>(callee);
+      method && method->isDefaulted() && IsComparisonOperator(method)) {
+    return IsUserDefinedDecl(method->getParent());
+  }
+  if (!callee->isUserProvided() || !IsUserDefinedDecl(callee)) {
     return false;
   }
   if (const auto *method = clang::dyn_cast<clang::CXXMethodDecl>(callee)) {
@@ -864,6 +871,21 @@ bool RecordNeedsDestruction(const clang::CXXRecordDecl *decl) {
   return GetUserDefinedDestructor(decl) || HasFieldsNeedingDestruction(decl);
 }
 
+bool IsComparisonOperator(const clang::FunctionDecl *fn) {
+  switch (fn->getOverloadedOperator()) {
+  case clang::OO_EqualEqual:
+  case clang::OO_ExclaimEqual:
+  case clang::OO_Less:
+  case clang::OO_LessEqual:
+  case clang::OO_Greater:
+  case clang::OO_GreaterEqual:
+  case clang::OO_Spaceship:
+    return true;
+  default:
+    return false;
+  }
+}
+
 bool IsEmittableMethod(clang::CXXMethodDecl *method) {
   if (method->isDeleted()) {
     return false;
@@ -875,6 +897,9 @@ bool IsEmittableMethod(clang::CXXMethodDecl *method) {
   // Virtual methods go into the base trait impl
   if (method->isVirtual()) {
     return false;
+  }
+  if (IsComparisonOperator(method)) {
+    return method->hasBody();
   }
   // Compiler-generated members are covered by derived traits
   if (method->isImplicit()) {
@@ -889,8 +914,9 @@ bool IsEmittableMethod(clang::CXXMethodDecl *method) {
 }
 
 bool IsMethodOnPtr(const clang::CXXMethodDecl *method) {
-  if (method->isImplicit() || method->isDeleted() || method->isStatic() ||
-      method->isVirtual() || clang::isa<clang::CXXConstructorDecl>(method)) {
+  if ((method->isImplicit() && !IsComparisonOperator(method)) ||
+      method->isDeleted() || method->isStatic() || method->isVirtual() ||
+      clang::isa<clang::CXXConstructorDecl>(method)) {
     return false;
   }
   if (!IsUserDefinedDecl(method->getParent()) ||
@@ -898,7 +924,8 @@ bool IsMethodOnPtr(const clang::CXXMethodDecl *method) {
     return false;
   }
   if (auto *definition = method->getDefinition();
-      definition && definition->isDefaulted()) {
+      definition && definition->isDefaulted() &&
+      !IsComparisonOperator(method)) {
     return false;
   }
   if (clang::isa<clang::CXXDestructorDecl>(method)) {

--- a/cpp2rust/converter/converter_lib.cpp
+++ b/cpp2rust/converter/converter_lib.cpp
@@ -648,12 +648,17 @@ std::string GetNamedDeclAsString(const clang::NamedDecl *decl) {
     auto *pdecl = llvm::dyn_cast<clang::ParmVarDecl>(decl);
     assert(pdecl && "Unexpected unnamed construct");
 
-    const auto *ctor =
-        llvm::dyn_cast<clang::CXXConstructorDecl>(pdecl->getDeclContext());
-    name = (pdecl->isExplicitObjectParameter() ||
-            (ctor && ctor->isCopyOrMoveConstructor()))
-               ? "self"
-               : "_";
+    const auto *fn =
+        llvm::dyn_cast<clang::FunctionDecl>(pdecl->getDeclContext());
+    const auto *ctor = llvm::dyn_cast_or_null<clang::CXXConstructorDecl>(fn);
+    if (pdecl->isExplicitObjectParameter() ||
+        (ctor && ctor->isCopyOrMoveConstructor())) {
+      name = "self";
+    } else if (fn && fn->isDefaulted() && IsComparisonOperator(fn)) {
+      name = std::format("_arg{}", pdecl->getFunctionScopeIndex());
+    } else {
+      name = "_";
+    }
   } else if (auto *pdecl = llvm::dyn_cast<clang::ParmVarDecl>(decl)) {
     // Expanded parameter packs share one name across the expansion
     if (auto *fn = llvm::dyn_cast_or_null<clang::FunctionDecl>(

--- a/cpp2rust/converter/converter_lib.h
+++ b/cpp2rust/converter/converter_lib.h
@@ -91,6 +91,7 @@ bool IsConvertibleCXXRecordDecl(const clang::CXXRecordDecl *decl);
 
 bool IsConvertibleCXXMethodDecl(const clang::CXXMethodDecl *decl);
 
+bool IsComparisonOperator(const clang::FunctionDecl *fn);
 bool IsEmittableMethod(clang::CXXMethodDecl *method);
 
 bool IsMethodOnPtr(const clang::CXXMethodDecl *method);

--- a/tests/unit/operator_comparison_defaulted.cpp
+++ b/tests/unit/operator_comparison_defaulted.cpp
@@ -26,6 +26,28 @@ struct OrdOnly {
   bool operator==(const OrdOnly &) const = delete;
 };
 
+struct Inner {
+  int x;
+  auto operator<=>(const Inner &) const = default;
+};
+
+struct Outer {
+  Inner i;
+  int y;
+  auto operator<=>(const Outer &) const = default;
+};
+
+// Secondary comparison operators can be defaulted too; they are defined as
+// rewrites of the primary ones: != as !(a == b), < and >= via (a <=> b).
+struct Secondary {
+  int a;
+  bool operator==(const Secondary &) const = default;
+  bool operator!=(const Secondary &) const = default;
+  auto operator<=>(const Secondary &) const = default;
+  bool operator<(const Secondary &) const = default;
+  bool operator>=(const Secondary &) const = default;
+};
+
 int main() {
   Eq e1{1, 2}, e2{1, 2}, e3{1, 3};
   assert(e1 == e2);
@@ -41,5 +63,14 @@ int main() {
   OrdOnly o1{1}, o2{2};
   assert(o1 < o2);
   assert((o2 <=> o1) == std::strong_ordering::greater);
+  Outer x1{{1}, 9}, x2{{2}, 0}, x3{{1}, 9};
+  assert(x1 < x2);
+  assert(x1 == x3);
+  assert((x2 <=> x1) == std::strong_ordering::greater);
+  Secondary s1{1}, s2{2};
+  assert(s1 != s2);
+  assert(s1 < s2);
+  assert(s2 >= s1);
+  assert(!(s2 < s1));
   return 0;
 }

--- a/tests/unit/operator_comparison_defaulted.cpp
+++ b/tests/unit/operator_comparison_defaulted.cpp
@@ -20,6 +20,12 @@ struct Both {
   std::strong_ordering operator<=>(const Both &) const = default;
 };
 
+struct OrdOnly {
+  int a;
+  auto operator<=>(const OrdOnly &) const = default;
+  bool operator==(const OrdOnly &) const = delete;
+};
+
 int main() {
   Eq e1{1, 2}, e2{1, 2}, e3{1, 3};
   assert(e1 == e2);
@@ -32,5 +38,8 @@ int main() {
   Both b1{1}, b2{2};
   assert(b1 < b2);
   assert(b2 == b2);
+  OrdOnly o1{1}, o2{2};
+  assert(o1 < o2);
+  assert((o2 <=> o1) == std::strong_ordering::greater);
   return 0;
 }

--- a/tests/unit/operator_comparison_defaulted.cpp
+++ b/tests/unit/operator_comparison_defaulted.cpp
@@ -1,0 +1,36 @@
+// ADDITIONAL_COMPILE_FLAGS: -std=c++20
+#include <cassert>
+#include <compare>
+
+struct Eq {
+  int a;
+  int b;
+  bool operator==(const Eq &) const = default;
+};
+
+struct Cmp {
+  int a;
+  int b;
+  auto operator<=>(const Cmp &) const = default;
+};
+
+struct Both {
+  int a;
+  bool operator==(const Both &) const = default;
+  std::strong_ordering operator<=>(const Both &) const = default;
+};
+
+int main() {
+  Eq e1{1, 2}, e2{1, 2}, e3{1, 3};
+  assert(e1 == e2);
+  assert(e1 != e3);
+  Cmp c1{1, 2}, c2{1, 3}, c3{2, 0}, c4{1, 9};
+  assert(c1 < c2);
+  assert(c3 > c4);
+  assert(c1 == c1);
+  assert((c1 <=> c2) == std::strong_ordering::less);
+  Both b1{1}, b2{2};
+  assert(b1 < b2);
+  assert(b2 == b2);
+  return 0;
+}

--- a/tests/unit/out/refcount/bool_condition_ptr.rs
+++ b/tests/unit/out/refcount/bool_condition_ptr.rs
@@ -16,13 +16,13 @@ fn main_0() -> i32 {
     if !(*p.borrow()).is_null() {
         assert!(true);
     }
-    if !!(*p.borrow()).is_null() {
+    if !(!(*p.borrow()).is_null()) {
         assert!(false);
     }
     if !(*np.borrow()).is_null() {
         assert!(false);
     }
-    if !!(*np.borrow()).is_null() {
+    if !(!(*np.borrow()).is_null()) {
         assert!(true);
     }
     let iter: Value<Ptr<i32>> = Rc::new(RefCell::new((*p.borrow()).clone()));
@@ -36,9 +36,9 @@ fn main_0() -> i32 {
     assert!(((*t3.borrow()) == 1));
     let t4: Value<i32> = Rc::new(RefCell::new(if !(*np.borrow()).is_null() { 1 } else { 0 }));
     assert!(((*t4.borrow()) == 0));
-    let t5: Value<i32> = Rc::new(RefCell::new((!!(*p.borrow()).is_null() as i32)));
+    let t5: Value<i32> = Rc::new(RefCell::new((!(!(*p.borrow()).is_null()) as i32)));
     assert!(((*t5.borrow()) == 0));
-    let t6: Value<i32> = Rc::new(RefCell::new((!!(*np.borrow()).is_null() as i32)));
+    let t6: Value<i32> = Rc::new(RefCell::new((!(!(*np.borrow()).is_null()) as i32)));
     assert!(((*t6.borrow()) == 1));
     let b2: Value<bool> = Rc::new(RefCell::new(!(*p.borrow()).is_null()));
     let b3: Value<bool> = Rc::new(RefCell::new(!(*np.borrow()).is_null()));

--- a/tests/unit/out/refcount/bool_condition_ptr_c.rs
+++ b/tests/unit/out/refcount/bool_condition_ptr_c.rs
@@ -16,13 +16,13 @@ fn main_0() -> i32 {
     if !(*p.borrow()).is_null() {
         assert!((1 != 0));
     }
-    if !!(*p.borrow()).is_null() {
+    if !(!(*p.borrow()).is_null()) {
         assert!((0 != 0));
     }
     if !(*np.borrow()).is_null() {
         assert!((0 != 0));
     }
-    if !!(*np.borrow()).is_null() {
+    if !(!(*np.borrow()).is_null()) {
         assert!((1 != 0));
     }
     let iter: Value<Ptr<i32>> = Rc::new(RefCell::new((*p.borrow()).clone()));
@@ -36,9 +36,9 @@ fn main_0() -> i32 {
     assert!(((((*t3.borrow()) == 1) as i32) != 0));
     let t4: Value<i32> = Rc::new(RefCell::new(if !(*np.borrow()).is_null() { 1 } else { 0 }));
     assert!(((((*t4.borrow()) == 0) as i32) != 0));
-    let t5: Value<i32> = Rc::new(RefCell::new((!!(*p.borrow()).is_null() as i32)));
+    let t5: Value<i32> = Rc::new(RefCell::new((!(!(*p.borrow()).is_null()) as i32)));
     assert!(((((*t5.borrow()) == 0) as i32) != 0));
-    let t6: Value<i32> = Rc::new(RefCell::new((!!(*np.borrow()).is_null() as i32)));
+    let t6: Value<i32> = Rc::new(RefCell::new((!(!(*np.borrow()).is_null()) as i32)));
     assert!(((((*t6.borrow()) == 1) as i32) != 0));
     let b2: Value<bool> = Rc::new(RefCell::new(!(*p.borrow()).is_null()));
     let b3: Value<bool> = Rc::new(RefCell::new(!(*np.borrow()).is_null()));

--- a/tests/unit/out/refcount/builtin.rs
+++ b/tests/unit/out/refcount/builtin.rs
@@ -38,11 +38,11 @@ pub fn test_popcountl_7() {
 pub fn test_mul_overflow_long_8() {
     let r: Value<i64> = Rc::new(RefCell::new(0_i64));
     assert!(
-        ((!{
+        ((!({
             let (val, ovf) = 3_i64.overflowing_mul(7_i64);
             (r.as_pointer()).write(val);
             ovf
-        } as i32)
+        }) as i32)
             != 0)
     );
     assert!(((((*r.borrow()) == 21_i64) as i32) != 0));
@@ -55,11 +55,11 @@ pub fn test_mul_overflow_long_8() {
 pub fn test_mul_overflow_long_long_9() {
     let r: Value<i64> = Rc::new(RefCell::new(0_i64));
     assert!(
-        ((!{
+        ((!({
             let (val, ovf) = 1000_i64.overflowing_mul(1000_i64);
             (r.as_pointer()).write(val);
             ovf
-        } as i32)
+        }) as i32)
             != 0)
     );
     assert!(((((*r.borrow()) == 1000000_i64) as i32) != 0));

--- a/tests/unit/out/refcount/fn_ptr_as_condition.rs
+++ b/tests/unit/out/refcount/fn_ptr_as_condition.rs
@@ -31,7 +31,7 @@ fn main_0() -> i32 {
     ({ maybe_call_1(FnPtr::<fn(Ptr<i32>)>::null(), (b.as_pointer())) });
     assert!(((*b.borrow()) == 5));
     let fn_: Value<FnPtr<fn(Ptr<i32>)>> = Rc::new(RefCell::new(FnPtr::<fn(Ptr<i32>)>::null()));
-    if !!(*fn_.borrow()).is_null() {
+    if !(!(*fn_.borrow()).is_null()) {
         (*fn_.borrow_mut()) = FnPtr::<fn(Ptr<i32>)>::new(double_it_0);
     }
     let c: Value<i32> = Rc::new(RefCell::new(3));

--- a/tests/unit/out/refcount/libc_char_ptr_field.rs
+++ b/tests/unit/out/refcount/libc_char_ptr_field.rs
@@ -22,7 +22,7 @@ fn main_0() -> i32 {
             }
         },
     ));
-    if !!(*pw.borrow()).is_null() {
+    if !(!(*pw.borrow()).is_null()) {
         return 0;
     }
     let home: Value<Ptr<u8>> = Rc::new(RefCell::new(

--- a/tests/unit/out/refcount/operator_comparison_defaulted.rs
+++ b/tests/unit/out/refcount/operator_comparison_defaulted.rs
@@ -1,0 +1,323 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+#[derive(Default)]
+pub struct Eq {
+    pub a: Value<i32>,
+    pub b: Value<i32>,
+}
+impl std::cmp::PartialEq for Eq {
+    fn eq(&self, other: &Self) -> bool {
+        {
+            EqImpl::operator_eq(
+                &Rc::new(RefCell::new(Eq {
+                    a: self.a.clone(),
+                    b: self.b.clone(),
+                }))
+                .as_pointer(),
+                Rc::new(RefCell::new(Eq {
+                    a: other.a.clone(),
+                    b: other.b.clone(),
+                }))
+                .as_pointer(),
+            )
+        }
+    }
+}
+impl std::cmp::Eq for Eq {}
+impl Clone for Eq {
+    fn clone(&self) -> Self {
+        let __this: Value<Eq> = Rc::new(RefCell::new(Self {
+            a: Rc::new(RefCell::new((*self.a.borrow()))),
+            b: Rc::new(RefCell::new((*self.b.borrow()))),
+        }));
+        let this: Ptr<Eq> = __this.as_pointer();
+        Rc::try_unwrap(__this).ok().unwrap().into_inner()
+    }
+}
+impl ByteRepr for Eq {
+    fn byte_size() -> usize {
+        8
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.a.borrow()).to_bytes(&mut buf[0..4]);
+        (*self.b.borrow()).to_bytes(&mut buf[4..8]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            a: Rc::new(RefCell::new(<i32>::from_bytes(&buf[0..4]))),
+            b: Rc::new(RefCell::new(<i32>::from_bytes(&buf[4..8]))),
+        }
+    }
+}
+#[derive(Default)]
+pub struct Cmp {
+    pub a: Value<i32>,
+    pub b: Value<i32>,
+}
+impl std::cmp::Ord for Cmp {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        {
+            CmpImpl::operator_cmp(
+                &Rc::new(RefCell::new(Cmp {
+                    a: self.a.clone(),
+                    b: self.b.clone(),
+                }))
+                .as_pointer(),
+                Rc::new(RefCell::new(Cmp {
+                    a: other.a.clone(),
+                    b: other.b.clone(),
+                }))
+                .as_pointer(),
+            )
+        }
+    }
+}
+impl std::cmp::PartialOrd for Cmp {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl std::cmp::PartialEq for Cmp {
+    fn eq(&self, other: &Self) -> bool {
+        {
+            CmpImpl::operator_cmp(
+                &Rc::new(RefCell::new(Cmp {
+                    a: self.a.clone(),
+                    b: self.b.clone(),
+                }))
+                .as_pointer(),
+                Rc::new(RefCell::new(Cmp {
+                    a: other.a.clone(),
+                    b: other.b.clone(),
+                }))
+                .as_pointer(),
+            ) == std::cmp::Ordering::Equal
+        }
+    }
+}
+impl std::cmp::Eq for Cmp {}
+impl Clone for Cmp {
+    fn clone(&self) -> Self {
+        let __this: Value<Cmp> = Rc::new(RefCell::new(Self {
+            a: Rc::new(RefCell::new((*self.a.borrow()))),
+            b: Rc::new(RefCell::new((*self.b.borrow()))),
+        }));
+        let this: Ptr<Cmp> = __this.as_pointer();
+        Rc::try_unwrap(__this).ok().unwrap().into_inner()
+    }
+}
+impl ByteRepr for Cmp {
+    fn byte_size() -> usize {
+        8
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.a.borrow()).to_bytes(&mut buf[0..4]);
+        (*self.b.borrow()).to_bytes(&mut buf[4..8]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            a: Rc::new(RefCell::new(<i32>::from_bytes(&buf[0..4]))),
+            b: Rc::new(RefCell::new(<i32>::from_bytes(&buf[4..8]))),
+        }
+    }
+}
+#[derive(Default)]
+pub struct Both {
+    pub a: Value<i32>,
+}
+impl std::cmp::Ord for Both {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        {
+            BothImpl::operator_cmp(
+                &Rc::new(RefCell::new(Both { a: self.a.clone() })).as_pointer(),
+                Rc::new(RefCell::new(Both { a: other.a.clone() })).as_pointer(),
+            )
+        }
+    }
+}
+impl std::cmp::PartialOrd for Both {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl std::cmp::PartialEq for Both {
+    fn eq(&self, other: &Self) -> bool {
+        {
+            BothImpl::operator_eq(
+                &Rc::new(RefCell::new(Both { a: self.a.clone() })).as_pointer(),
+                Rc::new(RefCell::new(Both { a: other.a.clone() })).as_pointer(),
+            )
+        }
+    }
+}
+impl std::cmp::Eq for Both {}
+impl Clone for Both {
+    fn clone(&self) -> Self {
+        let __this: Value<Both> = Rc::new(RefCell::new(Self {
+            a: Rc::new(RefCell::new((*self.a.borrow()))),
+        }));
+        let this: Ptr<Both> = __this.as_pointer();
+        Rc::try_unwrap(__this).ok().unwrap().into_inner()
+    }
+}
+impl ByteRepr for Both {
+    fn byte_size() -> usize {
+        4
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.a.borrow()).to_bytes(&mut buf[0..4]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            a: Rc::new(RefCell::new(<i32>::from_bytes(&buf[0..4]))),
+        }
+    }
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    let e1: Value<Eq> = Rc::new(RefCell::new(Eq {
+        a: Rc::new(RefCell::new(1)),
+        b: Rc::new(RefCell::new(2)),
+    }));
+    let e2: Value<Eq> = Rc::new(RefCell::new(Eq {
+        a: Rc::new(RefCell::new(1)),
+        b: Rc::new(RefCell::new(2)),
+    }));
+    let e3: Value<Eq> = Rc::new(RefCell::new(Eq {
+        a: Rc::new(RefCell::new(1)),
+        b: Rc::new(RefCell::new(3)),
+    }));
+    assert!(({ EqImpl::operator_eq(&e1.as_pointer(), e2.as_pointer(),) }));
+    assert!(!({ EqImpl::operator_eq(&e1.as_pointer(), e3.as_pointer(),) }));
+    let c1: Value<Cmp> = Rc::new(RefCell::new(Cmp {
+        a: Rc::new(RefCell::new(1)),
+        b: Rc::new(RefCell::new(2)),
+    }));
+    let c2: Value<Cmp> = Rc::new(RefCell::new(Cmp {
+        a: Rc::new(RefCell::new(1)),
+        b: Rc::new(RefCell::new(3)),
+    }));
+    let c3: Value<Cmp> = Rc::new(RefCell::new(Cmp {
+        a: Rc::new(RefCell::new(2)),
+        b: Rc::new(RefCell::new(0)),
+    }));
+    let c4: Value<Cmp> = Rc::new(RefCell::new(Cmp {
+        a: Rc::new(RefCell::new(1)),
+        b: Rc::new(RefCell::new(9)),
+    }));
+    assert!(
+        ({ CmpImpl::operator_cmp(&c1.as_pointer(), c2.as_pointer(),) }) == std::cmp::Ordering::Less
+    );
+    assert!(
+        ({ CmpImpl::operator_cmp(&c3.as_pointer(), c4.as_pointer(),) })
+            == std::cmp::Ordering::Greater
+    );
+    assert!(
+        ({
+            let _arg0: Ptr<Cmp> = c1.as_pointer();
+            CmpImpl::operator_eq(&c1.as_pointer(), _arg0)
+        })
+    );
+    assert!(
+        ({ CmpImpl::operator_cmp(&c1.as_pointer(), c2.as_pointer(),) }) == std::cmp::Ordering::Less
+    );
+    let b1: Value<Both> = Rc::new(RefCell::new(Both {
+        a: Rc::new(RefCell::new(1)),
+    }));
+    let b2: Value<Both> = Rc::new(RefCell::new(Both {
+        a: Rc::new(RefCell::new(2)),
+    }));
+    assert!(
+        ({ BothImpl::operator_cmp(&b1.as_pointer(), b2.as_pointer(),) })
+            == std::cmp::Ordering::Less
+    );
+    assert!(
+        ({
+            let _arg0: Ptr<Both> = b2.as_pointer();
+            BothImpl::operator_eq(&b2.as_pointer(), _arg0)
+        })
+    );
+    return 0;
+}
+pub trait BothImpl {
+    fn operator_eq(&self, __p0: Ptr<Both>) -> bool;
+    fn operator_cmp(&self, __p0: Ptr<Both>) -> std::cmp::Ordering;
+}
+impl BothImpl for Ptr<Both> {
+    fn operator_eq(&self, __p0: Ptr<Both>) -> bool {
+        return {
+            let _lhs = (*(*(*self).upgrade().deref()).a.borrow());
+            _lhs == (*(*__p0.upgrade().deref()).a.borrow())
+        };
+    }
+    fn operator_cmp(&self, __p0: Ptr<Both>) -> std::cmp::Ordering {
+        {
+            let cmp: Value<std::cmp::Ordering> = Rc::new(RefCell::new(
+                (*(*(*self).upgrade().deref()).a.borrow())
+                    .cmp(&(*(*__p0.upgrade().deref()).a.borrow())),
+            ));
+            if !((*cmp.borrow()) == std::cmp::Ordering::Equal) {
+                return (*cmp.borrow_mut()).clone();
+            }
+        }
+        return std::cmp::Ordering::Equal;
+    }
+}
+pub trait CmpImpl {
+    fn operator_cmp(&self, __p0: Ptr<Cmp>) -> std::cmp::Ordering;
+    fn operator_eq(&self, __p0: Ptr<Cmp>) -> bool;
+}
+impl CmpImpl for Ptr<Cmp> {
+    fn operator_cmp(&self, __p0: Ptr<Cmp>) -> std::cmp::Ordering {
+        {
+            let cmp: Value<std::cmp::Ordering> = Rc::new(RefCell::new(
+                (*(*(*self).upgrade().deref()).a.borrow())
+                    .cmp(&(*(*__p0.upgrade().deref()).a.borrow())),
+            ));
+            if !((*cmp.borrow()) == std::cmp::Ordering::Equal) {
+                return (*cmp.borrow_mut()).clone();
+            }
+        }
+        {
+            let cmp: Value<std::cmp::Ordering> = Rc::new(RefCell::new(
+                (*(*(*self).upgrade().deref()).b.borrow())
+                    .cmp(&(*(*__p0.upgrade().deref()).b.borrow())),
+            ));
+            if !((*cmp.borrow()) == std::cmp::Ordering::Equal) {
+                return (*cmp.borrow_mut()).clone();
+            }
+        }
+        return std::cmp::Ordering::Equal;
+    }
+    fn operator_eq(&self, __p0: Ptr<Cmp>) -> bool {
+        return ({
+            let _lhs = (*(*(*self).upgrade().deref()).a.borrow());
+            _lhs == (*(*__p0.upgrade().deref()).a.borrow())
+        }) && ({
+            let _lhs = (*(*(*self).upgrade().deref()).b.borrow());
+            _lhs == (*(*__p0.upgrade().deref()).b.borrow())
+        });
+    }
+}
+pub trait EqImpl {
+    fn operator_eq(&self, __p0: Ptr<Eq>) -> bool;
+}
+impl EqImpl for Ptr<Eq> {
+    fn operator_eq(&self, __p0: Ptr<Eq>) -> bool {
+        return ({
+            let _lhs = (*(*(*self).upgrade().deref()).a.borrow());
+            _lhs == (*(*__p0.upgrade().deref()).a.borrow())
+        }) && ({
+            let _lhs = (*(*(*self).upgrade().deref()).b.borrow());
+            _lhs == (*(*__p0.upgrade().deref()).b.borrow())
+        });
+    }
+}

--- a/tests/unit/out/refcount/operator_comparison_defaulted.rs
+++ b/tests/unit/out/refcount/operator_comparison_defaulted.rs
@@ -179,6 +179,234 @@ impl ByteRepr for Both {
         }
     }
 }
+#[derive(Default)]
+pub struct OrdOnly {
+    pub a: Value<i32>,
+}
+impl std::cmp::Ord for OrdOnly {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        {
+            OrdOnlyImpl::operator_cmp(
+                &Rc::new(RefCell::new(OrdOnly { a: self.a.clone() })).as_pointer(),
+                Rc::new(RefCell::new(OrdOnly { a: other.a.clone() })).as_pointer(),
+            )
+        }
+    }
+}
+impl std::cmp::PartialOrd for OrdOnly {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl std::cmp::PartialEq for OrdOnly {
+    fn eq(&self, other: &Self) -> bool {
+        {
+            OrdOnlyImpl::operator_cmp(
+                &Rc::new(RefCell::new(OrdOnly { a: self.a.clone() })).as_pointer(),
+                Rc::new(RefCell::new(OrdOnly { a: other.a.clone() })).as_pointer(),
+            ) == std::cmp::Ordering::Equal
+        }
+    }
+}
+impl std::cmp::Eq for OrdOnly {}
+impl Clone for OrdOnly {
+    fn clone(&self) -> Self {
+        let __this: Value<OrdOnly> = Rc::new(RefCell::new(Self {
+            a: Rc::new(RefCell::new((*self.a.borrow()))),
+        }));
+        let this: Ptr<OrdOnly> = __this.as_pointer();
+        Rc::try_unwrap(__this).ok().unwrap().into_inner()
+    }
+}
+impl ByteRepr for OrdOnly {
+    fn byte_size() -> usize {
+        4
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.a.borrow()).to_bytes(&mut buf[0..4]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            a: Rc::new(RefCell::new(<i32>::from_bytes(&buf[0..4]))),
+        }
+    }
+}
+#[derive(Default)]
+pub struct Inner {
+    pub x: Value<i32>,
+}
+impl std::cmp::Ord for Inner {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        {
+            InnerImpl::operator_cmp(
+                &Rc::new(RefCell::new(Inner { x: self.x.clone() })).as_pointer(),
+                Rc::new(RefCell::new(Inner { x: other.x.clone() })).as_pointer(),
+            )
+        }
+    }
+}
+impl std::cmp::PartialOrd for Inner {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl std::cmp::PartialEq for Inner {
+    fn eq(&self, other: &Self) -> bool {
+        {
+            InnerImpl::operator_cmp(
+                &Rc::new(RefCell::new(Inner { x: self.x.clone() })).as_pointer(),
+                Rc::new(RefCell::new(Inner { x: other.x.clone() })).as_pointer(),
+            ) == std::cmp::Ordering::Equal
+        }
+    }
+}
+impl std::cmp::Eq for Inner {}
+impl Clone for Inner {
+    fn clone(&self) -> Self {
+        let __this: Value<Inner> = Rc::new(RefCell::new(Self {
+            x: Rc::new(RefCell::new((*self.x.borrow()))),
+        }));
+        let this: Ptr<Inner> = __this.as_pointer();
+        Rc::try_unwrap(__this).ok().unwrap().into_inner()
+    }
+}
+impl ByteRepr for Inner {
+    fn byte_size() -> usize {
+        4
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.x.borrow()).to_bytes(&mut buf[0..4]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            x: Rc::new(RefCell::new(<i32>::from_bytes(&buf[0..4]))),
+        }
+    }
+}
+#[derive(Default)]
+pub struct Outer {
+    pub i: Value<Inner>,
+    pub y: Value<i32>,
+}
+impl std::cmp::Ord for Outer {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        {
+            OuterImpl::operator_cmp(
+                &Rc::new(RefCell::new(Outer {
+                    i: self.i.clone(),
+                    y: self.y.clone(),
+                }))
+                .as_pointer(),
+                Rc::new(RefCell::new(Outer {
+                    i: other.i.clone(),
+                    y: other.y.clone(),
+                }))
+                .as_pointer(),
+            )
+        }
+    }
+}
+impl std::cmp::PartialOrd for Outer {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl std::cmp::PartialEq for Outer {
+    fn eq(&self, other: &Self) -> bool {
+        {
+            OuterImpl::operator_cmp(
+                &Rc::new(RefCell::new(Outer {
+                    i: self.i.clone(),
+                    y: self.y.clone(),
+                }))
+                .as_pointer(),
+                Rc::new(RefCell::new(Outer {
+                    i: other.i.clone(),
+                    y: other.y.clone(),
+                }))
+                .as_pointer(),
+            ) == std::cmp::Ordering::Equal
+        }
+    }
+}
+impl std::cmp::Eq for Outer {}
+impl Clone for Outer {
+    fn clone(&self) -> Self {
+        let __this: Value<Outer> = Rc::new(RefCell::new(Self {
+            i: Rc::new(RefCell::new((*self.i.borrow()).clone())),
+            y: Rc::new(RefCell::new((*self.y.borrow()))),
+        }));
+        let this: Ptr<Outer> = __this.as_pointer();
+        Rc::try_unwrap(__this).ok().unwrap().into_inner()
+    }
+}
+impl ByteRepr for Outer {
+    fn byte_size() -> usize {
+        8
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.i.borrow()).to_bytes(&mut buf[0..4]);
+        (*self.y.borrow()).to_bytes(&mut buf[4..8]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            i: Rc::new(RefCell::new(<Inner>::from_bytes(&buf[0..4]))),
+            y: Rc::new(RefCell::new(<i32>::from_bytes(&buf[4..8]))),
+        }
+    }
+}
+#[derive(Default)]
+pub struct Secondary {
+    pub a: Value<i32>,
+}
+impl std::cmp::Ord for Secondary {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        {
+            SecondaryImpl::operator_cmp(
+                &Rc::new(RefCell::new(Secondary { a: self.a.clone() })).as_pointer(),
+                Rc::new(RefCell::new(Secondary { a: other.a.clone() })).as_pointer(),
+            )
+        }
+    }
+}
+impl std::cmp::PartialOrd for Secondary {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl std::cmp::PartialEq for Secondary {
+    fn eq(&self, other: &Self) -> bool {
+        {
+            SecondaryImpl::operator_eq(
+                &Rc::new(RefCell::new(Secondary { a: self.a.clone() })).as_pointer(),
+                Rc::new(RefCell::new(Secondary { a: other.a.clone() })).as_pointer(),
+            )
+        }
+    }
+}
+impl std::cmp::Eq for Secondary {}
+impl Clone for Secondary {
+    fn clone(&self) -> Self {
+        let __this: Value<Secondary> = Rc::new(RefCell::new(Self {
+            a: Rc::new(RefCell::new((*self.a.borrow()))),
+        }));
+        let this: Ptr<Secondary> = __this.as_pointer();
+        Rc::try_unwrap(__this).ok().unwrap().into_inner()
+    }
+}
+impl ByteRepr for Secondary {
+    fn byte_size() -> usize {
+        4
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.a.borrow()).to_bytes(&mut buf[0..4]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            a: Rc::new(RefCell::new(<i32>::from_bytes(&buf[0..4]))),
+        }
+    }
+}
 pub fn main() {
     std::process::exit(main_0());
 }
@@ -245,6 +473,57 @@ fn main_0() -> i32 {
             BothImpl::operator_eq(&b2.as_pointer(), _arg0)
         })
     );
+    let o1: Value<OrdOnly> = Rc::new(RefCell::new(OrdOnly {
+        a: Rc::new(RefCell::new(1)),
+    }));
+    let o2: Value<OrdOnly> = Rc::new(RefCell::new(OrdOnly {
+        a: Rc::new(RefCell::new(2)),
+    }));
+    assert!(
+        ({ OrdOnlyImpl::operator_cmp(&o1.as_pointer(), o2.as_pointer(),) })
+            == std::cmp::Ordering::Less
+    );
+    assert!(
+        ({ OrdOnlyImpl::operator_cmp(&o2.as_pointer(), o1.as_pointer(),) })
+            == std::cmp::Ordering::Greater
+    );
+    let x1: Value<Outer> = Rc::new(RefCell::new(Outer {
+        i: Rc::new(RefCell::new(Inner {
+            x: Rc::new(RefCell::new(1)),
+        })),
+        y: Rc::new(RefCell::new(9)),
+    }));
+    let x2: Value<Outer> = Rc::new(RefCell::new(Outer {
+        i: Rc::new(RefCell::new(Inner {
+            x: Rc::new(RefCell::new(2)),
+        })),
+        y: Rc::new(RefCell::new(0)),
+    }));
+    let x3: Value<Outer> = Rc::new(RefCell::new(Outer {
+        i: Rc::new(RefCell::new(Inner {
+            x: Rc::new(RefCell::new(1)),
+        })),
+        y: Rc::new(RefCell::new(9)),
+    }));
+    assert!(
+        ({ OuterImpl::operator_cmp(&x1.as_pointer(), x2.as_pointer(),) })
+            == std::cmp::Ordering::Less
+    );
+    assert!(({ OuterImpl::operator_eq(&x1.as_pointer(), x3.as_pointer(),) }));
+    assert!(
+        ({ OuterImpl::operator_cmp(&x2.as_pointer(), x1.as_pointer(),) })
+            == std::cmp::Ordering::Greater
+    );
+    let s1: Value<Secondary> = Rc::new(RefCell::new(Secondary {
+        a: Rc::new(RefCell::new(1)),
+    }));
+    let s2: Value<Secondary> = Rc::new(RefCell::new(Secondary {
+        a: Rc::new(RefCell::new(2)),
+    }));
+    assert!(({ SecondaryImpl::operator_ne(&s1.as_pointer(), s2.as_pointer(),) }));
+    assert!(({ SecondaryImpl::operator_lt(&s1.as_pointer(), s2.as_pointer(),) }));
+    assert!(({ SecondaryImpl::operator_ge(&s2.as_pointer(), s1.as_pointer(),) }));
+    assert!(!({ SecondaryImpl::operator_lt(&s2.as_pointer(), s1.as_pointer(),) }));
     return 0;
 }
 pub trait BothImpl {
@@ -319,5 +598,129 @@ impl EqImpl for Ptr<Eq> {
             let _lhs = (*(*(*self).upgrade().deref()).b.borrow());
             _lhs == (*(*_arg0.upgrade().deref()).b.borrow())
         });
+    }
+}
+pub trait InnerImpl {
+    fn operator_cmp(&self, _arg0: Ptr<Inner>) -> std::cmp::Ordering;
+    fn operator_eq(&self, _arg0: Ptr<Inner>) -> bool;
+}
+impl InnerImpl for Ptr<Inner> {
+    fn operator_cmp(&self, _arg0: Ptr<Inner>) -> std::cmp::Ordering {
+        {
+            let cmp: Value<std::cmp::Ordering> = Rc::new(RefCell::new(
+                (*(*(*self).upgrade().deref()).x.borrow())
+                    .cmp(&(*(*_arg0.upgrade().deref()).x.borrow())),
+            ));
+            if !((*cmp.borrow()) == std::cmp::Ordering::Equal) {
+                return (*cmp.borrow_mut()).clone();
+            }
+        }
+        return std::cmp::Ordering::Equal;
+    }
+    fn operator_eq(&self, _arg0: Ptr<Inner>) -> bool {
+        return {
+            let _lhs = (*(*(*self).upgrade().deref()).x.borrow());
+            _lhs == (*(*_arg0.upgrade().deref()).x.borrow())
+        };
+    }
+}
+pub trait OrdOnlyImpl {
+    fn operator_cmp(&self, _arg0: Ptr<OrdOnly>) -> std::cmp::Ordering;
+}
+impl OrdOnlyImpl for Ptr<OrdOnly> {
+    fn operator_cmp(&self, _arg0: Ptr<OrdOnly>) -> std::cmp::Ordering {
+        {
+            let cmp: Value<std::cmp::Ordering> = Rc::new(RefCell::new(
+                (*(*(*self).upgrade().deref()).a.borrow())
+                    .cmp(&(*(*_arg0.upgrade().deref()).a.borrow())),
+            ));
+            if !((*cmp.borrow()) == std::cmp::Ordering::Equal) {
+                return (*cmp.borrow_mut()).clone();
+            }
+        }
+        return std::cmp::Ordering::Equal;
+    }
+}
+pub trait OuterImpl {
+    fn operator_cmp(&self, _arg0: Ptr<Outer>) -> std::cmp::Ordering;
+    fn operator_eq(&self, _arg0: Ptr<Outer>) -> bool;
+}
+impl OuterImpl for Ptr<Outer> {
+    fn operator_cmp(&self, _arg0: Ptr<Outer>) -> std::cmp::Ordering {
+        {
+            let cmp: Value<std::cmp::Ordering> = Rc::new(RefCell::new(
+                ({
+                    let _arg0: Ptr<Inner> = (*_arg0.upgrade().deref()).i.as_pointer();
+                    InnerImpl::operator_cmp(&(*(*self).upgrade().deref()).i.as_pointer(), _arg0)
+                }),
+            ));
+            if !((*cmp.borrow()) == std::cmp::Ordering::Equal) {
+                return (*cmp.borrow_mut()).clone();
+            }
+        }
+        {
+            let cmp: Value<std::cmp::Ordering> = Rc::new(RefCell::new(
+                (*(*(*self).upgrade().deref()).y.borrow())
+                    .cmp(&(*(*_arg0.upgrade().deref()).y.borrow())),
+            ));
+            if !((*cmp.borrow()) == std::cmp::Ordering::Equal) {
+                return (*cmp.borrow_mut()).clone();
+            }
+        }
+        return std::cmp::Ordering::Equal;
+    }
+    fn operator_eq(&self, _arg0: Ptr<Outer>) -> bool {
+        return ({
+            let _arg0: Ptr<Inner> = (*_arg0.upgrade().deref()).i.as_pointer();
+            InnerImpl::operator_eq(&(*(*self).upgrade().deref()).i.as_pointer(), _arg0)
+        }) && ({
+            let _lhs = (*(*(*self).upgrade().deref()).y.borrow());
+            _lhs == (*(*_arg0.upgrade().deref()).y.borrow())
+        });
+    }
+}
+pub trait SecondaryImpl {
+    fn operator_eq(&self, _arg0: Ptr<Secondary>) -> bool;
+    fn operator_ne(&self, _arg0: Ptr<Secondary>) -> bool;
+    fn operator_cmp(&self, _arg0: Ptr<Secondary>) -> std::cmp::Ordering;
+    fn operator_lt(&self, _arg0: Ptr<Secondary>) -> bool;
+    fn operator_ge(&self, _arg0: Ptr<Secondary>) -> bool;
+}
+impl SecondaryImpl for Ptr<Secondary> {
+    fn operator_eq(&self, _arg0: Ptr<Secondary>) -> bool {
+        return {
+            let _lhs = (*(*(*self).upgrade().deref()).a.borrow());
+            _lhs == (*(*_arg0.upgrade().deref()).a.borrow())
+        };
+    }
+    fn operator_ne(&self, _arg0: Ptr<Secondary>) -> bool {
+        return !({
+            let _arg0: Ptr<Secondary> = (_arg0).clone();
+            SecondaryImpl::operator_eq(&(*self), _arg0)
+        });
+    }
+    fn operator_cmp(&self, _arg0: Ptr<Secondary>) -> std::cmp::Ordering {
+        {
+            let cmp: Value<std::cmp::Ordering> = Rc::new(RefCell::new(
+                (*(*(*self).upgrade().deref()).a.borrow())
+                    .cmp(&(*(*_arg0.upgrade().deref()).a.borrow())),
+            ));
+            if !((*cmp.borrow()) == std::cmp::Ordering::Equal) {
+                return (*cmp.borrow_mut()).clone();
+            }
+        }
+        return std::cmp::Ordering::Equal;
+    }
+    fn operator_lt(&self, _arg0: Ptr<Secondary>) -> bool {
+        return ({
+            let _arg0: Ptr<Secondary> = (_arg0).clone();
+            SecondaryImpl::operator_cmp(&(*self), _arg0)
+        }) == std::cmp::Ordering::Less;
+    }
+    fn operator_ge(&self, _arg0: Ptr<Secondary>) -> bool {
+        return ({
+            let _arg0: Ptr<Secondary> = (_arg0).clone();
+            SecondaryImpl::operator_cmp(&(*self), _arg0)
+        }) != std::cmp::Ordering::Less;
     }
 }

--- a/tests/unit/out/refcount/operator_comparison_defaulted.rs
+++ b/tests/unit/out/refcount/operator_comparison_defaulted.rs
@@ -248,21 +248,21 @@ fn main_0() -> i32 {
     return 0;
 }
 pub trait BothImpl {
-    fn operator_eq(&self, __p0: Ptr<Both>) -> bool;
-    fn operator_cmp(&self, __p0: Ptr<Both>) -> std::cmp::Ordering;
+    fn operator_eq(&self, _arg0: Ptr<Both>) -> bool;
+    fn operator_cmp(&self, _arg0: Ptr<Both>) -> std::cmp::Ordering;
 }
 impl BothImpl for Ptr<Both> {
-    fn operator_eq(&self, __p0: Ptr<Both>) -> bool {
+    fn operator_eq(&self, _arg0: Ptr<Both>) -> bool {
         return {
             let _lhs = (*(*(*self).upgrade().deref()).a.borrow());
-            _lhs == (*(*__p0.upgrade().deref()).a.borrow())
+            _lhs == (*(*_arg0.upgrade().deref()).a.borrow())
         };
     }
-    fn operator_cmp(&self, __p0: Ptr<Both>) -> std::cmp::Ordering {
+    fn operator_cmp(&self, _arg0: Ptr<Both>) -> std::cmp::Ordering {
         {
             let cmp: Value<std::cmp::Ordering> = Rc::new(RefCell::new(
                 (*(*(*self).upgrade().deref()).a.borrow())
-                    .cmp(&(*(*__p0.upgrade().deref()).a.borrow())),
+                    .cmp(&(*(*_arg0.upgrade().deref()).a.borrow())),
             ));
             if !((*cmp.borrow()) == std::cmp::Ordering::Equal) {
                 return (*cmp.borrow_mut()).clone();
@@ -272,15 +272,15 @@ impl BothImpl for Ptr<Both> {
     }
 }
 pub trait CmpImpl {
-    fn operator_cmp(&self, __p0: Ptr<Cmp>) -> std::cmp::Ordering;
-    fn operator_eq(&self, __p0: Ptr<Cmp>) -> bool;
+    fn operator_cmp(&self, _arg0: Ptr<Cmp>) -> std::cmp::Ordering;
+    fn operator_eq(&self, _arg0: Ptr<Cmp>) -> bool;
 }
 impl CmpImpl for Ptr<Cmp> {
-    fn operator_cmp(&self, __p0: Ptr<Cmp>) -> std::cmp::Ordering {
+    fn operator_cmp(&self, _arg0: Ptr<Cmp>) -> std::cmp::Ordering {
         {
             let cmp: Value<std::cmp::Ordering> = Rc::new(RefCell::new(
                 (*(*(*self).upgrade().deref()).a.borrow())
-                    .cmp(&(*(*__p0.upgrade().deref()).a.borrow())),
+                    .cmp(&(*(*_arg0.upgrade().deref()).a.borrow())),
             ));
             if !((*cmp.borrow()) == std::cmp::Ordering::Equal) {
                 return (*cmp.borrow_mut()).clone();
@@ -289,7 +289,7 @@ impl CmpImpl for Ptr<Cmp> {
         {
             let cmp: Value<std::cmp::Ordering> = Rc::new(RefCell::new(
                 (*(*(*self).upgrade().deref()).b.borrow())
-                    .cmp(&(*(*__p0.upgrade().deref()).b.borrow())),
+                    .cmp(&(*(*_arg0.upgrade().deref()).b.borrow())),
             ));
             if !((*cmp.borrow()) == std::cmp::Ordering::Equal) {
                 return (*cmp.borrow_mut()).clone();
@@ -297,27 +297,27 @@ impl CmpImpl for Ptr<Cmp> {
         }
         return std::cmp::Ordering::Equal;
     }
-    fn operator_eq(&self, __p0: Ptr<Cmp>) -> bool {
+    fn operator_eq(&self, _arg0: Ptr<Cmp>) -> bool {
         return ({
             let _lhs = (*(*(*self).upgrade().deref()).a.borrow());
-            _lhs == (*(*__p0.upgrade().deref()).a.borrow())
+            _lhs == (*(*_arg0.upgrade().deref()).a.borrow())
         }) && ({
             let _lhs = (*(*(*self).upgrade().deref()).b.borrow());
-            _lhs == (*(*__p0.upgrade().deref()).b.borrow())
+            _lhs == (*(*_arg0.upgrade().deref()).b.borrow())
         });
     }
 }
 pub trait EqImpl {
-    fn operator_eq(&self, __p0: Ptr<Eq>) -> bool;
+    fn operator_eq(&self, _arg0: Ptr<Eq>) -> bool;
 }
 impl EqImpl for Ptr<Eq> {
-    fn operator_eq(&self, __p0: Ptr<Eq>) -> bool {
+    fn operator_eq(&self, _arg0: Ptr<Eq>) -> bool {
         return ({
             let _lhs = (*(*(*self).upgrade().deref()).a.borrow());
-            _lhs == (*(*__p0.upgrade().deref()).a.borrow())
+            _lhs == (*(*_arg0.upgrade().deref()).a.borrow())
         }) && ({
             let _lhs = (*(*(*self).upgrade().deref()).b.borrow());
-            _lhs == (*(*__p0.upgrade().deref()).b.borrow())
+            _lhs == (*(*_arg0.upgrade().deref()).b.borrow())
         });
     }
 }

--- a/tests/unit/out/refcount/pointer_to_boolean.rs
+++ b/tests/unit/out/refcount/pointer_to_boolean.rs
@@ -11,6 +11,6 @@ pub fn main() {
 }
 fn main_0() -> i32 {
     let x: Value<Ptr<i32>> = Rc::new(RefCell::new(Ptr::<i32>::null()));
-    assert!(!!(*x.borrow()).is_null());
+    assert!(!(!(*x.borrow()).is_null()));
     return 0;
 }

--- a/tests/unit/out/refcount/vector.rs
+++ b/tests/unit/out/refcount/vector.rs
@@ -17,7 +17,7 @@ fn main_0() -> i32 {
     assert!(((*v1.borrow()).len() == 0_usize));
     assert!((*v1.borrow()).is_empty());
     (*v1.borrow_mut()).push(1);
-    assert!(!(*v1.borrow()).is_empty());
+    assert!(!((*v1.borrow()).is_empty()));
     (*v1.borrow_mut()).pop();
     assert!((*v1.borrow()).is_empty());
     let s1: Value<usize> = Rc::new(RefCell::new((*v1.borrow()).len()));

--- a/tests/unit/out/refcount/vector_with_allocator.rs
+++ b/tests/unit/out/refcount/vector_with_allocator.rs
@@ -95,7 +95,7 @@ fn main_0() -> i32 {
     assert!(((*v1.borrow()).len() == 0_usize));
     assert!((*v1.borrow()).is_empty());
     (*v1.borrow_mut()).push(1);
-    assert!(!(*v1.borrow()).is_empty());
+    assert!(!((*v1.borrow()).is_empty()));
     (*v1.borrow_mut()).pop();
     assert!((*v1.borrow()).is_empty());
     let s1: Value<usize> = Rc::new(RefCell::new((*v1.borrow()).len()));

--- a/tests/unit/out/unsafe/bool_condition_enum.rs
+++ b/tests/unit/out/unsafe/bool_condition_enum.rs
@@ -33,6 +33,6 @@ unsafe fn main_0() -> i32 {
     let mut t9: i32 = (!(code != 0) as i32);
     assert!(((t9) == (1)));
     let mut b4: bool = (code != 0);
-    assert!(!b4);
+    assert!(!(b4));
     return 0;
 }

--- a/tests/unit/out/unsafe/bool_condition_enum_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_enum_c.rs
@@ -33,6 +33,6 @@ unsafe fn main_0() -> i32 {
     let mut t9: i32 = (!(code != 0) as i32);
     assert!(((((t9) == (1)) as i32) != 0));
     let mut b4: bool = (code != 0);
-    assert!(((!b4 as i32) != 0));
+    assert!(((!(b4) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/bool_condition_logical.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical.rs
@@ -79,7 +79,7 @@ unsafe fn main_0() -> i32 {
     }
     let mut k: u32 = 2_u32;
     let mut done: bool = false;
-    if ((k) > (1_u32)) || (!done) {
+    if ((k) > (1_u32)) || (!(done)) {
         assert!(true);
     }
     if ((x) > (y)) || (((flags) & (4_u32)) != 0) {

--- a/tests/unit/out/unsafe/bool_condition_logical_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_logical_c.rs
@@ -82,7 +82,7 @@ unsafe fn main_0() -> i32 {
     }
     let mut k: u32 = 2_u32;
     let mut done: bool = (0 != 0);
-    if (((((((k) > (1_u32)) as i32) != 0) || (!done)) as i32) != 0) {
+    if (((((((k) > (1_u32)) as i32) != 0) || (!(done))) as i32) != 0) {
         assert!((1 != 0));
     }
     if (((((((x) > (y)) as i32) != 0) || (((flags) & (4_u32)) != 0)) as i32) != 0) {

--- a/tests/unit/out/unsafe/bool_condition_ptr.rs
+++ b/tests/unit/out/unsafe/bool_condition_ptr.rs
@@ -18,13 +18,13 @@ unsafe fn main_0() -> i32 {
     if !(p).is_null() {
         assert!(true);
     }
-    if !!(p).is_null() {
+    if !(!(p).is_null()) {
         assert!(false);
     }
     if !(np).is_null() {
         assert!(false);
     }
-    if !!(np).is_null() {
+    if !(!(np).is_null()) {
         assert!(true);
     }
     let mut iter: *mut i32 = p;
@@ -38,13 +38,13 @@ unsafe fn main_0() -> i32 {
     assert!(((t3) == (1)));
     let mut t4: i32 = if !(np).is_null() { 1 } else { 0 };
     assert!(((t4) == (0)));
-    let mut t5: i32 = (!!(p).is_null() as i32);
+    let mut t5: i32 = (!(!(p).is_null()) as i32);
     assert!(((t5) == (0)));
-    let mut t6: i32 = (!!(np).is_null() as i32);
+    let mut t6: i32 = (!(!(np).is_null()) as i32);
     assert!(((t6) == (1)));
     let mut b2: bool = !(p).is_null();
     let mut b3: bool = !(np).is_null();
     assert!(b2);
-    assert!(!b3);
+    assert!(!(b3));
     return 0;
 }

--- a/tests/unit/out/unsafe/bool_condition_ptr_c.rs
+++ b/tests/unit/out/unsafe/bool_condition_ptr_c.rs
@@ -18,13 +18,13 @@ unsafe fn main_0() -> i32 {
     if !(p).is_null() {
         assert!((1 != 0));
     }
-    if !!(p).is_null() {
+    if !(!(p).is_null()) {
         assert!((0 != 0));
     }
     if !(np).is_null() {
         assert!((0 != 0));
     }
-    if !!(np).is_null() {
+    if !(!(np).is_null()) {
         assert!((1 != 0));
     }
     let mut iter: *mut i32 = p;
@@ -38,13 +38,13 @@ unsafe fn main_0() -> i32 {
     assert!(((((t3) == (1)) as i32) != 0));
     let mut t4: i32 = if !(np).is_null() { 1 } else { 0 };
     assert!(((((t4) == (0)) as i32) != 0));
-    let mut t5: i32 = (!!(p).is_null() as i32);
+    let mut t5: i32 = (!(!(p).is_null()) as i32);
     assert!(((((t5) == (0)) as i32) != 0));
-    let mut t6: i32 = (!!(np).is_null() as i32);
+    let mut t6: i32 = (!(!(np).is_null()) as i32);
     assert!(((((t6) == (1)) as i32) != 0));
     let mut b2: bool = !(p).is_null();
     let mut b3: bool = !(np).is_null();
     assert!(b2);
-    assert!(((!b3 as i32) != 0));
+    assert!(((!(b3) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/builtin.rs
+++ b/tests/unit/out/unsafe/builtin.rs
@@ -38,11 +38,11 @@ pub unsafe fn test_popcountl_7() {
 pub unsafe fn test_mul_overflow_long_8() {
     let mut r: i64 = 0_i64;
     assert!(
-        ((!{
+        ((!({
             let (val, ovf) = 3_i64.overflowing_mul(7_i64);
             *(&mut r as *mut i64) = val;
             ovf
-        } as i32)
+        }) as i32)
             != 0)
     );
     assert!(((((r) == (21_i64)) as i32) != 0));
@@ -55,11 +55,11 @@ pub unsafe fn test_mul_overflow_long_8() {
 pub unsafe fn test_mul_overflow_long_long_9() {
     let mut r: i64 = 0_i64;
     assert!(
-        ((!{
+        ((!({
             let (val, ovf) = 1000_i64.overflowing_mul(1000_i64);
             *(&mut r as *mut i64) = val;
             ovf
-        } as i32)
+        }) as i32)
             != 0)
     );
     assert!(((((r) == (1000000_i64)) as i32) != 0));

--- a/tests/unit/out/unsafe/fn_ptr_as_condition.rs
+++ b/tests/unit/out/unsafe/fn_ptr_as_condition.rs
@@ -27,7 +27,7 @@ unsafe fn main_0() -> i32 {
     (unsafe { maybe_call_1(None, (&mut b as *mut i32)) });
     assert!(((b) == (5)));
     let mut fn_: Option<unsafe fn(*mut i32)> = None;
-    if !!(fn_).is_none() {
+    if !(!(fn_).is_none()) {
         fn_ = Some(double_it_0);
     }
     let mut c: i32 = 3;

--- a/tests/unit/out/unsafe/int_to_bool_explicit.rs
+++ b/tests/unit/out/unsafe/int_to_bool_explicit.rs
@@ -16,6 +16,6 @@ unsafe fn main_0() -> i32 {
     let mut b1: bool = (flag != 0);
     let mut b2: bool = (0_u32 != 0);
     assert!(b1);
-    assert!(!b2);
+    assert!(!(b2));
     return 0;
 }

--- a/tests/unit/out/unsafe/int_to_bool_explicit_c.rs
+++ b/tests/unit/out/unsafe/int_to_bool_explicit_c.rs
@@ -16,6 +16,6 @@ unsafe fn main_0() -> i32 {
     let mut b1: bool = (flag != 0);
     let mut b2: bool = (0_u32 != 0);
     assert!(b1);
-    assert!(((!b2 as i32) != 0));
+    assert!(((!(b2) as i32) != 0));
     return 0;
 }

--- a/tests/unit/out/unsafe/libc_char_ptr_field.rs
+++ b/tests/unit/out/unsafe/libc_char_ptr_field.rs
@@ -13,7 +13,7 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut pw: *mut ::libc::passwd = libc::getpwuid(libc::geteuid());
-    if !!(pw).is_null() {
+    if !(!(pw).is_null()) {
         return 0;
     }
     let mut home: *mut libc::c_char = (*pw).pw_dir;

--- a/tests/unit/out/unsafe/operator_comparison_defaulted.rs
+++ b/tests/unit/out/unsafe/operator_comparison_defaulted.rs
@@ -13,9 +13,9 @@ pub struct Eq {
     pub b: i32,
 }
 impl Eq {
-    pub unsafe fn operator_eq(&self, __p0: *const Eq) -> bool {
-        return (((*(self as *const Eq)).a) == ((*__p0).a))
-            && (((*(self as *const Eq)).b) == ((*__p0).b));
+    pub unsafe fn operator_eq(&self, _arg0: *const Eq) -> bool {
+        return (((*(self as *const Eq)).a) == ((*_arg0).a))
+            && (((*(self as *const Eq)).b) == ((*_arg0).b));
     }
 }
 impl std::cmp::PartialEq for Eq {
@@ -31,24 +31,24 @@ pub struct Cmp {
     pub b: i32,
 }
 impl Cmp {
-    pub unsafe fn operator_cmp(&self, __p0: *const Cmp) -> std::cmp::Ordering {
+    pub unsafe fn operator_cmp(&self, _arg0: *const Cmp) -> std::cmp::Ordering {
         {
-            let mut cmp: std::cmp::Ordering = ((*(self as *const Cmp)).a).cmp(&((*__p0).a));
+            let mut cmp: std::cmp::Ordering = ((*(self as *const Cmp)).a).cmp(&((*_arg0).a));
             if !(cmp == std::cmp::Ordering::Equal) {
                 return cmp;
             }
         }
         {
-            let mut cmp: std::cmp::Ordering = ((*(self as *const Cmp)).b).cmp(&((*__p0).b));
+            let mut cmp: std::cmp::Ordering = ((*(self as *const Cmp)).b).cmp(&((*_arg0).b));
             if !(cmp == std::cmp::Ordering::Equal) {
                 return cmp;
             }
         }
         return std::cmp::Ordering::Equal;
     }
-    pub unsafe fn operator_eq(&self, __p0: *const Cmp) -> bool {
-        return (((*(self as *const Cmp)).a) == ((*__p0).a))
-            && (((*(self as *const Cmp)).b) == ((*__p0).b));
+    pub unsafe fn operator_eq(&self, _arg0: *const Cmp) -> bool {
+        return (((*(self as *const Cmp)).a) == ((*_arg0).a))
+            && (((*(self as *const Cmp)).b) == ((*_arg0).b));
     }
 }
 impl std::cmp::Ord for Cmp {
@@ -73,12 +73,12 @@ pub struct Both {
     pub a: i32,
 }
 impl Both {
-    pub unsafe fn operator_eq(&self, __p0: *const Both) -> bool {
-        return (((*(self as *const Both)).a) == ((*__p0).a));
+    pub unsafe fn operator_eq(&self, _arg0: *const Both) -> bool {
+        return (((*(self as *const Both)).a) == ((*_arg0).a));
     }
-    pub unsafe fn operator_cmp(&self, __p0: *const Both) -> std::cmp::Ordering {
+    pub unsafe fn operator_cmp(&self, _arg0: *const Both) -> std::cmp::Ordering {
         {
-            let mut cmp: std::cmp::Ordering = ((*(self as *const Both)).a).cmp(&((*__p0).a));
+            let mut cmp: std::cmp::Ordering = ((*(self as *const Both)).a).cmp(&((*_arg0).a));
             if !(cmp == std::cmp::Ordering::Equal) {
                 return cmp;
             }

--- a/tests/unit/out/unsafe/operator_comparison_defaulted.rs
+++ b/tests/unit/out/unsafe/operator_comparison_defaulted.rs
@@ -102,6 +102,174 @@ impl std::cmp::PartialEq for Both {
     }
 }
 impl std::cmp::Eq for Both {}
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct OrdOnly {
+    pub a: i32,
+}
+impl OrdOnly {
+    pub unsafe fn operator_cmp(&self, _arg0: *const OrdOnly) -> std::cmp::Ordering {
+        {
+            let mut cmp: std::cmp::Ordering = ((*(self as *const OrdOnly)).a).cmp(&((*_arg0).a));
+            if !(cmp == std::cmp::Ordering::Equal) {
+                return cmp;
+            }
+        }
+        return std::cmp::Ordering::Equal;
+    }
+}
+impl std::cmp::Ord for OrdOnly {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        unsafe { OrdOnly::operator_cmp(self, other as *const OrdOnly) }
+    }
+}
+impl std::cmp::PartialOrd for OrdOnly {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl std::cmp::PartialEq for OrdOnly {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { OrdOnly::operator_cmp(self, other as *const OrdOnly) == std::cmp::Ordering::Equal }
+    }
+}
+impl std::cmp::Eq for OrdOnly {}
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct Inner {
+    pub x: i32,
+}
+impl Inner {
+    pub unsafe fn operator_cmp(&self, _arg0: *const Inner) -> std::cmp::Ordering {
+        {
+            let mut cmp: std::cmp::Ordering = ((*(self as *const Inner)).x).cmp(&((*_arg0).x));
+            if !(cmp == std::cmp::Ordering::Equal) {
+                return cmp;
+            }
+        }
+        return std::cmp::Ordering::Equal;
+    }
+    pub unsafe fn operator_eq(&self, _arg0: *const Inner) -> bool {
+        return (((*(self as *const Inner)).x) == ((*_arg0).x));
+    }
+}
+impl std::cmp::Ord for Inner {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        unsafe { Inner::operator_cmp(self, other as *const Inner) }
+    }
+}
+impl std::cmp::PartialOrd for Inner {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl std::cmp::PartialEq for Inner {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { Inner::operator_cmp(self, other as *const Inner) == std::cmp::Ordering::Equal }
+    }
+}
+impl std::cmp::Eq for Inner {}
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct Outer {
+    pub i: Inner,
+    pub y: i32,
+}
+impl Outer {
+    pub unsafe fn operator_cmp(&self, _arg0: *const Outer) -> std::cmp::Ordering {
+        {
+            let mut cmp: std::cmp::Ordering = (unsafe {
+                let _arg0: *const Inner = &(*_arg0).i as *const Inner;
+                Inner::operator_cmp(&(*(self as *const Outer)).i, _arg0)
+            });
+            if !(cmp == std::cmp::Ordering::Equal) {
+                return cmp;
+            }
+        }
+        {
+            let mut cmp: std::cmp::Ordering = ((*(self as *const Outer)).y).cmp(&((*_arg0).y));
+            if !(cmp == std::cmp::Ordering::Equal) {
+                return cmp;
+            }
+        }
+        return std::cmp::Ordering::Equal;
+    }
+    pub unsafe fn operator_eq(&self, _arg0: *const Outer) -> bool {
+        return (unsafe {
+            let _arg0: *const Inner = &(*_arg0).i as *const Inner;
+            Inner::operator_eq(&(*(self as *const Outer)).i, _arg0)
+        }) && (((*(self as *const Outer)).y) == ((*_arg0).y));
+    }
+}
+impl std::cmp::Ord for Outer {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        unsafe { Outer::operator_cmp(self, other as *const Outer) }
+    }
+}
+impl std::cmp::PartialOrd for Outer {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl std::cmp::PartialEq for Outer {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { Outer::operator_cmp(self, other as *const Outer) == std::cmp::Ordering::Equal }
+    }
+}
+impl std::cmp::Eq for Outer {}
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct Secondary {
+    pub a: i32,
+}
+impl Secondary {
+    pub unsafe fn operator_eq(&self, _arg0: *const Secondary) -> bool {
+        return (((*(self as *const Secondary)).a) == ((*_arg0).a));
+    }
+    pub unsafe fn operator_ne(&self, _arg0: *const Secondary) -> bool {
+        return !(unsafe {
+            let _arg0: *const Secondary = _arg0;
+            Secondary::operator_eq(&(*(self as *const Secondary)), _arg0)
+        });
+    }
+    pub unsafe fn operator_cmp(&self, _arg0: *const Secondary) -> std::cmp::Ordering {
+        {
+            let mut cmp: std::cmp::Ordering = ((*(self as *const Secondary)).a).cmp(&((*_arg0).a));
+            if !(cmp == std::cmp::Ordering::Equal) {
+                return cmp;
+            }
+        }
+        return std::cmp::Ordering::Equal;
+    }
+    pub unsafe fn operator_lt(&self, _arg0: *const Secondary) -> bool {
+        return (unsafe {
+            let _arg0: *const Secondary = _arg0;
+            Secondary::operator_cmp(&(*(self as *const Secondary)), _arg0)
+        }) == std::cmp::Ordering::Less;
+    }
+    pub unsafe fn operator_ge(&self, _arg0: *const Secondary) -> bool {
+        return (unsafe {
+            let _arg0: *const Secondary = _arg0;
+            Secondary::operator_cmp(&(*(self as *const Secondary)), _arg0)
+        }) != std::cmp::Ordering::Less;
+    }
+}
+impl std::cmp::Ord for Secondary {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        unsafe { Secondary::operator_cmp(self, other as *const Secondary) }
+    }
+}
+impl std::cmp::PartialOrd for Secondary {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl std::cmp::PartialEq for Secondary {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { Secondary::operator_eq(self, other as *const Secondary) }
+    }
+}
+impl std::cmp::Eq for Secondary {}
 pub fn main() {
     unsafe {
         std::process::exit(main_0() as i32);
@@ -135,5 +303,39 @@ unsafe fn main_0() -> i32 {
             Both::operator_eq(&b2, _arg0)
         })
     );
+    let mut o1: OrdOnly = OrdOnly { a: 1 };
+    let mut o2: OrdOnly = OrdOnly { a: 2 };
+    assert!(
+        (unsafe { OrdOnly::operator_cmp(&o1, &o2 as *const OrdOnly,) }) == std::cmp::Ordering::Less
+    );
+    assert!(
+        (unsafe { OrdOnly::operator_cmp(&o2, &o1 as *const OrdOnly,) })
+            == std::cmp::Ordering::Greater
+    );
+    let mut x1: Outer = Outer {
+        i: Inner { x: 1 },
+        y: 9,
+    };
+    let mut x2: Outer = Outer {
+        i: Inner { x: 2 },
+        y: 0,
+    };
+    let mut x3: Outer = Outer {
+        i: Inner { x: 1 },
+        y: 9,
+    };
+    assert!(
+        (unsafe { Outer::operator_cmp(&x1, &x2 as *const Outer,) }) == std::cmp::Ordering::Less
+    );
+    assert!((unsafe { Outer::operator_eq(&x1, &x3 as *const Outer,) }));
+    assert!(
+        (unsafe { Outer::operator_cmp(&x2, &x1 as *const Outer,) }) == std::cmp::Ordering::Greater
+    );
+    let mut s1: Secondary = Secondary { a: 1 };
+    let mut s2: Secondary = Secondary { a: 2 };
+    assert!((unsafe { Secondary::operator_ne(&s1, &s2 as *const Secondary,) }));
+    assert!((unsafe { Secondary::operator_lt(&s1, &s2 as *const Secondary,) }));
+    assert!((unsafe { Secondary::operator_ge(&s2, &s1 as *const Secondary,) }));
+    assert!(!(unsafe { Secondary::operator_lt(&s2, &s1 as *const Secondary,) }));
     return 0;
 }

--- a/tests/unit/out/unsafe/operator_comparison_defaulted.rs
+++ b/tests/unit/out/unsafe/operator_comparison_defaulted.rs
@@ -1,0 +1,139 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct Eq {
+    pub a: i32,
+    pub b: i32,
+}
+impl Eq {
+    pub unsafe fn operator_eq(&self, __p0: *const Eq) -> bool {
+        return (((*(self as *const Eq)).a) == ((*__p0).a))
+            && (((*(self as *const Eq)).b) == ((*__p0).b));
+    }
+}
+impl std::cmp::PartialEq for Eq {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { Eq::operator_eq(self, other as *const Eq) }
+    }
+}
+impl std::cmp::Eq for Eq {}
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct Cmp {
+    pub a: i32,
+    pub b: i32,
+}
+impl Cmp {
+    pub unsafe fn operator_cmp(&self, __p0: *const Cmp) -> std::cmp::Ordering {
+        {
+            let mut cmp: std::cmp::Ordering = ((*(self as *const Cmp)).a).cmp(&((*__p0).a));
+            if !(cmp == std::cmp::Ordering::Equal) {
+                return cmp;
+            }
+        }
+        {
+            let mut cmp: std::cmp::Ordering = ((*(self as *const Cmp)).b).cmp(&((*__p0).b));
+            if !(cmp == std::cmp::Ordering::Equal) {
+                return cmp;
+            }
+        }
+        return std::cmp::Ordering::Equal;
+    }
+    pub unsafe fn operator_eq(&self, __p0: *const Cmp) -> bool {
+        return (((*(self as *const Cmp)).a) == ((*__p0).a))
+            && (((*(self as *const Cmp)).b) == ((*__p0).b));
+    }
+}
+impl std::cmp::Ord for Cmp {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        unsafe { Cmp::operator_cmp(self, other as *const Cmp) }
+    }
+}
+impl std::cmp::PartialOrd for Cmp {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl std::cmp::PartialEq for Cmp {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { Cmp::operator_cmp(self, other as *const Cmp) == std::cmp::Ordering::Equal }
+    }
+}
+impl std::cmp::Eq for Cmp {}
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct Both {
+    pub a: i32,
+}
+impl Both {
+    pub unsafe fn operator_eq(&self, __p0: *const Both) -> bool {
+        return (((*(self as *const Both)).a) == ((*__p0).a));
+    }
+    pub unsafe fn operator_cmp(&self, __p0: *const Both) -> std::cmp::Ordering {
+        {
+            let mut cmp: std::cmp::Ordering = ((*(self as *const Both)).a).cmp(&((*__p0).a));
+            if !(cmp == std::cmp::Ordering::Equal) {
+                return cmp;
+            }
+        }
+        return std::cmp::Ordering::Equal;
+    }
+}
+impl std::cmp::Ord for Both {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        unsafe { Both::operator_cmp(self, other as *const Both) }
+    }
+}
+impl std::cmp::PartialOrd for Both {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl std::cmp::PartialEq for Both {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { Both::operator_eq(self, other as *const Both) }
+    }
+}
+impl std::cmp::Eq for Both {}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    let mut e1: Eq = Eq { a: 1, b: 2 };
+    let mut e2: Eq = Eq { a: 1, b: 2 };
+    let mut e3: Eq = Eq { a: 1, b: 3 };
+    assert!((unsafe { Eq::operator_eq(&e1, &e2 as *const Eq,) }));
+    assert!(!(unsafe { Eq::operator_eq(&e1, &e3 as *const Eq,) }));
+    let mut c1: Cmp = Cmp { a: 1, b: 2 };
+    let mut c2: Cmp = Cmp { a: 1, b: 3 };
+    let mut c3: Cmp = Cmp { a: 2, b: 0 };
+    let mut c4: Cmp = Cmp { a: 1, b: 9 };
+    assert!((unsafe { Cmp::operator_cmp(&c1, &c2 as *const Cmp,) }) == std::cmp::Ordering::Less);
+    assert!((unsafe { Cmp::operator_cmp(&c3, &c4 as *const Cmp,) }) == std::cmp::Ordering::Greater);
+    assert!(
+        (unsafe {
+            let _arg0: *const Cmp = &c1 as *const Cmp;
+            Cmp::operator_eq(&c1, _arg0)
+        })
+    );
+    assert!((unsafe { Cmp::operator_cmp(&c1, &c2 as *const Cmp,) }) == std::cmp::Ordering::Less);
+    let mut b1: Both = Both { a: 1 };
+    let mut b2: Both = Both { a: 2 };
+    assert!((unsafe { Both::operator_cmp(&b1, &b2 as *const Both,) }) == std::cmp::Ordering::Less);
+    assert!(
+        (unsafe {
+            let _arg0: *const Both = &b2 as *const Both;
+            Both::operator_eq(&b2, _arg0)
+        })
+    );
+    return 0;
+}

--- a/tests/unit/out/unsafe/pointer_to_boolean.rs
+++ b/tests/unit/out/unsafe/pointer_to_boolean.rs
@@ -13,6 +13,6 @@ pub fn main() {
 }
 unsafe fn main_0() -> i32 {
     let mut x: *mut i32 = std::ptr::null_mut();
-    assert!(!!(x).is_null());
+    assert!(!(!(x).is_null()));
     return 0;
 }

--- a/tests/unit/out/unsafe/polymorphism.rs
+++ b/tests/unit/out/unsafe/polymorphism.rs
@@ -42,6 +42,6 @@ unsafe fn main_0() -> i32 {
     let mut cat: Cat = <Cat>::default();
     animal = (&mut cat as *mut Cat);
     let mut eat2: bool = (unsafe { (*(animal).cast_const()).bark() });
-    assert!((eat1) && (!eat2));
+    assert!((eat1) && (!(eat2)));
     return 0;
 }

--- a/tests/unit/out/unsafe/vector.rs
+++ b/tests/unit/out/unsafe/vector.rs
@@ -17,7 +17,7 @@ unsafe fn main_0() -> i32 {
     assert!(((v1.len()) == (0_usize)));
     assert!(v1.is_empty());
     v1.push(1);
-    assert!(!v1.is_empty());
+    assert!(!(v1.is_empty()));
     v1.pop();
     assert!(v1.is_empty());
     let mut s1: usize = v1.len();

--- a/tests/unit/out/unsafe/vector_with_allocator.rs
+++ b/tests/unit/out/unsafe/vector_with_allocator.rs
@@ -66,7 +66,7 @@ unsafe fn main_0() -> i32 {
     assert!(((v1.len()) == (0_usize)));
     assert!(v1.is_empty());
     v1.push(1);
-    assert!(!v1.is_empty());
+    assert!(!(v1.is_empty()));
     v1.pop();
     assert!(v1.is_empty());
     let mut s1: usize = v1.len();


### PR DESCRIPTION
This PR translates defaulted comparison operator such as `==` or `<=>` and the implicit comparison operators derived from `<=>`.

It asks Sema to define the defaulted/implicit operators and then cpp2rust translates them as normal methods.