### PR TITLE
Translate reference to array

### DIFF
--- a/cpp2rust/converter/converter.cpp
+++ b/cpp2rust/converter/converter.cpp
@@ -2186,8 +2186,11 @@ std::string Converter::GetEscapedStringLiteral(clang::Expr *expr,
 }
 
 bool Converter::VisitStringLiteral(clang::StringLiteral *expr) {
-  if (!curr_init_type_.empty() && curr_init_type_.back()->isArrayType()) {
-    if (auto *arr_ty = ctx_.getAsConstantArrayType(curr_init_type_.back())) {
+  auto init_type = curr_init_type_.empty()
+                       ? clang::QualType()
+                       : curr_init_type_.back().getNonReferenceType();
+  if (!init_type.isNull() && init_type->isArrayType()) {
+    if (auto *arr_ty = ctx_.getAsConstantArrayType(init_type)) {
       uint64_t arr_size = arr_ty->getSize().getZExtValue();
       if (expr->getString().empty()) {
         StrCat(std::format("[0 as libc::c_char; {}]", arr_size));

--- a/cpp2rust/converter/models/converter_refcount.cpp
+++ b/cpp2rust/converter/models/converter_refcount.cpp
@@ -129,6 +129,7 @@ bool ConverterRefCount::NeedsMut(const clang::VarDecl *decl,
 std::string ConverterRefCount::BoxType(std::string &&str) const {
   switch (getConversionKind()) {
   case ConversionKind::Unboxed:
+  case ConversionKind::Pointee:
   case ConversionKind::Ptr:
     return std::move(str);
   case ConversionKind::FullRefCount:
@@ -140,6 +141,7 @@ std::string ConverterRefCount::BoxType(std::string &&str) const {
 std::string ConverterRefCount::BoxValue(std::string &&str) const {
   switch (getConversionKind()) {
   case ConversionKind::Unboxed:
+  case ConversionKind::Pointee:
   case ConversionKind::Ptr:
     return std::move(str);
   case ConversionKind::FullRefCount:
@@ -178,7 +180,7 @@ bool ConverterRefCount::VisitIncompleteArrayType(
 }
 
 bool ConverterRefCount::VisitReferenceType(clang::ReferenceType *type) {
-  PushConversionKind push(*this, ConversionKind::Unboxed);
+  PushConversionKind push(*this, ConversionKind::Pointee);
   StrCat("Ptr<");
   Convert(type->getPointeeType());
   StrCat(token::kGt);
@@ -297,6 +299,7 @@ bool ConverterRefCount::VisitConstantArrayType(clang::ConstantArrayType *type) {
   case ConversionKind::Ptr:
     Convert(type->getElementType());
     break;
+  case ConversionKind::Pointee:
   case ConversionKind::FullRefCount:
     StrCat("Box<[");
     Convert(type->getElementType());
@@ -396,7 +399,9 @@ bool ConverterRefCount::VisitArraySubscriptExpr(
     clang::ArraySubscriptExpr *expr) {
   auto *base = expr->getBase();
   if (base->IgnoreCasts()->getType()->isPointerType() ||
-      IsUnionArrayMember(base)) {
+      IsUnionArrayMember(base) ||
+      (IsReferenceType(base) &&
+       base->IgnoreCasts()->getType()->isArrayType())) {
     ConvertPointerSubscript(expr);
   } else {
     if (!base->IgnoreCasts()->getType()->isArrayType()) {
@@ -846,7 +851,8 @@ bool ConverterRefCount::VisitDeclRefExpr(clang::DeclRefExpr *expr) {
     // std::vector<T>& gets converted to Ptr<vec<T>>
     // So we need to make a pointer to the vector itself
     if (isObject()) {
-      if (IsBoxedType(ref->getPointeeType())) {
+      if (IsBoxedType(ref->getPointeeType()) ||
+          ref->getPointeeType()->isArrayType()) {
         StrCat(str, ".to_strong().as_pointer()");
         computed_expr_type_ = ComputedExprType::FreshPointer;
         return false;
@@ -1227,7 +1233,9 @@ bool ConverterRefCount::VisitImplicitCastExpr(clang::ImplicitCastExpr *expr) {
       // smart enough to pick the right specialization
       PushConversionKind push(*this, ConversionKind::Unboxed);
       PushParen paren(*this);
-      StrCat(ConvertPointer(sub_expr), keyword::kAs, ToString(expr->getType()));
+      StrCat(IsReferenceType(sub_expr) ? ConvertObject(sub_expr)
+                                       : ConvertPointer(sub_expr),
+             keyword::kAs, ToString(expr->getType()));
       return false;
     }
   }
@@ -1590,6 +1598,7 @@ bool ConverterRefCount::VisitInitListExpr(clang::InitListExpr *expr) {
   case ConversionKind::Ptr:
     Converter::VisitInitListExpr(expr);
     break;
+  case ConversionKind::Pointee:
   case ConversionKind::FullRefCount:
     StrCat("Box::new(");
     Converter::VisitInitListExpr(expr);
@@ -2078,6 +2087,14 @@ std::string ConverterRefCount::ConvertVarInitValue(clang::QualType qual_type,
     if (llvm::isa<clang::MaterializeTemporaryExpr>(expr->IgnoreImpCasts())) {
       return EmitMaterializedTempBinding(qual_type, expr);
     }
+    if (qual_type.getNonReferenceType()->isArrayType()) {
+      if (IsStringLiteralExpr(expr)) {
+        return std::format("Ptr::from_string_literal_array({})",
+                           ToString(expr->IgnoreParens()->IgnoreImplicit()));
+      }
+      return std::format("({} as {})", ConvertFreshPointer(expr),
+                         ToString(qual_type));
+    }
     return ConvertFreshPointer(expr);
   }
   return ConvertFreshRValue(expr, qual_type);
@@ -2449,7 +2466,7 @@ void ConverterRefCount::ConvertDeref(clang::Expr *expr) {
   }
 
   if (isObject()) {
-    if (IsBoxedType(pointee_type)) {
+    if (IsBoxedType(pointee_type) || pointee_type->isArrayType()) {
       StrCat(".to_strong().as_pointer()");
       computed_expr_type_ = ComputedExprType::FreshPointer;
     }

--- a/cpp2rust/converter/models/converter_refcount.h
+++ b/cpp2rust/converter/models/converter_refcount.h
@@ -285,6 +285,7 @@ private:
   /// The kind of conversion that should be performed.
   enum class ConversionKind : uint8_t {
     Unboxed,
+    Pointee,
     Ptr,
     FullRefCount,
   };
@@ -293,6 +294,8 @@ private:
     switch (k) {
     case ConversionKind::Unboxed:
       return "Unboxed";
+    case ConversionKind::Pointee:
+      return "Pointee";
     case ConversionKind::Ptr:
       return "Ptr";
     case ConversionKind::FullRefCount:

--- a/libcc2rs/src/cstr.rs
+++ b/libcc2rs/src/cstr.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::rc::Rc;
 
 use crate::CStringIterator;
-use crate::rc::{Ptr, PtrKind};
+use crate::rc::{AsPointer, Ptr, PtrKind};
 
 impl fmt::Display for Ptr<u8> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -27,10 +27,30 @@ impl fmt::Display for Ptr<u8> {
     }
 }
 
-type StringLiteralMap = HashMap<&'static [u8], Rc<RefCell<Vec<u8>>>>;
+type StringLiteralMap = HashMap<&'static [u8], Rc<RefCell<Box<[u8]>>>>;
 
 thread_local! {
     static STRING_LITERALS: RefCell<StringLiteralMap> = RefCell::new(HashMap::new());
+}
+
+impl Ptr<Box<[u8]>> {
+    #[inline]
+    pub fn from_string_literal_array(s: &'static [u8]) -> Self {
+        STRING_LITERALS.with(|literals| {
+            let mut literals = literals.borrow_mut();
+            let weak = Rc::downgrade(literals.entry(s).or_insert_with(|| {
+                Rc::new(RefCell::new({
+                    let mut v = s.to_vec();
+                    v.push(0);
+                    v.into_boxed_slice()
+                }))
+            }));
+            Ptr {
+                offset: 0,
+                kind: PtrKind::StackSingle(weak),
+            }
+        })
+    }
 }
 
 impl Ptr<u8> {
@@ -86,20 +106,9 @@ impl Ptr<u8> {
 
     #[inline]
     pub fn from_string_literal(s: &'static [u8]) -> Self {
-        STRING_LITERALS.with(|literals| {
-            let mut literals = literals.borrow_mut();
-            let weak = Rc::downgrade(literals.entry(s).or_insert_with(|| {
-                Rc::new(RefCell::new({
-                    let mut v = s.to_vec();
-                    v.push(0);
-                    v
-                }))
-            }));
-            Ptr {
-                offset: 0,
-                kind: PtrKind::Vec(weak),
-            }
-        })
+        Ptr::<Box<[u8]>>::from_string_literal_array(s)
+            .to_strong()
+            .as_pointer()
     }
 
     pub fn to_c_string_iterator(&self) -> CStringIterator {

--- a/tests/unit/array_reference.cpp
+++ b/tests/unit/array_reference.cpp
@@ -8,6 +8,14 @@ int len(const char (&s)[5]) {
   return n;
 }
 
+int len5(const char *s) {
+  int n = 0;
+  while (s[n] != '\0') {
+    ++n;
+  }
+  return n;
+}
+
 int sum(const int (&a)[3]) { return a[0] + a[1] + a[2]; }
 
 void fill(int (&a)[3], int v) {
@@ -23,6 +31,22 @@ void fill_and_sum(int (&a)[3], int v, int &out) {
   out = sum_twice(a);
 }
 
+const char (&pick(const char (&s)[5]))[5] { return s; }
+
+struct Point {
+  int x;
+  int y;
+};
+
+int sum_points(const Point (&p)[2]) { return p[0].x + p[0].y + p[1].x + p[1].y; }
+
+void shift_points(Point (&p)[2], int d) {
+  p[0].x += d;
+  p[1].y += d;
+}
+
+int total_len(const char *(&names)[2]) { return len5(names[0]) + len5(names[1]); }
+
 int main() {
   assert(len("beta") == 4);
   char buf[5] = "abcd";
@@ -36,5 +60,17 @@ int main() {
   fill_and_sum(arr, 2, out);
   assert(out == 12);
   assert(arr[0] == 2);
+  const char (&lit)[5] = "beta";
+  assert(len(lit) == 4);
+  assert(pick("beta")[0] == 'b');
+  assert(len(pick(buf)) == 4);
+  Point pts[2] = {{1, 2}, {3, 4}};
+  assert(sum_points(pts) == 10);
+  shift_points(pts, 10);
+  assert(pts[0].x == 11);
+  assert(pts[1].y == 14);
+  assert(sum_points(pts) == 30);
+  const char *names[2] = {"ab", "cde"};
+  assert(total_len(names) == 5);
   return 0;
 }

--- a/tests/unit/array_reference.cpp
+++ b/tests/unit/array_reference.cpp
@@ -38,14 +38,18 @@ struct Point {
   int y;
 };
 
-int sum_points(const Point (&p)[2]) { return p[0].x + p[0].y + p[1].x + p[1].y; }
+int sum_points(const Point (&p)[2]) {
+  return p[0].x + p[0].y + p[1].x + p[1].y;
+}
 
 void shift_points(Point (&p)[2], int d) {
   p[0].x += d;
   p[1].y += d;
 }
 
-int total_len(const char *(&names)[2]) { return len5(names[0]) + len5(names[1]); }
+int total_len(const char *(&names)[2]) {
+  return len5(names[0]) + len5(names[1]);
+}
 
 int main() {
   assert(len("beta") == 4);

--- a/tests/unit/array_reference.cpp
+++ b/tests/unit/array_reference.cpp
@@ -1,0 +1,40 @@
+#include <cassert>
+
+int len(const char (&s)[5]) {
+  int n = 0;
+  while (s[n] != '\0') {
+    ++n;
+  }
+  return n;
+}
+
+int sum(const int (&a)[3]) { return a[0] + a[1] + a[2]; }
+
+void fill(int (&a)[3], int v) {
+  for (int i = 0; i < 3; ++i) {
+    a[i] = v;
+  }
+}
+
+int sum_twice(const int (&a)[3]) { return sum(a) + sum(a); }
+
+void fill_and_sum(int (&a)[3], int v, int &out) {
+  fill(a, v);
+  out = sum_twice(a);
+}
+
+int main() {
+  assert(len("beta") == 4);
+  char buf[5] = "abcd";
+  assert(len(buf) == 4);
+  int arr[3] = {1, 2, 3};
+  assert(sum(arr) == 6);
+  fill(arr, 7);
+  assert(sum(arr) == 21);
+  assert(sum_twice(arr) == 42);
+  int out = 0;
+  fill_and_sum(arr, 2, out);
+  assert(out == 12);
+  assert(arr[0] == 2);
+  return 0;
+}

--- a/tests/unit/out/refcount/array_reference.rs
+++ b/tests/unit/out/refcount/array_reference.rs
@@ -17,7 +17,17 @@ pub fn len_0(s: Ptr<Box<[u8]>>) -> i32 {
     }
     return (*n.borrow());
 }
-pub fn sum_1(a: Ptr<Box<[i32]>>) -> i32 {
+pub fn len5_1(s: Ptr<u8>) -> i32 {
+    let s: Value<Ptr<u8>> = Rc::new(RefCell::new(s));
+    let n: Value<i32> = Rc::new(RefCell::new(0));
+    'loop_: while ((((*s.borrow()).offset((*n.borrow()) as isize).read()) as i32)
+        != (('\0' as u8) as i32))
+    {
+        (*n.borrow_mut()).prefix_inc();
+    }
+    return (*n.borrow());
+}
+pub fn sum_2(a: Ptr<Box<[i32]>>) -> i32 {
     return ((((a.to_strong().as_pointer() as Ptr<i32>)
         .offset((0) as isize)
         .read())
@@ -28,7 +38,7 @@ pub fn sum_1(a: Ptr<Box<[i32]>>) -> i32 {
             .offset((2) as isize)
             .read()));
 }
-pub fn fill_2(a: Ptr<Box<[i32]>>, v: i32) {
+pub fn fill_3(a: Ptr<Box<[i32]>>, v: i32) {
     let v: Value<i32> = Rc::new(RefCell::new(v));
     let i: Value<i32> = Rc::new(RefCell::new(0));
     'loop_: while ((*i.borrow()) < 3) {
@@ -38,19 +48,116 @@ pub fn fill_2(a: Ptr<Box<[i32]>>, v: i32) {
         (*i.borrow_mut()).prefix_inc();
     }
 }
-pub fn sum_twice_3(a: Ptr<Box<[i32]>>) -> i32 {
-    return (({ sum_1(((a).clone() as Ptr<Box<[i32]>>)) })
-        + ({ sum_1(((a).clone() as Ptr<Box<[i32]>>)) }));
+pub fn sum_twice_4(a: Ptr<Box<[i32]>>) -> i32 {
+    return (({ sum_2(((a).clone() as Ptr<Box<[i32]>>)) })
+        + ({ sum_2(((a).clone() as Ptr<Box<[i32]>>)) }));
 }
-pub fn fill_and_sum_4(a: Ptr<Box<[i32]>>, v: i32, out: Ptr<i32>) {
+pub fn fill_and_sum_5(a: Ptr<Box<[i32]>>, v: i32, out: Ptr<i32>) {
     let v: Value<i32> = Rc::new(RefCell::new(v));
     ({
         let _a: Ptr<Box<[i32]>> = ((a).clone() as Ptr<Box<[i32]>>);
         let _v: i32 = (*v.borrow());
-        fill_2(_a, _v)
+        fill_3(_a, _v)
     });
-    let __rhs = ({ sum_twice_3(((a).clone() as Ptr<Box<[i32]>>)) });
+    let __rhs = ({ sum_twice_4(((a).clone() as Ptr<Box<[i32]>>)) });
     out.write(__rhs);
+}
+pub fn pick_6(s: Ptr<Box<[u8]>>) -> Ptr<Box<[u8]>> {
+    return ((s).clone() as Ptr<Box<[u8]>>);
+}
+#[derive(Default)]
+pub struct Point {
+    pub x: Value<i32>,
+    pub y: Value<i32>,
+}
+impl Clone for Point {
+    fn clone(&self) -> Self {
+        let __this: Value<Point> = Rc::new(RefCell::new(Self {
+            x: Rc::new(RefCell::new((*self.x.borrow()))),
+            y: Rc::new(RefCell::new((*self.y.borrow()))),
+        }));
+        let this: Ptr<Point> = __this.as_pointer();
+        Rc::try_unwrap(__this).ok().unwrap().into_inner()
+    }
+}
+impl ByteRepr for Point {
+    fn byte_size() -> usize {
+        8
+    }
+    fn to_bytes(&self, buf: &mut [u8]) {
+        (*self.x.borrow()).to_bytes(&mut buf[0..4]);
+        (*self.y.borrow()).to_bytes(&mut buf[4..8]);
+    }
+    fn from_bytes(buf: &[u8]) -> Self {
+        Self {
+            x: Rc::new(RefCell::new(<i32>::from_bytes(&buf[0..4]))),
+            y: Rc::new(RefCell::new(<i32>::from_bytes(&buf[4..8]))),
+        }
+    }
+}
+pub fn sum_points_7(p: Ptr<Box<[Point]>>) -> i32 {
+    return {
+        let _lhs = {
+            let _lhs = {
+                let _lhs = (*(*(p.to_strong().as_pointer() as Ptr<Point>)
+                    .offset((0) as isize)
+                    .upgrade()
+                    .deref())
+                .x
+                .borrow());
+                _lhs + (*(*(p.to_strong().as_pointer() as Ptr<Point>)
+                    .offset((0) as isize)
+                    .upgrade()
+                    .deref())
+                .y
+                .borrow())
+            };
+            _lhs + (*(*(p.to_strong().as_pointer() as Ptr<Point>)
+                .offset((1) as isize)
+                .upgrade()
+                .deref())
+            .x
+            .borrow())
+        };
+        _lhs + (*(*(p.to_strong().as_pointer() as Ptr<Point>)
+            .offset((1) as isize)
+            .upgrade()
+            .deref())
+        .y
+        .borrow())
+    };
+}
+pub fn shift_points_8(p: Ptr<Box<[Point]>>, d: i32) {
+    let d: Value<i32> = Rc::new(RefCell::new(d));
+    (*(*(p.to_strong().as_pointer() as Ptr<Point>)
+        .offset((0) as isize)
+        .upgrade()
+        .deref())
+    .x
+    .borrow_mut()) += (*d.borrow());
+    (*(*(p.to_strong().as_pointer() as Ptr<Point>)
+        .offset((1) as isize)
+        .upgrade()
+        .deref())
+    .y
+    .borrow_mut()) += (*d.borrow());
+}
+pub fn total_len_9(names: Ptr<Box<[Ptr<u8>]>>) -> i32 {
+    return (({
+        len5_1(
+            ((names.to_strong().as_pointer() as Ptr<Ptr<u8>>)
+                .offset((0) as isize)
+                .read())
+            .clone(),
+        )
+    }) + ({
+        len5_1(
+            ((names.to_strong().as_pointer() as Ptr<Ptr<u8>>)
+                .offset((1) as isize)
+                .read())
+            .clone(),
+        )
+    }));
 }
 pub fn main() {
     std::process::exit(main_0());
@@ -60,15 +167,47 @@ fn main_0() -> i32 {
     let buf: Value<Box<[u8]>> = Rc::new(RefCell::new(Box::from(*b"abcd\0")));
     assert!((({ len_0((buf.as_pointer() as Ptr<Box<[u8]>>),) }) == 4));
     let arr: Value<Box<[i32]>> = Rc::new(RefCell::new(Box::new([1, 2, 3])));
-    assert!((({ sum_1((arr.as_pointer() as Ptr<Box<[i32]>>),) }) == 6));
-    ({ fill_2((arr.as_pointer() as Ptr<Box<[i32]>>), 7) });
-    assert!((({ sum_1((arr.as_pointer() as Ptr<Box<[i32]>>),) }) == 21));
-    assert!((({ sum_twice_3((arr.as_pointer() as Ptr<Box<[i32]>>),) }) == 42));
+    assert!((({ sum_2((arr.as_pointer() as Ptr<Box<[i32]>>),) }) == 6));
+    ({ fill_3((arr.as_pointer() as Ptr<Box<[i32]>>), 7) });
+    assert!((({ sum_2((arr.as_pointer() as Ptr<Box<[i32]>>),) }) == 21));
+    assert!((({ sum_twice_4((arr.as_pointer() as Ptr<Box<[i32]>>),) }) == 42));
     let out: Value<i32> = Rc::new(RefCell::new(0));
-    ({ fill_and_sum_4((arr.as_pointer() as Ptr<Box<[i32]>>), 2, out.as_pointer()) });
+    ({ fill_and_sum_5((arr.as_pointer() as Ptr<Box<[i32]>>), 2, out.as_pointer()) });
     assert!(((*out.borrow()) == 12));
     assert!(((*arr.borrow())[(0) as usize] == 2));
     let lit: Ptr<Box<[u8]>> = Ptr::from_string_literal_array(b"beta");
     assert!((({ len_0(((lit).clone() as Ptr<Box<[u8]>>),) }) == 4));
+    assert!(
+        ((((({ pick_6(Ptr::from_string_literal_array(b"beta"),) })
+            .to_strong()
+            .as_pointer() as Ptr::<u8>)
+            .offset((0) as isize)
+            .read()) as i32)
+            == (('b' as u8) as i32))
+    );
+    assert!(
+        (({ len_0((({ pick_6((buf.as_pointer() as Ptr<Box<[u8]>>),) }) as Ptr<Box<[u8]>>),) })
+            == 4)
+    );
+    let pts: Value<Box<[Point]>> = Rc::new(RefCell::new(Box::new([
+        Point {
+            x: Rc::new(RefCell::new(1)),
+            y: Rc::new(RefCell::new(2)),
+        },
+        Point {
+            x: Rc::new(RefCell::new(3)),
+            y: Rc::new(RefCell::new(4)),
+        },
+    ])));
+    assert!((({ sum_points_7((pts.as_pointer() as Ptr<Box<[Point]>>),) }) == 10));
+    ({ shift_points_8((pts.as_pointer() as Ptr<Box<[Point]>>), 10) });
+    assert!(((*(*pts.borrow())[(0) as usize].x.borrow()) == 11));
+    assert!(((*(*pts.borrow())[(1) as usize].y.borrow()) == 14));
+    assert!((({ sum_points_7((pts.as_pointer() as Ptr<Box<[Point]>>),) }) == 30));
+    let names: Value<Box<[Ptr<u8>]>> = Rc::new(RefCell::new(Box::new([
+        Ptr::from_string_literal(b"ab"),
+        Ptr::from_string_literal(b"cde"),
+    ])));
+    assert!((({ total_len_9((names.as_pointer() as Ptr<Box<[Ptr::<u8>]>>),) }) == 5));
     return 0;
 }

--- a/tests/unit/out/refcount/array_reference.rs
+++ b/tests/unit/out/refcount/array_reference.rs
@@ -1,0 +1,72 @@
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsFd;
+use std::rc::{Rc, Weak};
+pub fn len_0(s: Ptr<Box<[u8]>>) -> i32 {
+    let n: Value<i32> = Rc::new(RefCell::new(0));
+    'loop_: while ((((s.to_strong().as_pointer() as Ptr<u8>)
+        .offset((*n.borrow()) as isize)
+        .read()) as i32)
+        != (('\0' as u8) as i32))
+    {
+        (*n.borrow_mut()).prefix_inc();
+    }
+    return (*n.borrow());
+}
+pub fn sum_1(a: Ptr<Box<[i32]>>) -> i32 {
+    return ((((a.to_strong().as_pointer() as Ptr<i32>)
+        .offset((0) as isize)
+        .read())
+        + ((a.to_strong().as_pointer() as Ptr<i32>)
+            .offset((1) as isize)
+            .read()))
+        + ((a.to_strong().as_pointer() as Ptr<i32>)
+            .offset((2) as isize)
+            .read()));
+}
+pub fn fill_2(a: Ptr<Box<[i32]>>, v: i32) {
+    let v: Value<i32> = Rc::new(RefCell::new(v));
+    let i: Value<i32> = Rc::new(RefCell::new(0));
+    'loop_: while ((*i.borrow()) < 3) {
+        (a.to_strong().as_pointer() as Ptr<i32>)
+            .offset((*i.borrow()) as isize)
+            .write((*v.borrow()));
+        (*i.borrow_mut()).prefix_inc();
+    }
+}
+pub fn sum_twice_3(a: Ptr<Box<[i32]>>) -> i32 {
+    return (({ sum_1(((a).clone() as Ptr<Box<[i32]>>)) })
+        + ({ sum_1(((a).clone() as Ptr<Box<[i32]>>)) }));
+}
+pub fn fill_and_sum_4(a: Ptr<Box<[i32]>>, v: i32, out: Ptr<i32>) {
+    let v: Value<i32> = Rc::new(RefCell::new(v));
+    ({
+        let _a: Ptr<Box<[i32]>> = ((a).clone() as Ptr<Box<[i32]>>);
+        let _v: i32 = (*v.borrow());
+        fill_2(_a, _v)
+    });
+    let __rhs = ({ sum_twice_3(((a).clone() as Ptr<Box<[i32]>>)) });
+    out.write(__rhs);
+}
+pub fn main() {
+    std::process::exit(main_0());
+}
+fn main_0() -> i32 {
+    assert!((({ len_0(Ptr::from_string_literal_array(b"beta"),) }) == 4));
+    let buf: Value<Box<[u8]>> = Rc::new(RefCell::new(Box::from(*b"abcd\0")));
+    assert!((({ len_0((buf.as_pointer() as Ptr<Box<[u8]>>),) }) == 4));
+    let arr: Value<Box<[i32]>> = Rc::new(RefCell::new(Box::new([1, 2, 3])));
+    assert!((({ sum_1((arr.as_pointer() as Ptr<Box<[i32]>>),) }) == 6));
+    ({ fill_2((arr.as_pointer() as Ptr<Box<[i32]>>), 7) });
+    assert!((({ sum_1((arr.as_pointer() as Ptr<Box<[i32]>>),) }) == 21));
+    assert!((({ sum_twice_3((arr.as_pointer() as Ptr<Box<[i32]>>),) }) == 42));
+    let out: Value<i32> = Rc::new(RefCell::new(0));
+    ({ fill_and_sum_4((arr.as_pointer() as Ptr<Box<[i32]>>), 2, out.as_pointer()) });
+    assert!(((*out.borrow()) == 12));
+    assert!(((*arr.borrow())[(0) as usize] == 2));
+    return 0;
+}

--- a/tests/unit/out/refcount/array_reference.rs
+++ b/tests/unit/out/refcount/array_reference.rs
@@ -68,5 +68,7 @@ fn main_0() -> i32 {
     ({ fill_and_sum_4((arr.as_pointer() as Ptr<Box<[i32]>>), 2, out.as_pointer()) });
     assert!(((*out.borrow()) == 12));
     assert!(((*arr.borrow())[(0) as usize] == 2));
+    let lit: Ptr<Box<[u8]>> = Ptr::from_string_literal_array(b"beta");
+    assert!((({ len_0(((lit).clone() as Ptr<Box<[u8]>>),) }) == 4));
     return 0;
 }

--- a/tests/unit/out/unsafe/array_reference.rs
+++ b/tests/unit/out/unsafe/array_reference.rs
@@ -54,5 +54,8 @@ unsafe fn main_0() -> i32 {
     (unsafe { fill_and_sum_4(&mut arr as *mut [i32; 3], 2, &mut out as *mut i32) });
     assert!(((out) == (12)));
     assert!(((arr[(0) as usize]) == (2)));
+    let lit: *const [libc::c_char; 5] =
+        &std::mem::transmute(*b"beta\0") as *const [libc::c_char; 5];
+    assert!(((unsafe { len_0(lit,) }) == (4)));
     return 0;
 }

--- a/tests/unit/out/unsafe/array_reference.rs
+++ b/tests/unit/out/unsafe/array_reference.rs
@@ -13,26 +13,54 @@ pub unsafe fn len_0(s: *const [libc::c_char; 5]) -> i32 {
     }
     return n;
 }
-pub unsafe fn sum_1(a: *const [i32; 3]) -> i32 {
+pub unsafe fn len5_1(mut s: *const libc::c_char) -> i32 {
+    let mut n: i32 = 0;
+    'loop_: while (((*s.offset((n) as isize)) as i32) != (('\0' as libc::c_char) as i32)) {
+        n.prefix_inc();
+    }
+    return n;
+}
+pub unsafe fn sum_2(a: *const [i32; 3]) -> i32 {
     return ((((*a)[(0) as usize]) + ((*a)[(1) as usize])) + ((*a)[(2) as usize]));
 }
-pub unsafe fn fill_2(a: *mut [i32; 3], mut v: i32) {
+pub unsafe fn fill_3(a: *mut [i32; 3], mut v: i32) {
     let mut i: i32 = 0;
     'loop_: while ((i) < (3)) {
         (*a)[(i) as usize] = v;
         i.prefix_inc();
     }
 }
-pub unsafe fn sum_twice_3(a: *const [i32; 3]) -> i32 {
-    return ((unsafe { sum_1(a) }) + (unsafe { sum_1(a) }));
+pub unsafe fn sum_twice_4(a: *const [i32; 3]) -> i32 {
+    return ((unsafe { sum_2(a) }) + (unsafe { sum_2(a) }));
 }
-pub unsafe fn fill_and_sum_4(a: *mut [i32; 3], mut v: i32, out: *mut i32) {
+pub unsafe fn fill_and_sum_5(a: *mut [i32; 3], mut v: i32, out: *mut i32) {
     (unsafe {
         let _a: *mut [i32; 3] = a;
         let _v: i32 = v;
-        fill_2(_a, _v)
+        fill_3(_a, _v)
     });
-    (*out) = (unsafe { sum_twice_3(a) });
+    (*out) = (unsafe { sum_twice_4(a) });
+}
+pub unsafe fn pick_6(s: *const [libc::c_char; 5]) -> *const [libc::c_char; 5] {
+    return s;
+}
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct Point {
+    pub x: i32,
+    pub y: i32,
+}
+pub unsafe fn sum_points_7(p: *const [Point; 2]) -> i32 {
+    return (((((*p)[(0) as usize].x) + ((*p)[(0) as usize].y)) + ((*p)[(1) as usize].x))
+        + ((*p)[(1) as usize].y));
+}
+pub unsafe fn shift_points_8(p: *mut [Point; 2], mut d: i32) {
+    (*p)[(0) as usize].x += d;
+    (*p)[(1) as usize].y += d;
+}
+pub unsafe fn total_len_9(names: *mut [*const libc::c_char; 2]) -> i32 {
+    return ((unsafe { len5_1((*names)[(0) as usize]) })
+        + (unsafe { len5_1((*names)[(1) as usize]) }));
 }
 pub fn main() {
     unsafe {
@@ -46,16 +74,30 @@ unsafe fn main_0() -> i32 {
     let mut buf: [libc::c_char; 5] = std::mem::transmute(*b"abcd\0");
     assert!(((unsafe { len_0(&buf as *const [libc::c_char; 5],) }) == (4)));
     let mut arr: [i32; 3] = [1, 2, 3];
-    assert!(((unsafe { sum_1(&arr as *const [i32; 3],) }) == (6)));
-    (unsafe { fill_2(&mut arr as *mut [i32; 3], 7) });
-    assert!(((unsafe { sum_1(&arr as *const [i32; 3],) }) == (21)));
-    assert!(((unsafe { sum_twice_3(&arr as *const [i32; 3],) }) == (42)));
+    assert!(((unsafe { sum_2(&arr as *const [i32; 3],) }) == (6)));
+    (unsafe { fill_3(&mut arr as *mut [i32; 3], 7) });
+    assert!(((unsafe { sum_2(&arr as *const [i32; 3],) }) == (21)));
+    assert!(((unsafe { sum_twice_4(&arr as *const [i32; 3],) }) == (42)));
     let mut out: i32 = 0;
-    (unsafe { fill_and_sum_4(&mut arr as *mut [i32; 3], 2, &mut out as *mut i32) });
+    (unsafe { fill_and_sum_5(&mut arr as *mut [i32; 3], 2, &mut out as *mut i32) });
     assert!(((out) == (12)));
     assert!(((arr[(0) as usize]) == (2)));
     let lit: *const [libc::c_char; 5] =
         &std::mem::transmute(*b"beta\0") as *const [libc::c_char; 5];
     assert!(((unsafe { len_0(lit,) }) == (4)));
+    assert!(
+        (((*(unsafe { pick_6(&std::mem::transmute(*b"beta\0") as *const [libc::c_char; 5],) }))
+            [(0) as usize] as i32)
+            == (('b' as libc::c_char) as i32))
+    );
+    assert!(((unsafe { len_0((unsafe { pick_6(&buf as *const [libc::c_char; 5],) }),) }) == (4)));
+    let mut pts: [Point; 2] = [Point { x: 1, y: 2 }, Point { x: 3, y: 4 }];
+    assert!(((unsafe { sum_points_7(&pts as *const [Point; 2],) }) == (10)));
+    (unsafe { shift_points_8(&mut pts as *mut [Point; 2], 10) });
+    assert!(((pts[(0) as usize].x) == (11)));
+    assert!(((pts[(1) as usize].y) == (14)));
+    assert!(((unsafe { sum_points_7(&pts as *const [Point; 2],) }) == (30)));
+    let mut names: [*const libc::c_char; 2] = [c"ab".as_ptr(), c"cde".as_ptr()];
+    assert!(((unsafe { total_len_9(&mut names as *mut [*const libc::c_char; 2],) }) == (5)));
     return 0;
 }

--- a/tests/unit/out/unsafe/array_reference.rs
+++ b/tests/unit/out/unsafe/array_reference.rs
@@ -1,0 +1,58 @@
+extern crate libc;
+use libc::*;
+extern crate libcc2rs;
+use libcc2rs::*;
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, Write};
+use std::os::fd::{AsFd, FromRawFd, IntoRawFd};
+use std::rc::Rc;
+pub unsafe fn len_0(s: *const [libc::c_char; 5]) -> i32 {
+    let mut n: i32 = 0;
+    'loop_: while (((*s)[(n) as usize] as i32) != (('\0' as libc::c_char) as i32)) {
+        n.prefix_inc();
+    }
+    return n;
+}
+pub unsafe fn sum_1(a: *const [i32; 3]) -> i32 {
+    return ((((*a)[(0) as usize]) + ((*a)[(1) as usize])) + ((*a)[(2) as usize]));
+}
+pub unsafe fn fill_2(a: *mut [i32; 3], mut v: i32) {
+    let mut i: i32 = 0;
+    'loop_: while ((i) < (3)) {
+        (*a)[(i) as usize] = v;
+        i.prefix_inc();
+    }
+}
+pub unsafe fn sum_twice_3(a: *const [i32; 3]) -> i32 {
+    return ((unsafe { sum_1(a) }) + (unsafe { sum_1(a) }));
+}
+pub unsafe fn fill_and_sum_4(a: *mut [i32; 3], mut v: i32, out: *mut i32) {
+    (unsafe {
+        let _a: *mut [i32; 3] = a;
+        let _v: i32 = v;
+        fill_2(_a, _v)
+    });
+    (*out) = (unsafe { sum_twice_3(a) });
+}
+pub fn main() {
+    unsafe {
+        std::process::exit(main_0() as i32);
+    }
+}
+unsafe fn main_0() -> i32 {
+    assert!(
+        ((unsafe { len_0(&std::mem::transmute(*b"beta\0") as *const [libc::c_char; 5],) }) == (4))
+    );
+    let mut buf: [libc::c_char; 5] = std::mem::transmute(*b"abcd\0");
+    assert!(((unsafe { len_0(&buf as *const [libc::c_char; 5],) }) == (4)));
+    let mut arr: [i32; 3] = [1, 2, 3];
+    assert!(((unsafe { sum_1(&arr as *const [i32; 3],) }) == (6)));
+    (unsafe { fill_2(&mut arr as *mut [i32; 3], 7) });
+    assert!(((unsafe { sum_1(&arr as *const [i32; 3],) }) == (21)));
+    assert!(((unsafe { sum_twice_3(&arr as *const [i32; 3],) }) == (42)));
+    let mut out: i32 = 0;
+    (unsafe { fill_and_sum_4(&mut arr as *mut [i32; 3], 2, &mut out as *mut i32) });
+    assert!(((out) == (12)));
+    assert!(((arr[(0) as usize]) == (2)));
+    return 0;
+}


### PR DESCRIPTION
Reference to array is translated as `Ptr<Box<[T]>>` in refcount and `*const/mut [T; N]` in unsafe.

I added a new ConversionKind called Pointee to translate reference to array in refcount. The semantics are:
* `FullRefCount`: `Value<Pointee>`
* `Pointee`: the object itself
* `Unboxed`: same as `Pointee`, except arrays which are `[T; N]` intead `Box<[T]>`

I also added `Ptr::from_string_literal_array` which is similar to `Ptr::from_string_literal`, the only difference is that that the new function returns `Ptr<Box<[u8]>>` instead of `Ptr<u8>`.